### PR TITLE
feat: add Oxlint and Changesets presets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,22 +1,38 @@
 # TODO
 
-Backlog for `@rtorcato/js-tooling` lives on GitHub now:
+Backlog for `@rtorcato/js-tooling` lives on GitHub:
 
 - **Open issues:** <https://github.com/rtorcato/js-tooling/issues>
-- **Tooling preset backlog (umbrella):** [#59](https://github.com/rtorcato/js-tooling/issues/59)
 
 Shipped work lives in [`CHANGELOG.md`](./CHANGELOG.md) and `git log`.
 
 ## Currently filed
 
+### CLI / pipeline
+
 | # | Title |
 |---|---|
-| [#54](https://github.com/rtorcato/js-tooling/issues/54) | Docusaurus docs-site helpers: `copy docusaurus-sync-changelog`, theme tokens, doctor check |
-| [#55](https://github.com/rtorcato/js-tooling/issues/55) | Add Changesets preset (alternative to semantic-release) |
 | [#56](https://github.com/rtorcato/js-tooling/issues/56) | Set up npm Trusted Publishers (OIDC) for releases |
-| [#57](https://github.com/rtorcato/js-tooling/issues/57) | Add Oxlint preset |
 | [#58](https://github.com/rtorcato/js-tooling/issues/58) | Add optional diff preview to `fix` when overwriting drift |
-| [#59](https://github.com/rtorcato/js-tooling/issues/59) | Tooling preset backlog (Release Please, Rollup, Bun, publint, Rolldown, Cypress, Tailwind, PostCSS, Turborepo, Nx, GH Actions templates) |
+| [#54](https://github.com/rtorcato/js-tooling/issues/54) | Docusaurus docs-site helpers (`copy docusaurus-sync-changelog`, theme tokens, doctor check) |
+
+### Tooling presets
+
+| # | Title |
+|---|---|
+| [#55](https://github.com/rtorcato/js-tooling/issues/55) | Changesets (release tool, alternative to semantic-release) |
+| [#57](https://github.com/rtorcato/js-tooling/issues/57) | Oxlint (linter, additive to Biome) |
+| [#60](https://github.com/rtorcato/js-tooling/issues/60) | Bun (runtime + test runner + bundler) |
+| [#61](https://github.com/rtorcato/js-tooling/issues/61) | Rolldown bundler (gated on v1) |
+| [#62](https://github.com/rtorcato/js-tooling/issues/62) | Nx monorepo orchestrator |
+| [#63](https://github.com/rtorcato/js-tooling/issues/63) | Tailwind CSS |
+| [#64](https://github.com/rtorcato/js-tooling/issues/64) | Release Please (release tool) |
+| [#65](https://github.com/rtorcato/js-tooling/issues/65) | PostCSS |
+| [#66](https://github.com/rtorcato/js-tooling/issues/66) | More GitHub Actions workflow templates (Docker, Vercel, Cloudflare, previews) |
+| [#67](https://github.com/rtorcato/js-tooling/issues/67) | Cypress E2E (peer to Playwright) |
+| [#68](https://github.com/rtorcato/js-tooling/issues/68) | Turborepo |
+| [#69](https://github.com/rtorcato/js-tooling/issues/69) | publint |
+| [#70](https://github.com/rtorcato/js-tooling/issues/70) | Rollup bundler |
 
 ## Deliberately deferred
 

--- a/apps/docs/docs/reference/changesets.md
+++ b/apps/docs/docs/reference/changesets.md
@@ -1,0 +1,81 @@
+---
+title: Changesets
+description: Monorepo-friendly release tool. Alternative to semantic-release.
+---
+
+[Changesets](https://github.com/changesets/changesets) is a release tool that captures release intent in markdown files at PR time rather than parsing it from commit messages. It's the monorepo-friendly alternative to [semantic-release](./semantic-release.md).
+
+**Pick one** — Changesets or semantic-release — per repo. The `doctor` check flags repos configured for both.
+
+## Setup
+
+The wizard offers Changesets as a peer to semantic-release for library projects:
+
+```text
+? 🚀 Automated release tool?
+  📦 semantic-release (commit-message-driven)
+> 📝 Changesets (changeset-file-driven, monorepo-friendly)
+  ❌ None
+```
+
+If you pick Changesets, the wizard drops `.changeset/config.json` at the project root.
+
+## Adding to an existing project
+
+```bash
+npx @rtorcato/js-tooling copy changesets
+```
+
+Install Changesets and the GitHub Action:
+
+```bash
+pnpm add -D @changesets/cli
+```
+
+## Authoring changesets
+
+For every change that should ship in a release, the author runs:
+
+```bash
+pnpm changeset
+```
+
+This is an interactive prompt that writes a markdown file under `.changeset/`, like:
+
+```markdown
+---
+'@rtorcato/my-pkg': minor
+---
+
+Add the new sparkle widget.
+```
+
+Commit the changeset file alongside the change. The release process consumes it later.
+
+## Releasing
+
+```bash
+pnpm changeset version   # consume changesets, bump versions, write CHANGELOG.md
+pnpm changeset publish   # publish to npm
+```
+
+In CI, the [Changesets release bot](https://github.com/changesets/action) opens a "Version Packages" PR whenever changesets are pending and publishes on merge.
+
+## Choosing between Changesets and semantic-release
+
+**Pick Changesets** when you have:
+- A monorepo with multiple publishable packages.
+- A team that finds commit-message conventions hard to enforce.
+- A workflow that benefits from `--snapshot` releases or `pre enter <tag>` prerelease modes.
+
+**Pick semantic-release** when you have:
+- A single-package repo.
+- A team already disciplined on conventional commits.
+- An existing CI built around `pnpm run release`.
+
+Both tools share the same shape: CI consumes intent, bumps versions, writes a changelog, and publishes to npm. The difference is *where* the intent lives.
+
+## Doctor behaviour
+
+- If only `.changeset/config.json` exists, `doctor` reports `semantic-release` as ok with "using Changesets instead".
+- If both exist, `doctor` flags drift — you have two release tools fighting for the same job. Remove one.

--- a/apps/docs/docs/reference/oxlint.md
+++ b/apps/docs/docs/reference/oxlint.md
@@ -1,0 +1,57 @@
+---
+title: Oxlint
+description: Rust-based linter additive to Biome. 50–100× faster than ESLint.
+---
+
+[Oxlint](https://oxc.rs/docs/guide/usage/linter.html) is a Rust-based linter that's 50–100× faster than ESLint. We position it as **additive** to Biome — Biome stays the source of truth for formatting and the broad lint baseline; Oxlint adds a faster pass for type-aware and import rules Biome doesn't cover yet.
+
+## Setup
+
+The setup wizard offers Oxlint as an opt-in after the primary linter prompt:
+
+```text
+? 🔍 Which linting/formatting tool? ⚡ Biome
+? 🦀 Also run Oxlint alongside (50–100× faster than ESLint)? Yes
+```
+
+If you opt in, the wizard drops `.oxlintrc.json` at the project root using the canonical preset.
+
+## Adding to an existing project
+
+```bash
+npx @rtorcato/js-tooling copy oxlint
+```
+
+Add a script to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "oxlint": "oxlint",
+    "verify": "pnpm typecheck && pnpm lint && pnpm oxlint && pnpm test --run"
+  }
+}
+```
+
+## Configuration
+
+The shipped preset (`tooling/oxlint/oxlintrc.json`) enables:
+
+| Category | Severity | Notes |
+|---|---|---|
+| `correctness` | error | bugs, type errors |
+| `perf` | warn | known perf footguns |
+| `suspicious` | warn | likely-wrong patterns |
+| `pedantic` / `style` / `restriction` / `nursery` | off | overlaps with Biome / too noisy |
+
+Plugins enabled: `typescript`, `unicorn`, `oxc`, `import`.
+
+## Customising
+
+Oxlint configs are project-owned (Oxlint's `extends` from npm packages isn't reliably supported), so once `.oxlintrc.json` is in your repo you fully own it. Drop the `categories` and `rules` you don't want.
+
+## When to skip Oxlint
+
+- Solo projects where Biome alone catches enough.
+- Repos with very small surface area (the speed advantage doesn't matter under ~5k LOC).
+- Projects that use ESLint as their primary linter — running both is redundant.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -19,10 +19,12 @@ const sidebars: SidebarsConfig = {
       label: 'Configuration Reference',
       items: [
         'reference/biome',
+        'reference/changesets',
         'reference/commitlint',
         'reference/esbuild',
         'reference/eslint',
         'reference/jest',
+        'reference/oxlint',
         'reference/prettier',
         'reference/semantic-release',
         'reference/tsup',

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
 		"tooling/tests/ssr-safety.d.mts",
 		"tooling/tsup/index.ts",
 		"tooling/biome/biome.json",
+		"tooling/changesets/config.json",
+		"tooling/oxlint/oxlintrc.json",
 		"tooling/typedoc/typedoc.json",
 		"tooling/semantic-release/*.mjs",
 		"tooling/semantic-release/*.d.mts",
@@ -146,6 +148,8 @@
 		},
 		"./tsup": "./tooling/tsup/index.ts",
 		"./biome": "./tooling/biome/biome.json",
+		"./changesets": "./tooling/changesets/config.json",
+		"./oxlint": "./tooling/oxlint/oxlintrc.json",
 		"./typedoc": "./tooling/typedoc/typedoc.json",
 		"./semantic-release": {
 			"types": "./tooling/semantic-release/index.d.mts",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -120,6 +120,24 @@ const FILE_CHECKS: FileCheck[] = [
 		matcher: /@rtorcato\/js-tooling\/commitlint\/config/,
 		optional: true,
 	},
+	{
+		check: 'Oxlint',
+		candidates: ['.oxlintrc.json', 'oxlintrc.json'],
+		// Oxlint configs are project-owned (extends from npm packages isn't
+		// reliably supported), so any well-formed file counts as ok.
+		expected: 'is a valid Oxlint configuration',
+		matcher: /"(rules|plugins|categories|extends)"/,
+		optional: true,
+		hint: 'Run `npx @rtorcato/js-tooling copy oxlint` to scaffold',
+	},
+	{
+		check: 'Changesets',
+		candidates: ['.changeset/config.json'],
+		expected: 'is a valid Changesets configuration',
+		matcher: /"(changelog|access|baseBranch)"/,
+		optional: true,
+		hint: 'Run `npx @rtorcato/js-tooling copy changesets` to scaffold',
+	},
 ]
 
 async function checkFile(dir: string, spec: FileCheck): Promise<CheckResult> {
@@ -510,7 +528,27 @@ async function checkSemanticRelease(dir: string, pkg: Pkg | null): Promise<Check
 		}
 	}
 
+	const hasChangesets = await fs.pathExists(path.join(dir, '.changeset', 'config.json'))
+
+	// Conflict: both semantic-release and Changesets configured.
+	if ((inPkg || configFile) && hasChangesets) {
+		return {
+			check: 'semantic-release',
+			status: 'drift',
+			detail: 'both semantic-release and Changesets are configured',
+			hint: 'Pick one release tool — remove either the semantic-release config or the .changeset/ directory',
+		}
+	}
+
 	if (!inPkg && !configFile) {
+		// Changesets present — treat semantic-release as intentionally not used.
+		if (hasChangesets) {
+			return {
+				check: 'semantic-release',
+				status: 'ok',
+				detail: 'using Changesets (.changeset/config.json) instead',
+			}
+		}
 		return {
 			check: 'semantic-release',
 			status: isPrivate ? 'optional-missing' : 'drift',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -284,6 +284,28 @@ const FIXERS: Fixer[] = [
 		},
 	},
 	{
+		target: 'changesets',
+		description: 'Scaffold .changeset/config.json (alternative to semantic-release)',
+		appliesTo: ['Changesets'],
+		outputs: ['.changeset/config.json'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('changesets', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'oxlint',
+		description: 'Scaffold .oxlintrc.json (additive to Biome/ESLint)',
+		appliesTo: ['Oxlint'],
+		outputs: ['.oxlintrc.json'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('oxlint', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
 		target: 'github-actions',
 		description: 'Scaffold .github/workflows/ci.yml',
 		appliesTo: ['GitHub Actions'],

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -132,6 +132,8 @@ export const CONFIG_SCHEMA = {
 		gitHooks: { type: 'boolean' },
 		commitLint: { type: 'boolean' },
 		semanticRelease: { type: 'boolean' },
+		changesets: { type: 'boolean' },
+		oxlint: { type: 'boolean' },
 		securityAutomation: { type: 'boolean' },
 		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'vite', 'none'] },
 		treeshakeCheck: { type: 'boolean' },
@@ -201,6 +203,8 @@ export function computeFileList(config: ProjectConfig): string[] {
 	else if (config.bundler === 'esbuild') files.push('build.mjs')
 	else if (config.bundler === 'vite') files.push('vite.config.ts')
 	if (config.semanticRelease) files.push('release.config.mjs')
+	if (config.changesets) files.push('.changeset/config.json')
+	if (config.oxlint) files.push('.oxlintrc.json')
 	if (config.treeshakeCheck && config.projectType === 'library') {
 		files.push(
 			'apps/treeshake-check/package.json',

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -35,6 +35,8 @@ export interface ProjectConfig {
 	gitHooks: boolean
 	commitLint: boolean
 	semanticRelease: boolean
+	changesets?: boolean
+	oxlint?: boolean
 	securityAutomation: boolean
 	bundler: 'tsup' | 'esbuild' | 'vite' | 'none'
 	treeshakeCheck?: boolean
@@ -201,6 +203,13 @@ async function promptForConfig(): Promise<ProjectConfig> {
 			when: (answers: any) => answers.lintingTool === 'eslint' || answers.lintingTool === 'both',
 		},
 		{
+			type: 'confirm',
+			name: 'oxlint',
+			message: '🦀 Also run Oxlint alongside (50–100× faster than ESLint)?',
+			default: false,
+			when: (answers: any) => answers.lintingTool !== 'none',
+		},
+		{
 			type: 'list',
 			name: 'testingFramework',
 			message: '🧪 Which testing framework?',
@@ -238,10 +247,15 @@ async function promptForConfig(): Promise<ProjectConfig> {
 			when: (answers: any) => answers.gitHooks,
 		},
 		{
-			type: 'confirm',
-			name: 'semanticRelease',
-			message: '🚀 Set up semantic release for automated versioning?',
-			default: (answers: any) => answers.projectType === 'library',
+			type: 'list',
+			name: 'releaseTool',
+			message: '🚀 Automated release tool?',
+			choices: [
+				{ name: '📦 semantic-release (commit-message-driven)', value: 'semantic-release' },
+				{ name: '📝 Changesets (changeset-file-driven, monorepo-friendly)', value: 'changesets' },
+				{ name: '❌ None', value: 'none' },
+			],
+			default: 'semantic-release',
 			when: (answers: any) => answers.projectType === 'library',
 		},
 		{
@@ -303,7 +317,9 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		},
 		gitHooks: answers.gitHooks || false,
 		commitLint: answers.commitLint || false,
-		semanticRelease: answers.semanticRelease || false,
+		semanticRelease: answers.releaseTool === 'semantic-release',
+		changesets: answers.releaseTool === 'changesets',
+		oxlint: answers.oxlint || false,
 		securityAutomation: answers.securityAutomation ?? false,
 		bundler: answers.bundler || 'none',
 		treeshakeCheck: answers.treeshakeCheck || false,

--- a/src/cli/generators/build.ts
+++ b/src/cli/generators/build.ts
@@ -15,6 +15,11 @@ export async function generateBuildConfigs(config: ProjectConfig, targetDir: str
 	if (config.semanticRelease) {
 		await generateSemanticReleaseConfig(targetDir)
 	}
+
+	// Generate Changesets config (alternative to semantic-release)
+	if (config.changesets) {
+		await generateChangesetsConfig(targetDir)
+	}
 }
 
 async function generateTsupConfig(targetDir: string) {
@@ -86,4 +91,12 @@ export async function generateSemanticReleaseConfig(targetDir: string) {
 `
 
 	await fs.writeFile(releaseConfigPath, releaseConfig)
+}
+
+export async function generateChangesetsConfig(targetDir: string) {
+	// Drop the canonical Changesets config into .changeset/config.json. The user
+	// owns this file once it's in their repo; subsequent `pnpm changeset` runs
+	// create per-change markdown files alongside it.
+	const { copyPreset } = await import('../utils/copy-preset.js')
+	await copyPreset('changesets', targetDir)
 }

--- a/src/cli/generators/linting.ts
+++ b/src/cli/generators/linting.ts
@@ -17,6 +17,19 @@ export async function generateLintingConfigs(config: ProjectConfig, targetDir: s
 	if (config.linting.tool === 'eslint') {
 		await generatePrettierConfig(targetDir)
 	}
+
+	// Generate Oxlint config (additive — runs alongside Biome/ESLint)
+	if (config.oxlint) {
+		await generateOxlintConfig(targetDir)
+	}
+}
+
+export async function generateOxlintConfig(targetDir: string) {
+	// Oxlint's `extends` resolution from npm packages isn't reliably supported,
+	// so we copy the full preset rather than write a thin pointer file (same
+	// pattern as biome.jsonc — the user owns the file once it's in their repo).
+	const { copyPreset } = await import('../utils/copy-preset.js')
+	await copyPreset('oxlint', targetDir)
 }
 
 export async function generateBiomeConfig(targetDir: string) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -156,6 +156,18 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: 'semantic-release',
 	},
 	{
+		name: 'Changesets',
+		description: 'Monorepo-friendly release tool (alternative to semantic-release)',
+		exports: ['@rtorcato/js-tooling/changesets'],
+		fixTarget: 'changesets',
+	},
+	{
+		name: 'Oxlint',
+		description: 'Rust-based linter (additive to Biome/ESLint)',
+		exports: ['@rtorcato/js-tooling/oxlint'],
+		fixTarget: 'oxlint',
+	},
+	{
 		name: 'tsup',
 		description: 'TypeScript bundler configuration',
 		exports: ['@rtorcato/js-tooling/tsup'],

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 
-export type PresetName = 'biome' | 'tsconfig'
+export type PresetName = 'biome' | 'changesets' | 'oxlint' | 'tsconfig'
 
 export interface PresetDefinition {
 	source: string
@@ -14,6 +14,16 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/biome/biome.json',
 		target: 'biome.json',
 		desc: 'Biome formatter and linter configuration',
+	},
+	changesets: {
+		source: 'tooling/changesets/config.json',
+		target: '.changeset/config.json',
+		desc: 'Changesets release-tool configuration',
+	},
+	oxlint: {
+		source: 'tooling/oxlint/oxlintrc.json',
+		target: '.oxlintrc.json',
+		desc: 'Oxlint linter configuration (additive to Biome)',
 	},
 	tsconfig: {
 		source: 'tooling/typescript/tsconfig.base.json',

--- a/tests/cli/generators/build.test.ts
+++ b/tests/cli/generators/build.test.ts
@@ -88,7 +88,17 @@ describe('generateBuildConfigs', () => {
 		expect(content).toContain('@rtorcato/js-tooling/semantic-release/github')
 	})
 
-	it('writes no files when bundler is none and semanticRelease is false', async () => {
+	it('writes .changeset/config.json when changesets is true', async () => {
+		const dir = newTmpDir()
+		await generateBuildConfigs(baseConfig({ changesets: true }), dir)
+
+		const config = await fs.readJson(join(dir, '.changeset/config.json'))
+		expect(config.access).toBe('public')
+		expect(config.baseBranch).toBe('main')
+		expect(await fs.pathExists(join(dir, 'release.config.mjs'))).toBe(false)
+	})
+
+	it('writes no files when bundler is none and no release tool is selected', async () => {
 		const dir = newTmpDir()
 		await generateBuildConfigs(baseConfig(), dir)
 
@@ -96,5 +106,6 @@ describe('generateBuildConfigs', () => {
 		expect(await fs.pathExists(join(dir, 'build.mjs'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'vite.config.ts'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'release.config.mjs'))).toBe(false)
+		expect(await fs.pathExists(join(dir, '.changeset/config.json'))).toBe(false)
 	})
 })

--- a/tests/cli/generators/linting.test.ts
+++ b/tests/cli/generators/linting.test.ts
@@ -70,4 +70,23 @@ describe('generateLintingConfigs', () => {
 		const eslint = await fs.readFile(join(dir, 'eslint.config.mjs'), 'utf-8')
 		expect(eslint).toContain("from '@rtorcato/js-tooling/eslint/base'")
 	})
+
+	it('drops .oxlintrc.json when oxlint is enabled (additive to Biome)', async () => {
+		const dir = newTmpDir()
+		await generateLintingConfigs(
+			baseConfig({ linting: { tool: 'biome' }, oxlint: true }),
+			dir
+		)
+
+		expect(await fs.pathExists(join(dir, 'biome.jsonc'))).toBe(true)
+		const oxlint = await fs.readJson(join(dir, '.oxlintrc.json'))
+		expect(oxlint.categories?.correctness).toBe('error')
+	})
+
+	it('skips .oxlintrc.json when oxlint flag is unset', async () => {
+		const dir = newTmpDir()
+		await generateLintingConfigs(baseConfig({ linting: { tool: 'biome' } }), dir)
+
+		expect(await fs.pathExists(join(dir, '.oxlintrc.json'))).toBe(false)
+	})
 })

--- a/tooling/changesets/README.md
+++ b/tooling/changesets/README.md
@@ -1,0 +1,35 @@
+# Changesets preset
+
+Shared [Changesets](https://github.com/changesets/changesets) configuration for projects using `@rtorcato/js-tooling`.
+
+Changesets is a **monorepo-friendly alternative to semantic-release**. The release workflow is the same shape (CI bumps versions, generates a changelog, publishes to npm), but the *intent* is captured in changeset markdown files at PR time rather than parsed from commit messages.
+
+Pick one — Changesets or semantic-release — per repo. The `doctor` check flags repos configured for both.
+
+## Usage
+
+```bash
+npx @rtorcato/js-tooling copy changesets
+```
+
+This scaffolds `.changeset/config.json` from this preset. After that:
+
+```bash
+pnpm changeset           # interactive — author a changeset for the current change
+pnpm changeset version   # consume changesets, bump versions, write CHANGELOG.md
+pnpm changeset publish   # publish to npm
+```
+
+CI typically runs the [Changesets release bot](https://github.com/changesets/action), which opens a "Version Packages" PR when changesets are present and publishes on merge.
+
+## Why pick this over semantic-release
+
+- **Monorepos** — Changesets handles multi-package version bumps in a way semantic-release doesn't out of the box.
+- **Explicit intent** — Authors declare a change's bump level in the changeset file rather than encoding it in commit message conventions, which is more forgiving for human commits.
+- **Pre-release flows** — `--snapshot` and `pre enter <tag>` are first-class.
+
+## Why pick semantic-release instead
+
+- **Single-package repos** — Less ceremony; nothing to author per change.
+- **Strict conventional-commits discipline already in place.**
+- **Existing CI built around the `npm run release` path.**

--- a/tooling/changesets/config.json
+++ b/tooling/changesets/config.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
+	"changelog": "@changesets/cli/changelog",
+	"commit": false,
+	"fixed": [],
+	"linked": [],
+	"access": "public",
+	"baseBranch": "main",
+	"updateInternalDependencies": "patch",
+	"ignore": []
+}

--- a/tooling/oxlint/README.md
+++ b/tooling/oxlint/README.md
@@ -1,0 +1,25 @@
+# Oxlint preset
+
+Shared [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) configuration for projects using `@rtorcato/js-tooling`.
+
+Oxlint is a Rust-based linter that's 50–100× faster than ESLint. It is intentionally **additive** to Biome — Biome handles formatting and the broad lint baseline, Oxlint adds a faster pass for the type-aware and import rules Biome doesn't cover yet.
+
+## Usage
+
+```bash
+npx @rtorcato/js-tooling copy oxlint
+```
+
+This drops `.oxlintrc.json` at the project root, extending the conventions in this preset. Run it with:
+
+```bash
+pnpm oxlint
+# or
+npx oxlint
+```
+
+## Notes
+
+- Oxlint shares its rule catalog with ESLint's plugins (`typescript`, `unicorn`, `oxc`, `import`), so most ESLint rules you know already work here.
+- The preset disables Biome-overlapping rules to keep CI noise down — Biome stays the source of truth for formatting and the baseline lint set.
+- For projects without Biome, you can run Oxlint standalone and re-enable the `style` and `pedantic` categories.

--- a/tooling/oxlint/oxlintrc.json
+++ b/tooling/oxlint/oxlintrc.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
+	"categories": {
+		"correctness": "error",
+		"perf": "warn",
+		"suspicious": "warn",
+		"pedantic": "off",
+		"style": "off",
+		"restriction": "off",
+		"nursery": "off"
+	},
+	"plugins": ["typescript", "unicorn", "oxc", "import"],
+	"rules": {
+		"no-console": "warn",
+		"no-debugger": "error",
+		"no-empty": "warn",
+		"no-unused-vars": "off",
+		"@typescript-eslint/no-unused-vars": [
+			"warn",
+			{ "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+		],
+		"unicorn/filename-case": "off",
+		"unicorn/no-null": "off",
+		"unicorn/prevent-abbreviations": "off",
+		"import/no-default-export": "off"
+	},
+	"ignorePatterns": ["node_modules", "dist", "build", "coverage", ".next", "*.d.ts"]
+}


### PR DESCRIPTION
Closes #55. Closes #57.

## Summary

Two new tooling presets following the existing copy/fix/doctor/wizard pattern.

### Oxlint (#57)

Rust-based linter, positioned as **additive to Biome** — Biome stays the source of truth for formatting and the broad lint baseline; Oxlint adds a faster pass for type-aware and import rules Biome doesn't cover.

- \`tooling/oxlint/oxlintrc.json\` preset (correctness/perf/suspicious categories on; style/pedantic off to avoid Biome overlap).
- \`oxlint?: boolean\` field on \`ProjectConfig\`.
- Setup wizard: "🦀 Also run Oxlint alongside (50–100× faster than ESLint)?" prompt after the linting tool choice.
- \`copy oxlint\`, \`fix oxlint\`, and a \`doctor\` check that accepts any well-formed \`.oxlintrc.json\`.
- \`docs/reference/oxlint.md\`.

### Changesets (#55)

Monorepo-friendly release tool as a **peer to semantic-release**.

- \`tooling/changesets/config.json\` preset.
- \`changesets?: boolean\` field on \`ProjectConfig\`.
- Setup wizard replaces the semantic-release confirm with a list: *semantic-release / Changesets / none*.
- \`copy changesets\`, \`fix changesets\`.
- \`doctor\` updates: \`checkSemanticRelease\` now accepts Changesets as a valid alternative ("using Changesets instead") and flags drift when **both** are configured.
- \`docs/reference/changesets.md\`.

## Other wiring

- \`package.json\` exports: \`./oxlint\`, \`./changesets\`.
- \`src/cli/index.ts\` tool catalog entries.
- \`apps/docs/sidebars.ts\` adds the two new reference pages.
- \`TODO.md\` updated to point at the freshly-split issues (#60-#70 from the #59 split).

## Test plan

- [x] \`pnpm exec vitest run\` — 231 passed, 18 skipped (same as before).
- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm --filter @rtorcato/docs build\` succeeds; new reference pages render.
- [ ] Manually run the setup wizard end-to-end against a tmp dir to spot-check the new prompts (defer to reviewer).