### PR TITLE
fix(doctor,fix): validate husky/lint-staged wiring, not just config presence

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -294,6 +294,18 @@ async function checkHusky(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	}
 }
 
+/**
+ * True when a shell hook has an uncommented line matching `pattern`. A
+ * commented-out line (e.g. `# pnpm verify`) doesn't count — the command never
+ * runs, so it isn't real wiring.
+ */
+function hookHasUncommented(contents: string, pattern: RegExp): boolean {
+	return contents.split('\n').some((line) => {
+		const trimmed = line.trim()
+		return trimmed.length > 0 && !trimmed.startsWith('#') && pattern.test(trimmed)
+	})
+}
+
 async function checkHuskyPrePush(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const huskyDir = await fs.pathExists(path.join(dir, '.husky'))
 	if (!huskyDir) {
@@ -315,7 +327,7 @@ async function checkHuskyPrePush(dir: string, pkg: Pkg | null): Promise<CheckRes
 		}
 	}
 	const contents = await fs.readFile(hookPath, 'utf-8')
-	if (/\bpnpm\s+verify\b/.test(contents)) {
+	if (hookHasUncommented(contents, /\bpnpm\s+verify\b/)) {
 		return {
 			check: 'Husky pre-push',
 			status: 'ok',
@@ -405,6 +417,23 @@ const LINT_STAGED_FILES = [
 	'lint-staged.config.mjs',
 ]
 
+/**
+ * True when any .husky hook has an uncommented line that invokes lint-staged.
+ * A commented-out `# npx lint-staged` line (react-common's repro) does not
+ * count — lint-staged never actually runs.
+ */
+async function huskyHookCallsLintStaged(dir: string): Promise<boolean> {
+	const huskyDir = path.join(dir, '.husky')
+	if (!(await fs.pathExists(huskyDir))) return false
+	for (const name of await fs.readdir(huskyDir)) {
+		const hookPath = path.join(huskyDir, name)
+		if (!(await fs.stat(hookPath)).isFile()) continue
+		const contents = await fs.readFile(hookPath, 'utf-8')
+		if (hookHasUncommented(contents, /\blint-staged\b/)) return true
+	}
+	return false
+}
+
 async function checkLintStaged(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const inPkg = pkg ? 'lint-staged' in pkg : false
 	let inFile: string | null = null
@@ -416,10 +445,23 @@ async function checkLintStaged(dir: string, pkg: Pkg | null): Promise<CheckResul
 	}
 
 	if (inPkg || inFile) {
+		const where = inPkg ? '`lint-staged` field in package.json' : `${inFile} found`
+		// Config presence isn't enough — verify a husky hook actually runs it.
+		// Only assert wiring when husky is in use; a non-husky setup may invoke
+		// lint-staged another way and shouldn't be flagged.
+		const huskyInUse = await fs.pathExists(path.join(dir, '.husky'))
+		if (huskyInUse && !(await huskyHookCallsLintStaged(dir))) {
+			return {
+				check: 'lint-staged',
+				status: 'drift',
+				detail: `${where} but no husky hook runs it`,
+				hint: 'Run `npx @rtorcato/js-tooling fix husky` to wire lint-staged into the pre-commit hook',
+			}
+		}
 		return {
 			check: 'lint-staged',
 			status: 'ok',
-			detail: inPkg ? '`lint-staged` field in package.json' : `${inFile} found`,
+			detail: where,
 		}
 	}
 	return {

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -1060,8 +1060,14 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			console.log()
 			process.exit(1)
 		}
+		// A fixer can cover several checks (e.g. husky covers Husky + lint-staged +
+		// Husky pre-push). Pick the first that still needs work rather than the
+		// first that merely matches — otherwise an `ok` check (Husky wired) masks a
+		// sibling drift (pre-push not calling verify) and the fixer no-ops.
+		const applicable = results.filter((r) => fixer.appliesTo.includes(r.check))
 		const result =
-			results.find((r) => fixer.appliesTo.includes(r.check)) ??
+			applicable.find((r) => r.status !== 'ok') ??
+			applicable[0] ??
 			({ check: fixer.appliesTo[0] ?? fixer.target, status: 'missing', detail: '' } as CheckResult)
 		// A check that's `ok` because the lockfile records an opt-out should still be
 		// fixable when the user explicitly targets it — treat it as optional-missing

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -198,6 +198,34 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'lint-staged')?.status).toBe('ok')
 	})
 
+	it('reports lint-staged ok when a husky hook actually calls it', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			'lint-staged': { '*.ts': 'biome check' },
+		})
+		await fs.ensureDir(join(dir, '.husky'))
+		await fs.writeFile(join(dir, '.husky', 'pre-commit'), 'npx lint-staged\n')
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'lint-staged')?.status).toBe('ok')
+	})
+
+	it('reports lint-staged drift when configured but the husky hook only comments it out', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			'lint-staged': { '*.ts': 'biome check' },
+		})
+		await fs.ensureDir(join(dir, '.husky'))
+		await fs.writeFile(join(dir, '.husky', 'pre-commit'), '# npx lint-staged\npnpm check\n')
+		const results = await runDoctor(dir)
+		const ls = results.find((r) => r.check === 'lint-staged')
+		expect(ls?.status).toBe('drift')
+		expect(ls?.hint).toMatch(/fix husky/)
+	})
+
 	it('detects knip config field', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
@@ -332,6 +360,20 @@ describe('doctor extended checks', () => {
 		const prePush = results.find((r) => r.check === 'Husky pre-push')
 		expect(prePush?.status).toBe('drift')
 		expect(prePush?.hint).toMatch(/fix husky/)
+	})
+
+	it('reports Husky pre-push drift when the verify call is commented out', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
+			scripts: { verify: 'pnpm typecheck && pnpm check' },
+		})
+		await fs.ensureDir(join(dir, '.husky'))
+		await fs.writeFile(join(dir, '.husky', 'pre-push'), '#!/usr/bin/env sh\n# pnpm verify\n')
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Husky pre-push')?.status).toBe('drift')
 	})
 
 	it('reports Husky pre-push optional-missing when husky is present but the hook is absent', async () => {

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -388,6 +388,27 @@ describe('fix targeted', () => {
 		expect(prePush).toContain('pnpm verify')
 	})
 
+	it('fix husky --yes repairs a commented-out pre-push even when Husky itself is ok', async () => {
+		const dir = newTmpDir()
+		// Husky wired (prepare script + .husky dir + pre-commit) → Husky check is
+		// `ok`, but pre-push is commented out → pre-push check is drift. The fixer
+		// must act on the drift, not report "already configured".
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			scripts: { prepare: 'husky', verify: 'pnpm typecheck && pnpm check' },
+			'lint-staged': { '*.ts': 'biome check' },
+			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
+		})
+		await fs.ensureDir(join(dir, '.husky'))
+		await fs.writeFile(join(dir, '.husky', 'pre-commit'), 'npx lint-staged\n')
+		await fs.writeFile(join(dir, '.husky', 'pre-push'), '# pnpm verify\n')
+		await fixCommand('husky', { directory: dir, yes: true })
+		const prePush = await fs.readFile(join(dir, '.husky', 'pre-push'), 'utf-8')
+		expect(prePush).toContain('pnpm verify')
+		expect(prePush).not.toMatch(/^#\s*pnpm verify/m)
+	})
+
 	it('fix treeshake-check --yes scaffolds apps/treeshake-check from pkg.exports', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {


### PR DESCRIPTION
## What

Fixes two doctor/fix wiring bugs in the husky + lint-staged area (issues #149, #150).

## Why

Both are the same class of bug: doctor/fix validated config-key *presence*, not whether the config is actually *wired* — and one check was blind to commented-out hook lines. Filed against real repro in `rtorcato/react-common`, where both `npx lint-staged` lines and the `pnpm verify` line were commented out in `.husky/` hooks in favor of inline commands.

## How

- `checkLintStaged` (#149): now verifies a husky hook has an uncommented line invoking `lint-staged` when husky is in use — was `ok` on config-key presence alone, so `knip` correctly flagged the devDependency as unused while doctor said everything was fine.
- `checkHuskyPrePush`: was itself comment-blind — `# pnpm verify` matched its regex and counted as wired. Both checks now share a `hookHasUncommented()` helper that skips commented-out lines.
- `fix husky` (#150): target resolution picked the *first* matching check (`results.find`) rather than the first one needing work. Husky itself being `ok` (prepare script + `.husky/` present) masked the sibling `Husky pre-push` drift, so `fix husky` printed "already configured" and changed nothing — even though the fixer itself does correctly repair pre-push when it actually runs. Now prefers the first non-`ok` applicable check.

Closes #149
Closes #150

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run` — new coverage: lint-staged wired vs commented-out, pre-push commented-out drift, and an integration test asserting `fix husky` repairs a commented pre-push while Husky itself is `ok`
- [x] `pnpm check`