### PR TITLE
feat(fix): add --diff flag for unified-diff preview before confirm

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -82,6 +82,7 @@ npx @rtorcato/js-tooling fix                    # walk all findings interactivel
 npx @rtorcato/js-tooling fix dependabot         # scaffold just .github/dependabot.yml
 npx @rtorcato/js-tooling fix --yes              # apply every recommended fix without prompts
 npx @rtorcato/js-tooling fix biome --dry-run    # print what would change, write nothing
+npx @rtorcato/js-tooling fix biome --diff       # show the exact diff before confirming
 ```
 
 ### Flags
@@ -91,10 +92,46 @@ npx @rtorcato/js-tooling fix biome --dry-run    # print what would change, write
 | `-d, --directory <path>` | Target directory (defaults to cwd) |
 | `--yes` | Assume yes to every prompt, including drift overwrites |
 | `--dry-run` | Print the files each fixer would write, without writing |
+| `--diff` | Print a unified diff of each change before the confirm prompt |
 
 ### Drift policy
 
 When a file exists but doesn't extend the preset, `fix` defaults the confirm prompt to **No** — your customisations are preserved unless you explicitly say yes (or pass `--yes`). The prompt always tells you which file is about to be overwritten.
+
+### Diff preview (`--diff`)
+
+When you want to see *exactly* what would change before saying yes, pass `--diff`. For each output the fixer would touch, you'll see:
+
+- a `create <path>` header if the file is new (no diff body to show), or
+- a `modify <path>` header followed by a unified diff comparing the current file to what the fixer would write.
+
+```text
+$ npx @rtorcato/js-tooling fix biome --diff
+🔧 biome — Biome is drift
+
+  modify biome.json
+    --- biome.json
+    +++ biome.json
+    @@ -1,3 +1,12 @@
+    -{
+    -  "rules": { "noConsole": "error" }
+    -}
+    +{
+    +  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+    +  "extends": ["@rtorcato/js-tooling/biome"],
+    +  …
+    +}
+? ⚠️  Scaffold biome.json … — overwrite existing file? user customizations will be lost (y/N)
+```
+
+The diff:
+
+- is suppressed in `--json` mode (the structured output stream stays clean),
+- is suppressed for safe-add fixers (those never overwrite existing files),
+- honours `NO_COLOR` and the standard terminal-colour detection chalk uses,
+- works in both targeted (`fix biome --diff`) and walk-all (`fix --diff`) modes.
+
+Implementation note: the preview is computed by shadow-running the fixer in a temp copy of your project directory — your real files are never touched until you confirm.
 
 ### Available targets
 

--- a/package.json
+++ b/package.json
@@ -175,11 +175,13 @@
 	"dependencies": {
 		"chalk": "^5.6.2",
 		"commander": "^14.0.3",
+		"diff": "^9.0.0",
 		"fs-extra": "^11.3.2",
 		"inquirer": "^14.0.2"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.16",
+		"@types/diff": "^8.0.0",
 		"@commitlint/cli": "^20.1.0",
 		"@commitlint/config-conventional": "^21.0.2",
 		"@commitlint/types": "^20.0.0",
@@ -239,6 +241,7 @@
 		"@semantic-release/github": "^12.0.8",
 		"@semantic-release/npm": "^13.0.0",
 		"@semantic-release/release-notes-generator": "^14.0.0",
+		"@size-limit/preset-small-lib": "^12.0.0",
 		"@total-typescript/ts-reset": "^0.6.0",
 		"@typescript-eslint/eslint-plugin": "^8.0.0",
 		"@typescript-eslint/parser": "^8.0.0",
@@ -252,7 +255,6 @@
 		"prettier": "^3.0.0",
 		"semantic-release": "^25.0.0",
 		"size-limit": "^12.0.0",
-		"@size-limit/preset-small-lib": "^12.0.0",
 		"ts-jest": "^29.0.0",
 		"tsup": "^8.0.0",
 		"typescript": ">=5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       fs-extra:
         specifier: ^11.3.2
         version: 11.3.5
@@ -75,6 +78,9 @@ importers:
       '@total-typescript/ts-reset':
         specifier: 0.6.1
         version: 0.6.1
+      '@types/diff':
+        specifier: ^8.0.0
+        version: 8.0.0
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -3160,6 +3166,10 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/diff@8.0.0':
+    resolution: {integrity: sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==}
+    deprecated: This is a stub types definition. diff provides its own type definitions, so you do not need this installed.
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -4525,6 +4535,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -13244,6 +13258,10 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/diff@8.0.0':
+    dependencies:
+      diff: 9.0.0
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -14798,6 +14816,8 @@ snapshots:
       dequal: 2.0.3
 
   diff-sequences@29.6.3: {}
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -1,5 +1,7 @@
 import path from 'node:path'
+import os from 'node:os'
 import chalk from 'chalk'
+import { createPatch } from 'diff'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { generateSemanticReleaseConfig } from '../generators/build.js'
@@ -50,6 +52,7 @@ export interface FixOptions {
 	json?: boolean
 	list?: boolean
 	resync?: boolean
+	diff?: boolean
 }
 
 export type FixActionStatus = 'applied' | 'dry-run' | 'skipped' | 'already-ok' | 'unsupported'
@@ -592,6 +595,130 @@ export function listFixers(): FixerSummary[] {
 	}))
 }
 
+// Fixer outputs sometimes carry annotations like
+// "package.json (lint-staged field)" — strip them to get a usable filesystem path.
+function outputToRelativePath(output: string): string {
+	return output.split(' ')[0] ?? output
+}
+
+function shouldColorise(): boolean {
+	// Respect NO_COLOR (https://no-color.org) and chalk's own detection.
+	if (process.env.NO_COLOR && process.env.NO_COLOR !== '') return false
+	return chalk.level > 0
+}
+
+function colorisePatch(patch: string): string {
+	if (!shouldColorise()) return patch
+	return patch
+		.split('\n')
+		.map((line) => {
+			if (line.startsWith('+++') || line.startsWith('---')) return chalk.bold(line)
+			if (line.startsWith('@@')) return chalk.cyan(line)
+			if (line.startsWith('+')) return chalk.green(line)
+			if (line.startsWith('-')) return chalk.red(line)
+			return line
+		})
+		.join('\n')
+}
+
+interface PreviewEntry {
+	path: string
+	kind: 'create' | 'modify' | 'unchanged'
+	patch: string | null
+}
+
+/**
+ * Shadow-run a fixer in a temp copy of the target directory and return per-output
+ * diffs. We copy the real target into tmp so fixers that read existing state
+ * (e.g. husky reading package.json) still produce realistic output.
+ */
+async function previewFixer(
+	fixer: Fixer,
+	result: CheckResult,
+	targetDir: string,
+	pkg: Pkg,
+	lock: Lockfile | null
+): Promise<PreviewEntry[]> {
+	// Pick a tmp root that is NOT inside targetDir. macOS sometimes hands us a
+	// $TMPDIR that lives under the working dir (e.g. when the caller is itself
+	// running inside a tempdir tree), which would make fs.copy fail with
+	// "subdirectory of itself". Fall back to the parent of targetDir if so.
+	const resolvedTarget = path.resolve(targetDir)
+	let tmpRoot = path.resolve(os.tmpdir())
+	if (tmpRoot === resolvedTarget || tmpRoot.startsWith(resolvedTarget + path.sep)) {
+		tmpRoot = path.dirname(resolvedTarget)
+	}
+	const tmpDir = await fs.mkdtemp(path.join(tmpRoot, 'js-tooling-fix-preview-'))
+	try {
+		await fs.copy(targetDir, tmpDir, {
+			filter: (src) => {
+				const rel = path.relative(targetDir, src)
+				if (!rel) return true
+				const first = rel.split(path.sep)[0]
+				// Skip large/derived dirs that fixers never touch — keeps preview fast on
+				// big repos.
+				return first !== 'node_modules' && first !== 'dist' && first !== 'build' && first !== '.git'
+			},
+		})
+		await fixer.run({ targetDir: tmpDir, pkg, result, lock })
+
+		const previews: PreviewEntry[] = []
+		const seen = new Set<string>()
+		for (const output of fixer.outputs) {
+			const rel = outputToRelativePath(output)
+			if (seen.has(rel)) continue
+			seen.add(rel)
+
+			const tmpPath = path.join(tmpDir, rel)
+			const realPath = path.join(targetDir, rel)
+			if (!(await fs.pathExists(tmpPath))) continue
+
+			const newContent = await fs.readFile(tmpPath, 'utf-8')
+			const existed = await fs.pathExists(realPath)
+			const oldContent = existed ? await fs.readFile(realPath, 'utf-8') : ''
+
+			if (newContent === oldContent) {
+				previews.push({ path: rel, kind: 'unchanged', patch: null })
+				continue
+			}
+			const patch = createPatch(rel, oldContent, newContent, undefined, undefined, { context: 3 })
+			previews.push({
+				path: rel,
+				kind: existed ? 'modify' : 'create',
+				patch: colorisePatch(patch),
+			})
+		}
+		return previews
+	} finally {
+		await fs.remove(tmpDir).catch(() => {
+			// Best-effort cleanup; tmp dirs get GC'd by the OS eventually.
+		})
+	}
+}
+
+function printPreviews(previews: PreviewEntry[]): void {
+	if (previews.length === 0) {
+		console.log(chalk.gray('  (no preview available — fixer produced no recognisable outputs)'))
+		return
+	}
+	for (const p of previews) {
+		if (p.kind === 'unchanged') {
+			console.log(chalk.gray(`  ${p.path} — unchanged`))
+			continue
+		}
+		const label = p.kind === 'create' ? chalk.green('create') : chalk.yellow('modify')
+		console.log(`  ${label} ${chalk.bold(p.path)}`)
+		if (p.patch) {
+			console.log(
+				p.patch
+					.split('\n')
+					.map((l) => `    ${l}`)
+					.join('\n')
+			)
+		}
+	}
+}
+
 async function applyFixer(
 	fixer: Fixer,
 	result: CheckResult,
@@ -678,6 +805,8 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 	// JSON mode implies --yes so prompts don't corrupt the output stream.
 	const assumeYes = options.yes === true || json
 	const silent = json
+	// Diff preview is interactive-only — suppress in JSON mode.
+	const showDiff = options.diff === true && !json
 
 	if (options.list) {
 		const summary = listFixers()
@@ -840,6 +969,10 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			)
 		}
 		const conflict = noteLockConflict(result.check)
+		if (showDiff && (fixer.riskLevel ?? 'destructive') !== 'safe-add') {
+			const previews = await previewFixer(fixer, effectiveResult, targetDir, pkg, lock)
+			printPreviews(previews)
+		}
 		const ok = await confirmApply(fixer, effectiveResult, assumeYes)
 		if (!ok) {
 			actions.push(
@@ -892,6 +1025,10 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			console.log(`  ${chalk.bold(result.check)} (${result.status}) → ${fixer.target}`)
 		}
 		const conflict = noteLockConflict(result.check)
+		if (showDiff && (fixer.riskLevel ?? 'destructive') !== 'safe-add') {
+			const previews = await previewFixer(fixer, result, targetDir, pkg, lock)
+			printPreviews(previews)
+		}
 		const ok = await confirmApply(fixer, result, assumeYes)
 		if (!ok) {
 			actions.push(recordFor(fixer.target, result.check, result.status, 'skipped', [], conflict))

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -264,6 +264,7 @@ program
 	.option('--json', 'Emit machine-readable JSON output (implies --yes)')
 	.option('--list', 'List all registered fix targets and exit')
 	.option('--resync', 'Re-scaffold every file recorded in .js-tooling.json')
+	.option('--diff', 'Show a unified diff of each change before confirming')
 	.action((target: string | undefined, options) =>
 		fixCommand(target, {
 			directory: options.directory,
@@ -272,6 +273,7 @@ program
 			json: options.json,
 			list: options.list,
 			resync: options.resync,
+			diff: options.diff,
 		})
 	)
 

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -720,3 +720,77 @@ describe('fix walk-all', () => {
 		expect(await fs.pathExists(join(dir, '.editorconfig'))).toBe(false)
 	})
 })
+
+describe('fix --diff', () => {
+	it('prints a unified diff before the confirm prompt for a drifted destructive fixer', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		// Seed a drifted biome.json so doctor flags drift and the diff has both sides.
+		await fs.writeJson(join(dir, 'biome.json'), { foo: 'bar' })
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		promptMock.mockResolvedValue({ confirm: false })
+		try {
+			await fixCommand('biome', { directory: dir, diff: true })
+			const output = logSpy.mock.calls.flat().join('\n')
+			// Unified diff headers come from `createPatch`.
+			expect(output).toMatch(/--- biome\.json/)
+			expect(output).toMatch(/\+\+\+ biome\.json/)
+			// The drifted content should appear as a removed line in the diff.
+			expect(output).toMatch(/-.*"foo"/)
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
+	it('labels the preview as "create" when the target file does not yet exist', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		promptMock.mockResolvedValue({ confirm: false })
+		try {
+			await fixCommand('nvmrc', { directory: dir, diff: true })
+			const output = logSpy.mock.calls.flat().join('\n')
+			expect(output).toMatch(/create.*\.nvmrc/)
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
+	it('emits no diff markers when --json is set (JSON output stream stays clean)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'biome.json'), { foo: 'bar' })
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await fixCommand('biome', { directory: dir, diff: true, json: true })
+			// Every console.log call in JSON mode should be valid JSON or empty.
+			for (const call of logSpy.mock.calls) {
+				const line = call[0] as string
+				if (!line || line.trim() === '') continue
+				expect(line).not.toMatch(/^\+\+\+ /)
+				expect(line).not.toMatch(/^--- /)
+			}
+			const lastCall = logSpy.mock.calls.at(-1)?.[0] as string
+			const payload = JSON.parse(lastCall)
+			expect(payload.actions).toBeDefined()
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
+	it('does not show a diff for safe-add fixers (would-be no-op)', async () => {
+		// `dependabot` is safe-add — the preview path should be skipped.
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		promptMock.mockResolvedValue({ confirm: false })
+		try {
+			await fixCommand('dependabot', { directory: dir, diff: true })
+			const output = logSpy.mock.calls.flat().join('\n')
+			expect(output).not.toMatch(/^\+\+\+ /m)
+			expect(output).not.toMatch(/^--- /m)
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+})


### PR DESCRIPTION
Closes #58.

## Summary

Adds an opt-in \`--diff\` flag to \`fix\` that prints a coloured unified diff of every change before the confirm prompt, so users can see exactly what they're about to overwrite. Works for both targeted runs (\`fix biome --diff\`) and walk-all (\`fix --diff\`).

## Example

```text
$ fix biome --diff
🔧 biome — Biome is drift

  modify biome.json
    --- biome.json
    +++ biome.json
    @@ -1,1 +1,63 @@
    -{"foo":"bar"}
    +{
    +	"\$schema": "https://biomejs.dev/schemas/2.3.0/schema.json",
    +	"vcs": { ... },
    +	...
    +}
? ⚠️  Scaffold biome.json … — overwrite existing file? (y/N)
```

## How it works

- \`previewFixer()\` **shadow-runs the fixer in a temp copy of the target dir**, so reads of existing state (husky → \`package.json\`, vitest → \`vitest.setup.ts\`, etc.) still produce realistic output. Real files are never touched until the user confirms.
- Each \`fixer.outputs\` entry becomes a \`PreviewEntry\`: \`create\` (new file, no body), \`modify\` (file exists, shows unified diff), or \`unchanged\` (skipped).
- Output path annotations like \`\"package.json (lint-staged field)\"\` are stripped to the bare path.

## Behaviour per acceptance criteria

| Criterion | Implementation |
|---|---|
| Colored unified diff for each change | ✅ Per-file \`createPatch\` from \`diff\`, plus a small \`colorisePatch\` that paints \`+\`/\`-\`/\`@@\` lines |
| Suppressed under \`--json\` | ✅ \`showDiff = options.diff === true && !json\` |
| Suppressed for safe-add fixers | ✅ Checked at each call site before \`previewFixer\` |
| Documented in \`docs/guides/cli.md\` | ✅ New 'Diff preview (\`--diff\`)' subsection with example |
| Honours \`NO_COLOR\` | ✅ \`shouldColorise()\` checks \`process.env.NO_COLOR\` and \`chalk.level\` |

## Dependencies

- Adds \`diff@^9\` as a runtime dep (small, MIT, zero transitive deps).
- \`@types/diff\` added as a devDep.

## Test plan

- [x] \`pnpm exec vitest run\` — 253 passed (249 prior + 4 new).
- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm --filter @rtorcato/docs build\` succeeds.
- [x] Manual smoke test: ran \`fix biome --diff\` against a drifted \`biome.json\` in a tmp dir — diff renders correctly, and the temp-dir-conflict edge case is handled (\`os.tmpdir()\` inside cwd falls back to parent).