### PR TITLE
chore(deps): whitelist tinyglobby + doc PR-title limit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ docs: update CLI usage examples in README
 chore: update dependencies to latest versions
 ```
 
+> **PR title length:** commitlint enforces a 72-char subject limit. GitHub's
+> squash-merge appends ` (#N)` to the title — keep PR titles ≤ 67 chars so
+> the merged commit doesn't trip the post-merge `commitlint` gate (which
+> would then skip the `release` job).
+
 ### Code Quality
 
 We use several tools to maintain code quality:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,11 @@ allowBuilds:
 onlyBuiltDependencies:
   - esbuild
   - sharp
+
+# Whitelist packages from pnpm's 24h minimumReleaseAge supply-chain policy.
+# The default cutoff defends against typosquat-hijack attacks, but it also
+# blocks every install (including CI) when a low-risk transitive dep we
+# already pinned gets a fresh patch publish. Add entries here when a
+# specific package has been vetted and the wait isn't worth the friction.
+minimumReleaseAgeExclude:
+  - tinyglobby


### PR DESCRIPTION
## Summary
- Adds `tinyglobby` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` so `pnpm install` stops failing on the supply-chain age check (tinyglobby@0.2.17 was published <24h before yesterday's dependabot merge, blocking every pre-commit hook here).
- Documents the squash-merge PR-title char limit in CONTRIBUTING.md — commitlint header-max-length=72 trips when GitHub appends ` (#N)` to a 67+ char title (silently skips the release job, as just happened on #13).

## Why now
Direct follow-up to #13 — the post-merge `release` job for the jsdom-shims feat was skipped because the squash-merge subject was 74 chars. We can't push a trigger commit while pnpm install is failing, so this fixes both root causes in one PR.

## Test plan
- [x] `pnpm install` clean
- [x] PR title 56 chars, +5 from squash = 61 — under the 72 limit