### PR TITLE
feat(cli): scaffold community-health files (CONTRIBUTING/SECURITY/templates)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -889,6 +889,24 @@ async function checkCodeowners(dir: string): Promise<CheckResult> {
 	}
 }
 
+async function checkCommunityHealth(dir: string): Promise<CheckResult> {
+	const anchors = ['CONTRIBUTING.md', 'SECURITY.md']
+	const present = await Promise.all(anchors.map((f) => fs.pathExists(path.join(dir, f))))
+	if (present.every(Boolean)) {
+		return {
+			check: 'Community health',
+			status: 'ok',
+			detail: 'CONTRIBUTING.md and SECURITY.md found',
+		}
+	}
+	return {
+		check: 'Community health',
+		status: 'optional-missing',
+		detail: 'missing community-health files (CONTRIBUTING/SECURITY/templates)',
+		hint: 'Run `npx @rtorcato/js-tooling fix community-health` to scaffold them',
+	}
+}
+
 async function checkGitLabCI(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -934,6 +952,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkCodeQL(targetDir))
 	results.push(await checkGitLabCI(targetDir))
 	results.push(await checkCodeowners(targetDir))
+	results.push(await checkCommunityHealth(targetDir))
 	results.push(await checkTypedoc(targetDir, pkg))
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { installAgentRules } from '../generators/agent-rules.js'
 import { generateSemanticReleaseConfig } from '../generators/build.js'
+import { generateCommunityHealth } from '../generators/community-health.js'
 import {
 	generateCommitlintConfig,
 	generateHuskyConfig,
@@ -379,6 +380,24 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const written = await generateCodeowners(targetDir)
 			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'community-health',
+		description: 'Scaffold CONTRIBUTING.md, SECURITY.md, PR + issue templates',
+		appliesTo: ['Community health'],
+		outputs: [
+			'CONTRIBUTING.md',
+			'SECURITY.md',
+			'.github/PULL_REQUEST_TEMPLATE.md',
+			'.github/ISSUE_TEMPLATE/bug_report.md',
+			'.github/ISSUE_TEMPLATE/feature_request.md',
+		],
+		riskLevel: 'safe-add',
+		canFixDrift: false,
+		async run({ targetDir }) {
+			const filesWritten = await generateCommunityHealth(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/generators/community-health.ts
+++ b/src/cli/generators/community-health.ts
@@ -1,0 +1,151 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+const CONTRIBUTING = `# Contributing
+
+Thanks for your interest in contributing!
+
+## Local setup
+
+\`\`\`bash
+pnpm install
+pnpm build
+pnpm test
+\`\`\`
+
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+Format: \`type(scope): summary\` — e.g. \`fix(api): handle empty payload\`.
+Common types: \`feat\`, \`fix\`, \`docs\`, \`refactor\`, \`test\`, \`chore\`.
+If commitizen is set up, run \`pnpm commit\` to be guided through it.
+
+## Pull requests
+
+- Keep PRs focused and small where possible.
+- Make sure \`pnpm test\` and \`pnpm check\` (lint) pass.
+- Add tests for new behaviour.
+- Describe what changed and why in the PR description.
+`
+
+// Relative advisory link works from a repo-root SECURITY.md on GitHub, so the
+// template stays repo-agnostic (no hardcoded owner/name). Fill in the contact.
+const SECURITY = `# Security Policy
+
+## Supported versions
+
+Only the latest major version receives security fixes.
+
+## Reporting a vulnerability
+
+Do **not** open a public GitHub issue for security vulnerabilities.
+
+Instead, use [GitHub's private vulnerability reporting](../../security/advisories/new)
+or email **<security-contact@example.com>** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You'll receive a response within 5 business days.
+`
+
+const PULL_REQUEST_TEMPLATE = `## Summary
+
+<!-- 1-3 bullet points describing what changed and why -->
+-
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Test plan
+
+- [ ] Existing tests pass (\`pnpm test\`)
+- [ ] New tests added for new behaviour
+
+## Checklist
+
+- [ ] No debug logging left in production code
+- [ ] No breaking changes (or BREAKING CHANGE footer added to commit)
+- [ ] Lint passes (\`pnpm check\` / \`pnpm lint\`)
+`
+
+const BUG_REPORT = `---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+## Actual behaviour
+
+<!-- Paste any error output here -->
+
+\`\`\`
+\`\`\`
+
+## Environment
+
+- Package version:
+- Node version (\`node -v\`):
+- Package manager + version:
+- OS:
+`
+
+const FEATURE_REQUEST = `---
+name: Feature request
+about: Suggest an idea or improvement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What are you trying to do that you can't do today? -->
+
+## Proposed solution
+
+## Alternatives considered
+
+## Additional context
+`
+
+const FILES: ReadonlyArray<{ rel: string; content: string }> = [
+	{ rel: 'CONTRIBUTING.md', content: CONTRIBUTING },
+	{ rel: 'SECURITY.md', content: SECURITY },
+	{ rel: '.github/PULL_REQUEST_TEMPLATE.md', content: PULL_REQUEST_TEMPLATE },
+	{ rel: '.github/ISSUE_TEMPLATE/bug_report.md', content: BUG_REPORT },
+	{ rel: '.github/ISSUE_TEMPLATE/feature_request.md', content: FEATURE_REQUEST },
+]
+
+/**
+ * Scaffold GitHub community-health files. Safe-add: existing files are left
+ * untouched (the user owns them once written). Returns the list of files
+ * actually created.
+ */
+export async function generateCommunityHealth(targetDir: string): Promise<string[]> {
+	const written: string[] = []
+	for (const { rel, content } of FILES) {
+		const filepath = path.join(targetDir, rel)
+		if (await fs.pathExists(filepath)) continue
+		await fs.ensureDir(path.dirname(filepath))
+		await fs.writeFile(filepath, content)
+		written.push(rel)
+	}
+	return written
+}

--- a/tests/cli/generators/community-health.test.ts
+++ b/tests/cli/generators/community-health.test.ts
@@ -1,0 +1,41 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { generateCommunityHealth } from '../../../src/cli/generators/community-health.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('generateCommunityHealth', () => {
+	it('scaffolds all five community-health files', async () => {
+		const dir = newTmpDir()
+		const written = await generateCommunityHealth(dir)
+		expect(written).toEqual([
+			'CONTRIBUTING.md',
+			'SECURITY.md',
+			'.github/PULL_REQUEST_TEMPLATE.md',
+			'.github/ISSUE_TEMPLATE/bug_report.md',
+			'.github/ISSUE_TEMPLATE/feature_request.md',
+		])
+		for (const rel of written) {
+			expect(await fs.pathExists(join(dir, rel))).toBe(true)
+		}
+	})
+
+	it('is safe-add: leaves an existing file untouched and reports only new files', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'CONTRIBUTING.md'), 'MY OWN CONTRIBUTING\n')
+
+		const written = await generateCommunityHealth(dir)
+
+		expect(written).not.toContain('CONTRIBUTING.md')
+		expect(written).toContain('SECURITY.md')
+		expect(await fs.readFile(join(dir, 'CONTRIBUTING.md'), 'utf-8')).toBe('MY OWN CONTRIBUTING\n')
+	})
+
+	it('writes nothing on a second run', async () => {
+		const dir = newTmpDir()
+		await generateCommunityHealth(dir)
+		expect(await generateCommunityHealth(dir)).toEqual([])
+	})
+})


### PR DESCRIPTION
Closes #77.

Adds a `community-health` target that scaffolds the GitHub community-health files new projects were missing:

- `CONTRIBUTING.md` — minimal: local setup, Conventional Commits, PR expectations
- `SECURITY.md` — repo-agnostic (relative advisory link + placeholder contact)
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/bug_report.md` + `feature_request.md`

## Approach

Mirrors the existing `codeowners` add-on — no new setup-wizard wiring:

- **Generator** `generateCommunityHealth` (safe-add: skips files that already exist, returns only what it wrote — never clobbers user content)
- **Doctor** check `Community health` → `optional-missing` when `CONTRIBUTING.md`/`SECURITY.md` are absent, with a `fix community-health` hint
- **Fixer** `community-health` (`riskLevel: safe-add`)

## Verification

- biome + `tsc` clean
- 3 new unit tests (create-all, safe-add-skip, idempotent second run); full suite **271/271**
- Smoke-tested: creates all 5, preserves a pre-existing `CONTRIBUTING.md`, writes nothing on re-run

## Follow-up (out of scope)

A `setup` wizard checkbox ("Scaffold community-health files?") could opt these in at bootstrap — left out to keep this aligned with the fix/doctor add-on pattern.