### PR TITLE
feat(docusaurus): shared TypeDoc helper + reusable docs deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,78 @@
+name: Reusable Deploy Docs
+
+# Reusable Docusaurus → GitHub Pages deploy. Call it from any @rtorcato/* repo:
+#
+#   jobs:
+#     docs:
+#       permissions: { contents: read, pages: write, id-token: write }
+#       uses: rtorcato/js-tooling/.github/workflows/docs-deploy.yml@main
+#       with:
+#         build-filter: '@rtorcato/<pkg>-docs'
+#
+# Caller decides WHEN to deploy (push paths, release, dispatch); this owns HOW.
+on:
+  workflow_call:
+    inputs:
+      build-filter:
+        description: 'pnpm --filter target for the docs app, e.g. @rtorcato/cf-common-docs'
+        required: true
+        type: string
+      build-output:
+        description: 'Directory the docs build emits'
+        required: false
+        default: 'apps/docs/build'
+        type: string
+      node-version:
+        description: 'Node version'
+        required: false
+        default: '22'
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs
+        run: pnpm --filter ${{ inputs.build-filter }} build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ inputs.build-output }}
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,19 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
+    # src/**, package.json and README.md so a shipped change or a release's
+    # version bump redeploys — not just edits under apps/docs.
     paths:
       - 'apps/docs/**'
+      - 'src/**'
+      - 'package.json'
+      - 'README.md'
       - '.github/workflows/docs.yml'
+      - '.github/workflows/docs-deploy.yml'
+  # semantic-release publishes a GitHub Release after the version commit lands;
+  # rebuild then so the site always tracks the latest release.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -13,46 +23,8 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build docs
-        run: pnpm --filter @rtorcato/docs build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: apps/docs/build
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  docs:
+    uses: ./.github/workflows/docs-deploy.yml
+    with:
+      build-filter: '@rtorcato/docs'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,10 @@ When adding support for a new development tool:
 - Add JSDoc comments for functions and classes
 - Update CLI help text when adding commands
 - Include examples in tool documentation
+- Setting up a library docs site? See the
+  [Docs site that stays in sync](apps/docs/docs/guides/docs-site.md) guide —
+  shared TypeDoc helper (`@rtorcato/js-tooling/docusaurus`) + reusable
+  `docs-deploy.yml` workflow.
 
 ## 🧪 Testing
 

--- a/apps/docs/docs/guides/docs-site.md
+++ b/apps/docs/docs/guides/docs-site.md
@@ -1,0 +1,93 @@
+---
+title: Docs site that stays in sync
+description: Shared Docusaurus + TypeDoc setup so a library's docs and README track every release with no manual edits.
+---
+
+# Docs site that stays in sync
+
+The `@rtorcato/*` libraries publish a Docusaurus site whose **API reference is
+generated from source JSDoc** and which **redeploys on every release** — so
+shipping a module or cutting a version updates the docs with no manual step.
+This guide is the canonical setup; each repo's `CONTRIBUTING.md` links here and
+adds only its own module list.
+
+## How it stays current
+
+- **API reference** — `docusaurus-plugin-typedoc` regenerates `docs/api/<mod>`
+  from each module's source on every build. Document the code, not the docs.
+- **Version badge** — the README uses a shields.io npm badge
+  (`https://img.shields.io/npm/v/<pkg>.svg`), which reflects npm automatically.
+- **Deploy on release** — the docs workflow rebuilds on `release: published`
+  and on `src/**` / `package.json` / `README.md` changes, not just edits under
+  `apps/docs/`.
+
+## 1. TypeDoc plugins
+
+Install the TypeDoc deps in the docs app:
+
+```sh
+pnpm --filter <docs-pkg> add -D docusaurus-plugin-typedoc typedoc typedoc-plugin-markdown
+```
+
+Wire the plugins with the shared helper — one instance per subpath module,
+generated from `src/<mod>/index.ts`:
+
+```ts
+// apps/docs/docusaurus.config.ts
+import { getTypedocPlugins } from '@rtorcato/js-tooling/docusaurus'
+
+const MODULES = ['errors', 'env', 'kv'] // add a module here when it ships
+
+const config: Config = {
+  // ...
+  plugins: [
+    ...getTypedocPlugins(MODULES),
+    // ...other plugins
+  ] as Config['plugins'],
+}
+```
+
+Add each module to the sidebar's API Reference category:
+
+```ts
+// apps/docs/sidebars.ts
+{ type: 'doc', id: 'api/kv/index', label: 'kv' }
+```
+
+`docs/api/` is generated — gitignore it, and have biome ignore it (enable
+`vcs.useIgnoreFile` in your root `biome.jsonc` so it isn't linted).
+
+## 2. Deploy workflow
+
+Call the reusable workflow instead of copying the build/deploy steps:
+
+```yaml
+# .github/workflows/docs.yml
+name: Deploy Docs
+on:
+  push:
+    branches: [main]
+    paths: ['apps/docs/**', 'src/**', 'package.json', 'README.md', '.github/workflows/docs.yml']
+  release:
+    types: [published]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  docs:
+    uses: rtorcato/js-tooling/.github/workflows/docs-deploy.yml@main
+    with:
+      build-filter: '@rtorcato/<pkg>-docs'
+```
+
+Enable GitHub Pages with **GitHub Actions** as the source
+(`gh api -X POST repos/<owner>/<repo>/pages -f build_type=workflow`).
+
+## 3. Shipping a module (per-repo checklist)
+
+Each repo's `CONTRIBUTING.md` should spell out: add the module to `MODULES` +
+the sidebar, add a row to the README modules table and the docs Status table,
+tick the roadmap, and commit `feat(<mod>): …`. The release and docs deploy run
+on merge.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -14,6 +14,7 @@ const sidebars: SidebarsConfig = {
         'guides/library-style',
         'guides/dependabot-strategy',
         'guides/public-repo-issue-safety',
+        'guides/docs-site',
       ],
     },
     {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
 		"tooling/tests/ssr-safety.d.mts",
 		"tooling/tsup/index.mjs",
 		"tooling/tsup/index.d.mts",
+		"tooling/docusaurus/index.mjs",
+		"tooling/docusaurus/index.d.mts",
 		"tooling/biome/biome.json",
 		"tooling/changesets/config.json",
 		"tooling/oxlint/oxlintrc.json",
@@ -151,6 +153,10 @@
 		"./tsup": {
 			"types": "./tooling/tsup/index.d.mts",
 			"import": "./tooling/tsup/index.mjs"
+		},
+		"./docusaurus": {
+			"types": "./tooling/docusaurus/index.d.mts",
+			"import": "./tooling/docusaurus/index.mjs"
 		},
 		"./biome": "./tooling/biome/biome.json",
 		"./changesets": "./tooling/changesets/config.json",

--- a/tooling/docusaurus/index.d.mts
+++ b/tooling/docusaurus/index.d.mts
@@ -1,0 +1,17 @@
+export interface TypedocPluginsOptions {
+	/** Directory holding each module's `<id>/index.ts`, relative to the docs app. Default `../../src`. */
+	srcDir?: string
+	/** tsconfig passed to TypeDoc, relative to the docs app. Default `../../tsconfig.json`. */
+	tsconfig?: string
+	/** Extra `docusaurus-plugin-typedoc` options merged into every instance. */
+	overrides?: Record<string, unknown>
+}
+
+/**
+ * Build one `docusaurus-plugin-typedoc` instance per subpath module. Returns
+ * docusaurus plugin tuples to spread into `plugins`.
+ */
+export declare const getTypedocPlugins: (
+	modules: string[],
+	options?: TypedocPluginsOptions
+) => Array<[string, Record<string, unknown>]>

--- a/tooling/docusaurus/index.mjs
+++ b/tooling/docusaurus/index.mjs
@@ -1,0 +1,38 @@
+/**
+ * Build one `docusaurus-plugin-typedoc` instance per subpath module, each
+ * generating `docs/api/<id>/index.md` from that module's source JSDoc.
+ *
+ * Centralises the TypeDoc wiring the @rtorcato/* docs sites share. The
+ * consuming docs app must have `docusaurus-plugin-typedoc`, `typedoc` and
+ * `typedoc-plugin-markdown` installed.
+ *
+ * @param {string[]} modules - module ids, e.g. ['errors', 'env', 'kv']
+ * @param {object} [options]
+ * @param {string} [options.srcDir] - dir holding `<id>/index.ts`, relative to the docs app. Default '../../src'.
+ * @param {string} [options.tsconfig] - tsconfig for TypeDoc, relative to the docs app. Default '../../tsconfig.json'.
+ * @param {object} [options.overrides] - extra plugin options merged into every instance.
+ * @returns {Array<[string, object]>} docusaurus plugin tuples to spread into `plugins`.
+ */
+export const getTypedocPlugins = (modules, options = {}) => {
+	const { srcDir = '../../src', tsconfig = '../../tsconfig.json', overrides = {} } = options
+	return modules.map((id) => [
+		'docusaurus-plugin-typedoc',
+		{
+			id,
+			entryPoints: [`${srcDir}/${id}/index.ts`],
+			tsconfig,
+			// The library typechecks on its own toolchain; the docs workspace may
+			// pin a different TS. Skip TypeDoc's redundant semantic check.
+			skipErrorChecking: true,
+			out: `docs/api/${id}`,
+			readme: 'none',
+			includeVersion: false,
+			excludePrivate: true,
+			excludeInternal: true,
+			excludeExternals: true,
+			sort: ['source-order'],
+			outputFileStrategy: 'modules',
+			...overrides,
+		},
+	])
+}

--- a/tooling/docusaurus/index.ts
+++ b/tooling/docusaurus/index.ts
@@ -1,0 +1,42 @@
+export interface TypedocPluginsOptions {
+	/** Directory holding each module's `<id>/index.ts`, relative to the docs app. Default `../../src`. */
+	srcDir?: string
+	/** tsconfig passed to TypeDoc, relative to the docs app. Default `../../tsconfig.json`. */
+	tsconfig?: string
+	/** Extra `docusaurus-plugin-typedoc` options merged into every instance. */
+	overrides?: Record<string, unknown>
+}
+
+/**
+ * Build one `docusaurus-plugin-typedoc` instance per subpath module, each
+ * generating `docs/api/<id>/index.md` from that module's source JSDoc.
+ *
+ * The consuming docs app must have `docusaurus-plugin-typedoc`, `typedoc` and
+ * `typedoc-plugin-markdown` installed.
+ */
+export const getTypedocPlugins = (
+	modules: string[],
+	options: TypedocPluginsOptions = {}
+): Array<[string, Record<string, unknown>]> => {
+	const { srcDir = '../../src', tsconfig = '../../tsconfig.json', overrides = {} } = options
+	return modules.map((id) => [
+		'docusaurus-plugin-typedoc',
+		{
+			id,
+			entryPoints: [`${srcDir}/${id}/index.ts`],
+			tsconfig,
+			// The library typechecks on its own toolchain; the docs workspace may
+			// pin a different TS. Skip TypeDoc's redundant semantic check.
+			skipErrorChecking: true,
+			out: `docs/api/${id}`,
+			readme: 'none',
+			includeVersion: false,
+			excludePrivate: true,
+			excludeInternal: true,
+			excludeExternals: true,
+			sort: ['source-order'],
+			outputFileStrategy: 'modules',
+			...overrides,
+		},
+	])
+}


### PR DESCRIPTION
Centralises the docs-site wiring duplicated across the `@rtorcato/*` libraries, so each repo's docs + README track releases with no manual editing.

## What's new
- **`@rtorcato/js-tooling/docusaurus`** — `getTypedocPlugins(modules, opts)` builds one `docusaurus-plugin-typedoc` instance per subpath module (generated from `src/<mod>/index.ts`). Replaces the identical hand-rolled `typedocPlugins` maps in cf-common and api-common.
- **`.github/workflows/docs-deploy.yml`** — reusable (`workflow_call`) Docusaurus → GitHub Pages deploy, parameterised by `build-filter`. Repos call it via `uses: rtorcato/js-tooling/.github/workflows/docs-deploy.yml@main`.
- **`docs.yml`** now calls that reusable workflow and triggers on `release: published` + `src/**`/`package.json`/`README.md` — fixing the gap where shipping code never redeployed the site.
- **Docs guide** "Docs site that stays in sync" documents the setup; CONTRIBUTING links to it.

## Follow-up (separate, gated)
Wiring cf-common + api-common to consume the helper + reusable workflow waits until this publishes and ages past the `minimumReleaseAge` gate.

Verified: helper output matches the existing hand-rolled config; js-tooling docs build + biome check pass; both workflow files parse.