### PR TITLE
feat(doctor,fix): Node version consistency check + node-version fix target

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -263,6 +263,105 @@ async function checkNodeVersionPin(dir: string): Promise<CheckResult> {
 	}
 }
 
+interface NodeSignal {
+	source: string
+	major: number
+}
+
+/** First integer in an `engines.node` range (the floor major), or null. */
+function enginesFloorMajor(pkg: Pkg | null): number | null {
+	const engines = (pkg?.engines as Record<string, string> | undefined) ?? {}
+	const raw = engines.node
+	if (!raw) return null
+	const m = raw.match(/\d+/)
+	return m ? Number.parseInt(m[0], 10) : null
+}
+
+async function nvmrcMajor(dir: string): Promise<{ file: string; major: number } | null> {
+	for (const candidate of ['.nvmrc', '.node-version']) {
+		const p = path.join(dir, candidate)
+		if (await fs.pathExists(p)) {
+			const m = (await fs.readFile(p, 'utf-8')).trim().match(/\d+/)
+			if (m) return { file: candidate, major: Number.parseInt(m[0], 10) }
+		}
+	}
+	return null
+}
+
+// Matches a hardcoded scalar `node-version: <major>` — a leading digit (after
+// an optional quote) is required. This skips matrix arrays (`[22, 24]`),
+// `${{ matrix.node-version }}` expressions, bare `node-version:` input keys, and
+// `node-version-file:` (a different key entirely) — those aren't drift signals.
+const HARDCODED_NODE_VERSION = /node-version:\s*['"]?(\d+)/g
+
+async function workflowNodeMajors(dir: string): Promise<NodeSignal[]> {
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (!(await fs.pathExists(workflowsDir))) return []
+	let files: string[]
+	try {
+		files = (await fs.readdir(workflowsDir)).filter(
+			(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+		)
+	} catch {
+		return []
+	}
+	const signals: NodeSignal[] = []
+	for (const file of files) {
+		const contents = await fs.readFile(path.join(workflowsDir, file), 'utf-8')
+		const seen = new Set<number>()
+		for (const match of contents.matchAll(HARDCODED_NODE_VERSION)) {
+			const major = Number.parseInt(match[1] ?? '', 10)
+			if (!Number.isNaN(major) && !seen.has(major)) {
+				seen.add(major)
+				signals.push({ source: `.github/workflows/${file}`, major })
+			}
+		}
+	}
+	return signals
+}
+
+// Root-cause check for the #94 class: a workflow hardcoding a Node major that
+// disagrees with .nvmrc / engines.node (e.g. ci.yml pinned Node 20 while
+// .nvmrc said 22 → node:sqlite crash under pnpm). Only flags genuine
+// disagreement; a matrix that tests several majors uses arrays/expressions and
+// is not counted.
+async function checkNodeVersionConsistency(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const signals: NodeSignal[] = []
+	const nvmrc = await nvmrcMajor(dir)
+	if (nvmrc) signals.push({ source: nvmrc.file, major: nvmrc.major })
+	const eng = enginesFloorMajor(pkg)
+	if (eng !== null) signals.push({ source: 'engines.node', major: eng })
+	signals.push(...(await workflowNodeMajors(dir)))
+
+	if (signals.length < 2) {
+		return {
+			check: 'Node version consistency',
+			status: 'ok',
+			detail:
+				signals.length === 0
+					? 'no Node version pins to cross-check'
+					: `single Node version source (${signals[0]?.source} → ${signals[0]?.major})`,
+		}
+	}
+
+	const distinct = [...new Set(signals.map((s) => s.major))]
+	if (distinct.length === 1) {
+		return {
+			check: 'Node version consistency',
+			status: 'ok',
+			detail: `Node ${distinct[0]} agrees across ${signals.length} sources`,
+		}
+	}
+
+	const summary = signals.map((s) => `${s.source}→${s.major}`).join(', ')
+	return {
+		check: 'Node version consistency',
+		status: 'drift',
+		detail: `Node major disagreement: ${summary}`,
+		hint: 'Run `npx @rtorcato/js-tooling fix node-version` to point workflows at `node-version-file: .nvmrc` (one source of truth)',
+	}
+}
+
 async function checkHusky(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const huskyDir = await fs.pathExists(path.join(dir, '.husky'))
 	const scripts = (pkg?.scripts as Record<string, string> | undefined) ?? {}
@@ -980,6 +1079,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(checkEnginesNode(pkg))
 	results.push(await checkEditorConfig(targetDir))
 	results.push(await checkNodeVersionPin(targetDir))
+	results.push(await checkNodeVersionConsistency(targetDir, pkg))
 	for (const spec of FILE_CHECKS) {
 		results.push(await checkFile(targetDir, spec))
 	}

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -6,6 +6,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'engines.node': 'engines',
 	EditorConfig: 'editorconfig',
 	'Node version pin': 'nvmrc',
+	'Node version consistency': 'node-version',
 	TypeScript: 'tsconfig',
 	Biome: 'biome',
 	ESLint: 'eslint',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -19,6 +19,7 @@ import {
 	ensureEnginesNode,
 	generateCodeowners,
 	generateEditorConfig,
+	alignNodeVersion,
 	generateKnipConfig,
 	generateNvmrc,
 	generateSizeLimitConfig,
@@ -431,6 +432,18 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			await generateNvmrc(targetDir)
 			return { filesWritten: ['.nvmrc'] }
+		},
+	},
+	{
+		target: 'node-version',
+		description: 'Point CI workflows at `node-version-file: .nvmrc` (one Node source of truth)',
+		appliesTo: ['Node version consistency'],
+		outputs: ['.nvmrc', '.github/workflows/*.yml (node-version-file)'],
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const filesWritten = await alignNodeVersion(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -52,6 +52,68 @@ export async function generateNvmrc(targetDir: string) {
 	await fs.writeFile(path.join(targetDir, '.nvmrc'), NVMRC_CONTENT)
 }
 
+const DEFAULT_NODE_MAJOR = 22
+
+/**
+ * Resolve the authoritative Node major: an existing .nvmrc/.node-version wins,
+ * else the `engines.node` floor, else the default. Used to seed .nvmrc when a
+ * repo has no pin yet before pointing workflows at it.
+ */
+async function resolveNodeMajor(targetDir: string): Promise<number> {
+	for (const candidate of ['.nvmrc', '.node-version']) {
+		const p = path.join(targetDir, candidate)
+		if (await fs.pathExists(p)) {
+			const m = (await fs.readFile(p, 'utf-8')).trim().match(/\d+/)
+			if (m) return Number.parseInt(m[0], 10)
+		}
+	}
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (await fs.pathExists(pkgPath)) {
+		const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+		const node = (pkg.engines as Record<string, string> | undefined)?.node
+		const m = node?.match(/\d+/)
+		if (m) return Number.parseInt(m[0], 10)
+	}
+	return DEFAULT_NODE_MAJOR
+}
+
+// A hardcoded scalar `node-version: <major>` line (leading digit after an
+// optional quote). Deliberately does NOT match matrix arrays (`[22, 24]`),
+// `${{ }}` expressions, or bare `node-version:` input keys — those are left as-is.
+const NODE_VERSION_LINE = /^([ \t]*)node-version:[ \t]*['"]?\d[\w.-]*['"]?[ \t]*$/gm
+
+/**
+ * Make .nvmrc the single Node source of truth: ensure it exists (pinned to the
+ * resolved major) and rewrite hardcoded scalar `node-version:` lines in CI
+ * workflows to `node-version-file: .nvmrc`. Returns the files changed.
+ */
+export async function alignNodeVersion(targetDir: string): Promise<string[]> {
+	const written: string[] = []
+	const nvmrcPath = path.join(targetDir, '.nvmrc')
+	if (!(await fs.pathExists(nvmrcPath))) {
+		const major = await resolveNodeMajor(targetDir)
+		await fs.writeFile(nvmrcPath, `${major}\n`)
+		written.push('.nvmrc')
+	}
+
+	const workflowsDir = path.join(targetDir, '.github', 'workflows')
+	if (await fs.pathExists(workflowsDir)) {
+		const files = (await fs.readdir(workflowsDir)).filter(
+			(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+		)
+		for (const file of files) {
+			const p = path.join(workflowsDir, file)
+			const contents = await fs.readFile(p, 'utf-8')
+			const next = contents.replace(NODE_VERSION_LINE, '$1node-version-file: .nvmrc')
+			if (next !== contents) {
+				await fs.writeFile(p, next)
+				written.push(`.github/workflows/${file}`)
+			}
+		}
+	}
+	return written
+}
+
 export type EnsureEnginesResult = 'added' | 'already-set' | 'no-package-json'
 
 export async function ensureEnginesNode(

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -166,6 +166,56 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'Node version pin')?.status).toBe('ok')
 	})
 
+	it('Node version consistency: ok when .nvmrc, engines, and workflow all agree', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			engines: { node: '>=22' },
+		})
+		await fs.writeFile(join(dir, '.nvmrc'), '22\n')
+		await fs.outputFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v6\n        with:\n          node-version: "22"\n'
+		)
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Node version consistency')?.status).toBe('ok')
+	})
+
+	it('Node version consistency: drift when a workflow hardcodes a different major', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			engines: { node: '>=22' },
+		})
+		await fs.writeFile(join(dir, '.nvmrc'), '22\n')
+		await fs.outputFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v6\n        with:\n          node-version: 20\n'
+		)
+		const results = await runDoctor(dir)
+		const c = results.find((r) => r.check === 'Node version consistency')
+		expect(c?.status).toBe('drift')
+		expect(c?.hint).toMatch(/fix node-version/)
+	})
+
+	it('Node version consistency: a matrix array is not flagged as drift', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			engines: { node: '>=22' },
+		})
+		await fs.writeFile(join(dir, '.nvmrc'), '22\n')
+		await fs.outputFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  test:\n    strategy:\n      matrix:\n        node-version: ["22", "24"]\n    steps:\n      - uses: actions/setup-node@v6\n        with:\n          node-version: ${{ matrix.node-version }}\n'
+		)
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Node version consistency')?.status).toBe('ok')
+	})
+
 	it('reports husky drift when .husky/ exists without prepare script', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -170,6 +170,40 @@ describe('fix targeted', () => {
 		expect(content.trim()).toBe('22')
 	})
 
+	it('fix node-version --yes rewrites hardcoded workflow versions to node-version-file', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { engines: { node: '>=22' } })
+		await fs.writeFile(join(dir, '.nvmrc'), '22\n')
+		await fs.outputFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			[
+				'jobs:',
+				'  build:',
+				'    steps:',
+				'      - uses: actions/setup-node@v6',
+				'        with:',
+				'          node-version: 20',
+				'  test:',
+				'    strategy:',
+				'      matrix:',
+				'        node-version: ["22", "24"]',
+				'    steps:',
+				'      - uses: actions/setup-node@v6',
+				'        with:',
+				'          node-version: ${{ matrix.node-version }}',
+				'',
+			].join('\n')
+		)
+		await fixCommand('node-version', { directory: dir, yes: true })
+		const yaml = await fs.readFile(join(dir, '.github', 'workflows', 'ci.yml'), 'utf-8')
+		// Hardcoded scalar rewritten...
+		expect(yaml).toContain('node-version-file: .nvmrc')
+		expect(yaml).not.toMatch(/node-version:\s*20\b/)
+		// ...but the matrix array and the ${{ }} expression are left untouched.
+		expect(yaml).toContain('node-version: ["22", "24"]')
+		expect(yaml).toContain('node-version: ${{ matrix.node-version }}')
+	})
+
 	it('fix engines adds engines.node when missing', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)


### PR DESCRIPTION
## What

Adds a doctor check + `fix` target that catch the whole class of Node-version drift between `.nvmrc`, `engines.node`, and CI workflows (issue #143).

## Why

#94 was the symptom: a generated `ci.yml` hardcoded Node 20 while `.nvmrc`/`engines` said 22, causing a `node:sqlite` crash under pnpm 11. That specific generator bug is fixed, but nothing caught the *drift* — so any repo that hand-edits a workflow can silently reintroduce it.

## How

**doctor — new `Node version consistency` check:**
- Reads the Node major from `.nvmrc`/`.node-version`, the `engines.node` floor, and every hardcoded scalar `node-version:` in `.github/workflows/*.yml`.
- `drift` when the majors disagree (with a `fix node-version` hint); `ok` when they agree or there's <2 sources.
- **Matrix arrays (`node-version: [22, 24]`), `${{ }}` expressions, and bare input keys are deliberately not counted** — a matrix that tests several majors is legitimate, not drift. This is why the parser only matches a leading-digit scalar. Verified against this repo's own `ci.yml` (scalar `"22"` + `[22, 24]` matrix + `${{ matrix.node-version }}`) → reports `ok`, no self-flag.

**fix — new `node-version` target:**
- Rewrites hardcoded scalar `node-version:` lines to `node-version-file: .nvmrc` (single source of truth), seeding `.nvmrc` from the resolved major (existing `.nvmrc` → `engines` floor → 22) when absent.
- Leaves matrix/expression forms untouched.

Closes #143

## Test plan
- [x] `pnpm typecheck`, `pnpm check`
- [x] `pnpm exec vitest run` (+ new cases: agreement→ok, disagreement→drift, matrix-not-flagged, fixer rewrites scalar but preserves matrix/expression)