### PR TITLE
feat(knip): match knip.json entry globs to the build model

### DIFF
--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -447,7 +447,7 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'knip',
-		description: 'Scaffold knip.json with default entry/project globs',
+		description: 'Scaffold knip.json (entry globs matched to the package.json build model)',
 		appliesTo: ['knip'],
 		outputs: ['knip.json'],
 		canFixDrift: true,

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -111,6 +111,9 @@ jobs:
 
       - name: 🔍 Run linting
         run: ${config.linting.tool === 'biome' || config.linting.tool === 'both' ? 'pnpm check' : 'pnpm lint'}
+
+      - name: 🧹 Check for unused files, exports, and dependencies
+        run: pnpm knip
 ${
 	hasTypeScript
 		? `

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -21,12 +21,6 @@ indent_size = 2
 
 const NVMRC_CONTENT = '22\n'
 
-const KNIP_CONFIG = {
-	$schema: 'https://unpkg.com/knip@5/schema.json',
-	entry: ['src/index.ts'],
-	project: ['src/**/*.ts'],
-}
-
 const SIZE_LIMIT_CONFIG = [
 	{
 		name: 'package (default entry)',
@@ -77,8 +71,39 @@ export async function ensureEnginesNode(
 	return 'added'
 }
 
+/**
+ * Build a knip config whose `entry` matches the project's build model, read
+ * from package.json `exports`:
+ *   - >1 public subpath export  → per-file/multi-entry lib (e.g. react-common,
+ *     whose build makes every src module its own entry). Every file is a public
+ *     entry, so `entry` covers all of src — flagging none as "unused files"
+ *     while still catching unused exports and dependencies.
+ *   - single root barrel / no exports → narrow `src/index` entry so knip can
+ *     trace and flag genuinely unreachable modules.
+ * `.tsx` is included so React libraries aren't silently skipped.
+ */
+export async function buildKnipConfig(targetDir: string) {
+	const pkgPath = path.join(targetDir, 'package.json')
+	let multiEntry = false
+	if (await fs.pathExists(pkgPath)) {
+		const pkg = (await fs.readJson(pkgPath)) as { exports?: unknown }
+		if (pkg.exports && typeof pkg.exports === 'object') {
+			const subpaths = Object.keys(pkg.exports).filter(
+				(k) => k.startsWith('.') && k !== './package.json'
+			)
+			multiEntry = subpaths.length > 1
+		}
+	}
+	return {
+		$schema: 'https://unpkg.com/knip@6/schema.json',
+		entry: multiEntry ? ['src/**/*.{ts,tsx}'] : ['src/index.{ts,tsx}'],
+		project: ['src/**/*.{ts,tsx}'],
+	}
+}
+
 export async function generateKnipConfig(targetDir: string) {
-	await fs.writeJson(path.join(targetDir, 'knip.json'), KNIP_CONFIG, { spaces: 2 })
+	const config = await buildKnipConfig(targetDir)
+	await fs.writeJson(path.join(targetDir, 'knip.json'), config, { spaces: 2 })
 }
 
 export async function generateSizeLimitConfig(targetDir: string) {

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -120,6 +120,9 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 		scripts['preview'] = 'vite preview'
 	}
 
+	// knip is part of the universal baseline (knip.json is always generated).
+	scripts['knip'] = 'knip'
+
 	// Git hooks
 	if (config.gitHooks) {
 		scripts['prepare'] = 'husky'
@@ -191,7 +194,8 @@ export function composeVerifyScriptFromPkg(
 }
 
 function getDependencies(config: ProjectConfig): Record<string, string> {
-	const deps: Record<string, string> = {}
+	// knip is part of the universal baseline (knip.json + `knip` script).
+	const deps: Record<string, string> = { knip: '^6.0.0' }
 
 	// TypeScript
 	if (config.typescript.enabled) {

--- a/tests/cli/generators/misc.test.ts
+++ b/tests/cli/generators/misc.test.ts
@@ -75,12 +75,40 @@ describe('ensureEnginesNode', () => {
 })
 
 describe('generateKnipConfig', () => {
-	it('writes knip.json with default entry and project', async () => {
+	it('writes a narrow src/index entry when no package.json exists', async () => {
 		const dir = newTmpDir()
 		await generateKnipConfig(dir)
 		const knip = await fs.readJson(join(dir, 'knip.json'))
-		expect(knip.entry).toEqual(['src/index.ts'])
-		expect(knip.project).toEqual(['src/**/*.ts'])
+		expect(knip.entry).toEqual(['src/index.{ts,tsx}'])
+		expect(knip.project).toEqual(['src/**/*.{ts,tsx}'])
+		expect(knip.$schema).toBe('https://unpkg.com/knip@6/schema.json')
+	})
+
+	it('keeps the narrow entry for a single-barrel library', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			exports: { '.': './dist/index.js' },
+		})
+		await generateKnipConfig(dir)
+		const knip = await fs.readJson(join(dir, 'knip.json'))
+		expect(knip.entry).toEqual(['src/index.{ts,tsx}'])
+	})
+
+	it('uses an all-of-src entry for per-file-entry libraries (>1 subpath export)', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			exports: {
+				'.': './dist/index.js',
+				'./hooks': './dist/hooks/index.js',
+				'./providers': './dist/providers/index.js',
+			},
+		})
+		await generateKnipConfig(dir)
+		const knip = await fs.readJson(join(dir, 'knip.json'))
+		expect(knip.entry).toEqual(['src/**/*.{ts,tsx}'])
+		expect(knip.project).toEqual(['src/**/*.{ts,tsx}'])
 	})
 })
 


### PR DESCRIPTION
## What

Finishes the knip preset (issue #145) — the scaffolding (catalog entry, doctor check, fixer) already existed; this fixes the entry-glob logic and adds the missing pieces the issue called for.

## Why

`knip.json`'s default `entry: ['src/index.ts']` mis-flags every module as unused for per-file-entry libraries (e.g. react-common, where `build.mjs` makes every `src/{lib,hooks,...}` file its own build entry rather than a single root barrel). Filed against a real hand-rolled `knip.json` I wrote for that repo (see issue comment).

## How

- `generateKnipConfig` now auto-detects the build model from `package.json` `exports`: >1 public subpath export → per-file-entry lib → `entry` covers all of `src` (no file is falsely flagged as unused, but unused exports/deps are still caught). Single root export / no exports → narrow `src/index` entry so knip can trace unreachable modules.
- Include `.tsx` in entry/project globs (was `.ts`-only, silently skipped React libs).
- Bump schema `knip@5` → `knip@6`.
- Add the `knip` script + `knip` devDependency to the generated package.json (`knip.json` was always scaffolded but nothing ran it).
- Wire a `pnpm knip` step into the generated CI `lint` job (piggybacks on the existing job instead of a new one).

Closes #145

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run` (misc.test.ts covers barrel vs multi-entry detection)
- [x] `pnpm check`