### PR TITLE
chore(generator): sync scaffolded tool versions to dogfooded floors

### DIFF
--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -196,12 +196,12 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 	// TypeScript
 	if (config.typescript.enabled) {
 		deps['typescript'] = '^5.9.3'
-		deps['@types/node'] = '^24.0.0'
+		deps['@types/node'] = '^26.0.1'
 	}
 
 	// Linting tools
 	if (config.linting.tool === 'biome' || config.linting.tool === 'both') {
-		deps['@biomejs/biome'] = '^2.3.0'
+		deps['@biomejs/biome'] = '^2.5.1'
 	}
 	if (config.linting.tool === 'eslint' || config.linting.tool === 'both') {
 		deps['eslint'] = '^9.0.0'
@@ -210,9 +210,9 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 
 	// Testing frameworks
 	if (config.testing.framework === 'vitest') {
-		deps['vitest'] = '^4.0.0'
+		deps['vitest'] = '^4.1.9'
 		if (config.testing.environment === 'browser' || config.testing.environment === 'both') {
-			deps['@vitest/ui'] = '^4.0.0'
+			deps['@vitest/ui'] = '^4.1.9'
 			deps['jsdom'] = '^25.0.0'
 		}
 	} else if (config.testing.framework === 'jest') {
@@ -221,7 +221,7 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 			deps['ts-jest'] = '^29.0.0'
 		}
 	} else if (config.testing.framework === 'playwright') {
-		deps['@playwright/test'] = '^1.56.0'
+		deps['@playwright/test'] = '^1.60.0'
 	}
 
 	// Build tools


### PR DESCRIPTION
## What

Bumps stale dependency version floors in the package-json generator to match what js-tooling itself declares (issue #76).

## Why

`getDependencies()` scaffolded fresh projects with version floors several minors/majors behind what this repo dogfoods. Caret ranges meant the old floors still resolved to current majors, so nothing was broken — but new projects started on stale minimums and drifted from the published preset. The issue's own guidance: keep scaffolded versions in lockstep with the preset.

## How

Synced each to the repo's own declared floor (single source of truth):

| dep | before | after |
|---|---|---|
| `@types/node` | `^24.0.0` | `^26.0.1` |
| `@biomejs/biome` | `^2.3.0` | `^2.5.1` |
| `vitest` | `^4.0.0` | `^4.1.9` |
| `@vitest/ui` | `^4.0.0` | `^4.1.9` |
| `@playwright/test` | `^1.56.0` | `^1.60.0` |

Left untouched: deps this repo doesn't dogfood (jest, ts-jest, eslint, prettier, tsup, esbuild, vite, husky, lint-staged, commitlint, semantic-release, jsdom) — bumping those without a registry-verified source of truth would be guessing.

`#73` (Biome schema `1.9.4`) was already resolved — `linting.ts` scaffolds schema `2.5.0` and no `1.x` refs remain; closed separately.

Closes #76

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run tests/cli/generators/package-json.test.ts`