### PR TITLE
feat(cli): scaffold RELEASE_TOKEN-aware release workflow + doctor check

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -622,6 +622,49 @@ async function checkGitHubActions(dir: string): Promise<CheckResult> {
 	}
 }
 
+// Detects the broken-release-on-protected-main footgun: a workflow that runs
+// semantic-release but only hands it GITHUB_TOKEN, which can't push the version
+// commit + tag past branch protection. The fix is an admin PAT (RELEASE_TOKEN)
+// with a GITHUB_TOKEN fallback.
+async function checkReleaseToken(dir: string): Promise<CheckResult> {
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (!(await fs.pathExists(workflowsDir))) {
+		return { check: 'Release token', status: 'optional-missing', detail: 'no .github/workflows/' }
+	}
+	try {
+		const files = await fs.readdir(workflowsDir)
+		for (const f of files) {
+			if (!(f.endsWith('.yml') || f.endsWith('.yaml'))) continue
+			const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+			if (!/semantic-release/.test(content)) continue
+			if (/RELEASE_TOKEN/.test(content)) {
+				return {
+					check: 'Release token',
+					status: 'ok',
+					detail: `${f} uses RELEASE_TOKEN (with GITHUB_TOKEN fallback)`,
+				}
+			}
+			return {
+				check: 'Release token',
+				status: 'drift',
+				detail: `${f} runs semantic-release with bare GITHUB_TOKEN`,
+				hint: 'GITHUB_TOKEN cannot push to a protected main. Set the checkout `token:` and the semantic-release `GITHUB_TOKEN` env to `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` and add a RELEASE_TOKEN admin PAT secret',
+			}
+		}
+		return {
+			check: 'Release token',
+			status: 'optional-missing',
+			detail: 'no semantic-release workflow found',
+		}
+	} catch {
+		return {
+			check: 'Release token',
+			status: 'optional-missing',
+			detail: 'unable to read .github/workflows/',
+		}
+	}
+}
+
 async function checkDependabot(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -948,6 +991,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkKnip(targetDir, pkg))
 	results.push(await checkSizeLimit(targetDir, pkg))
 	results.push(await checkGitHubActions(targetDir))
+	results.push(await checkReleaseToken(targetDir))
 	results.push(await checkDependabot(targetDir))
 	results.push(await checkCodeQL(targetDir))
 	results.push(await checkGitLabCI(targetDir))

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -237,7 +237,10 @@ ${
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: \${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN (admin PAT) lets semantic-release push the version
+          # commit + tag to a protected main; GITHUB_TOKEN can't bypass branch
+          # protection. Falls back to GITHUB_TOKEN when no PAT is set.
+          token: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v6
@@ -265,7 +268,7 @@ ${
 
       - name: 🚀 Run semantic-release
         env:
-          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx semantic-release`

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -701,4 +701,33 @@ describe('nextStepSuggestions', () => {
 		])
 		expect(suggestions).toEqual([])
 	})
+
+	it('flags a release workflow that runs semantic-release with bare GITHUB_TOKEN', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  release:\n    steps:\n      - run: npx semantic-release\n        env:\n          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n'
+		)
+
+		const results = await runDoctor(dir)
+		const rt = results.find((r) => r.check === 'Release token')
+		expect(rt?.status).toBe('drift')
+		expect(rt?.hint).toMatch(/RELEASE_TOKEN/)
+	})
+
+	it('reports ok when the release workflow uses the RELEASE_TOKEN fallback', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  release:\n    steps:\n      - uses: actions/checkout@v7\n        with:\n          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}\n      - run: npx semantic-release\n        env:\n          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}\n'
+		)
+
+		const results = await runDoctor(dir)
+		const rt = results.find((r) => r.check === 'Release token')
+		expect(rt?.status).toBe('ok')
+	})
 })


### PR DESCRIPTION
## Why

A scaffolded release job used a bare `GITHUB_TOKEN`, which **cannot push the version commit + tag to a protected `main`** (semantic-release fails). This is the exact footgun js-tooling's own repo just hit.

## What

- **Generator** (`github-actions.ts`): release job now uses `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` for the checkout `token:` and the semantic-release `GITHUB_TOKEN` env. Falls back to `GITHUB_TOKEN` when no PAT is set, so nothing breaks for unprotected repos.
- **doctor**: new `Release token` check flags any workflow running semantic-release with a bare `GITHUB_TOKEN`, with a hint to add the fallback + a `RELEASE_TOKEN` admin PAT.
- Tests for both drift and ok cases.

## Note

Branch-protection *settings* themselves remain out of scope (server-side, need admin `gh api`) — this only covers the workflow + detection.