### PR TITLE
fix(commitlint): raise header-max to 100, ungate release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
   # Release and publish
   release:
     runs-on: ubuntu-latest
-    needs: [dependencies, lint, typecheck, test, build, commitlint, varcheck, check-skip]
+    needs: [dependencies, lint, typecheck, test, build, varcheck, check-skip]
     if: |
       always() &&
       needs.check-skip.outputs.should-skip != 'true' &&
@@ -282,8 +282,7 @@ jobs:
       needs.typecheck.result == 'success' &&
       needs.test.result == 'success' &&
       needs.build.result == 'success' &&
-      needs.varcheck.result == 'success' &&
-      (needs.commitlint.result == 'success' || needs.commitlint.result == 'skipped')
+      needs.varcheck.result == 'success'
     permissions:
       contents: write
       issues: write

--- a/tooling/commitlint/commitlint.mjs
+++ b/tooling/commitlint/commitlint.mjs
@@ -20,9 +20,10 @@ export default {
 				"test",
 			],
 		],
-		// Enforce length limits: 72 chars matches the conventional-commits
-		// recommendation and git's default email format
-		"header-max-length": [2, "always", 72],
+		// 100 is the conventional-commits/semantic-release default. 72 was too
+		// tight: GitHub appends " (#NN)" to squash commits, overflowing the
+		// header on main and skipping the release. Body/footer stay at 72.
+		"header-max-length": [2, "always", 100],
 		"body-max-line-length": [2, "always", 72],
 		"footer-max-line-length": [2, "always", 72],
 		// Enforce case rules (allow common patterns)


### PR DESCRIPTION
GitHub appends ` (#NN)` to squash commit headers, overflowing the old 72-char `header-max-length` on main — commitlint then failed and **skipped the release** (the release job gated on it). This bit PR #131.

- Raise `header-max-length` 72→100 (conventional-commits default) in the shared preset `tooling/commitlint/commitlint.mjs`. Body/footer stay at 72.
- Drop `commitlint` from the release job's `needs`/`if` so a long squash header can't block a release. commitlint still runs on PRs pre-merge.

Unblocks the stuck release and finally exercises `RELEASE_TOKEN` end-to-end.