### PR TITLE
ci: use RELEASE_TOKEN PAT for semantic-release on protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch full history for semantic-release
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN is an admin PAT so semantic-release can push the
+          # version commit + tag to a protected main (github-actions[bot]
+          # can't bypass branch protection). Falls back to GITHUB_TOKEN.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -323,7 +326,7 @@ jobs:
 
       - name: 🚀 Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## What
Switches the `release` job to use a `RELEASE_TOKEN` secret (admin PAT) for both checkout and `semantic-release`, with a fallback to `GITHUB_TOKEN`.

## Why
`main` is now branch-protected with required status checks. `semantic-release` (via `@semantic-release/git`) pushes the `chore(release): … [skip ci]` version commit + tag **directly to `main`**. Running as `github-actions[bot]`, that push is **rejected** — a bot can't bypass branch protection. An admin PAT can (the protection has `enforce_admins: false`).

## How
- `token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` on checkout.
- `GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` on the semantic-release step.
- Fallback means nothing breaks for non-release runs before the secret exists.

## Required manual step before the next feat/fix release
Create the secret (admin token, owner `rtorcato`):
- **Fine-grained PAT** (recommended): repo `rtorcato/js-tooling`, **Contents: Read and write** (+ optionally Pull requests / Issues: write so semantic-release can comment). Add as repo secret **`RELEASE_TOKEN`**.
- Or a classic PAT with `repo` scope.

Until `RELEASE_TOKEN` is set, `docs:`/`ci:`/`chore:` merges are fine (they don't release); a `feat`/`fix` merge would fail at the release push.

Refs #109