### PR TITLE
fix(release): make npm publish opt-in and install preset plugins

### DIFF
--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -291,17 +291,18 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'semantic-release',
-		description: 'Scaffold release.config.mjs (skipped on private packages)',
+		description:
+			'Scaffold release.config.mjs + install preset plugins (skipped on private packages)',
 		appliesTo: ['semantic-release'],
-		outputs: ['release.config.mjs'],
+		outputs: ['release.config.mjs', 'package.json'],
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			if (pkg?.private === true) {
 				console.log(chalk.gray('   skipping — package is private'))
 				return { filesWritten: [] }
 			}
-			await generateSemanticReleaseConfig(targetDir)
-			return { filesWritten: ['release.config.mjs'] }
+			const filesWritten = await generateSemanticReleaseConfig(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/generators/build.ts
+++ b/src/cli/generators/build.ts
@@ -84,13 +84,46 @@ export default mergeConfig(preset, defineConfig({ plugins: [react()] }))
 	await fs.writeFile(viteConfigPath, viteConfig)
 }
 
-export async function generateSemanticReleaseConfig(targetDir: string) {
+// Plugins the github/gitlab preset activates that semantic-release core does
+// NOT bundle (core bundles only commit-analyzer, release-notes-generator, npm,
+// github). Without these in the consumer's deps, `semantic-release` crashes
+// with "Cannot find module '@semantic-release/changelog'" on first run.
+const RELEASE_PLUGIN_DEPS: Record<string, string> = {
+	'@semantic-release/changelog': '^6.0.0',
+	'@semantic-release/git': '^10.0.0',
+}
+
+export async function generateSemanticReleaseConfig(targetDir: string): Promise<string[]> {
 	const releaseConfigPath = path.join(targetDir, 'release.config.mjs')
 
 	const releaseConfig = `export { default } from '@rtorcato/js-tooling/semantic-release/github'
 `
 
 	await fs.writeFile(releaseConfigPath, releaseConfig)
+	const written = ['release.config.mjs']
+
+	// Ensure the preset's non-bundled plugins are installed; otherwise the
+	// scaffolded release.config.mjs references modules the consumer lacks.
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (await fs.pathExists(pkgPath)) {
+		const pkg = (await fs.readJson(pkgPath)) as Record<string, any>
+		const devDeps = (pkg.devDependencies ?? {}) as Record<string, string>
+		const deps = (pkg.dependencies ?? {}) as Record<string, string>
+		let changed = false
+		for (const [name, version] of Object.entries(RELEASE_PLUGIN_DEPS)) {
+			if (!devDeps[name] && !deps[name]) {
+				devDeps[name] = version
+				changed = true
+			}
+		}
+		if (changed) {
+			pkg.devDependencies = devDeps
+			await fs.writeJson(pkgPath, pkg, { spaces: 2 })
+			written.push('package.json')
+		}
+	}
+
+	return written
 }
 
 export async function generateChangesetsConfig(targetDir: string) {

--- a/tooling/semantic-release/github.mjs
+++ b/tooling/semantic-release/github.mjs
@@ -51,8 +51,11 @@ export default {
 				changelogFile: 'CHANGELOG.md',
 			},
 		],
-		['@semantic-release/npm', { npmPublish: true, pkgRoot: '.' }],
-		// NPM plugin to publish the package
+		// npm publishing is opt-in via NPM_TOKEN: a repo that provides the token
+		// (e.g. js-tooling's own CI) publishes; one that doesn't (GitHub-releases
+		// only) gets a green release instead of an EINVALIDNPMTOKEN failure. The
+		// version in package.json is still bumped either way.
+		['@semantic-release/npm', { npmPublish: Boolean(process.env.NPM_TOKEN), pkgRoot: '.' }],
 		[
 			'@semantic-release/git',
 			{

--- a/tooling/semantic-release/index.mjs
+++ b/tooling/semantic-release/index.mjs
@@ -52,8 +52,11 @@ export default {
 				changelogFile: 'CHANGELOG.md',
 			},
 		],
-		['@semantic-release/npm', { npmPublish: true, pkgRoot: '.' }],
-		// NPM plugin to publish the package
+		// npm publishing is opt-in via NPM_TOKEN: a repo that provides the token
+		// publishes; one that doesn't (GitLab releases only) gets a green release
+		// instead of an EINVALIDNPMTOKEN failure. The version in package.json is
+		// still bumped either way.
+		['@semantic-release/npm', { npmPublish: Boolean(process.env.NPM_TOKEN), pkgRoot: '.' }],
 		[
 			'@semantic-release/git',
 			{


### PR DESCRIPTION
## Summary

The shared semantic-release `github` preset failed for consumers out of the box in two ways. js-tooling itself uses this preset (`release.config.mjs` re-exports it) and publishes to npm, so both fixes are designed to be **non-breaking for the maintainer's own release**.

## Changes

### #103 — npm publish forced on, required `NPM_TOKEN`
The `github` preset hardcoded `npmPublish: true`, so a repo using it for GitHub releases only (no `NPM_TOKEN`) failed with `EINVALIDNPMTOKEN`. Now gated: `npmPublish: Boolean(process.env.NPM_TOKEN)`.

- Repos that provide `NPM_TOKEN` (e.g. js-tooling's own CI) → still publish.
- Repos that don't → npm plugin skips `verifyConditions`, green release; `package.json` version still bumped.
- Applied to both `github.mjs` and the GitLab `index.mjs`. "Providing the token" is the explicit opt-in the reporter asked for.

### #102 / #95 — preset plugins not installed
`fix semantic-release` wrote a `release.config.mjs` referencing `@semantic-release/changelog` and `@semantic-release/git` (not bundled by semantic-release core) without installing them → `Cannot find module`. `generateSemanticReleaseConfig` now ensures both are in `devDependencies` (idempotent; the `setup` path already did this).

`@semantic-release/exec` is commented out in the preset, so no exec dep is needed — #95's `exec` mention is moot.

## Verification

- `biome check` + `tsc --noEmit` clean; **268/268 tests pass**
- `generateSemanticReleaseConfig` on a fresh package.json → adds both plugins to devDeps and reports `package.json` written; second run is idempotent (no re-write)
- Preset import: `npmPublish` is `false` without `NPM_TOKEN`, `true` with it