### PR TITLE
fix(tsconfig): pin tsBuildInfoFile in the v1 base preset (TS5074)

### DIFF
--- a/tooling/typescript/v1/tsconfig.base.json
+++ b/tooling/typescript/v1/tsconfig.base.json
@@ -27,6 +27,10 @@
     // 📈 Performance
     "skipLibCheck": true, // Skip type checking of declaration files
     "incremental": true, // Enable incremental compilation
+    // Pin the build-info location so downstream emit tools (e.g. tsup's `dts`
+    // build) don't hit TS5074 from inheriting `incremental` without a file.
+    // ${configDir} resolves to the consuming project's dir (TS 5.5+).
+    "tsBuildInfoFile": "${configDir}/node_modules/.cache/tsconfig.tsbuildinfo",
     "disableSourceOfProjectReferenceRedirect": true, // Disable source of project reference redirect
 
     // 🚨 Strict Type Checking


### PR DESCRIPTION
## What

Applies the TS5074 fix to the legacy `@1` TypeScript presets (issue #98).

## Why

#98 reported that `@rtorcato/js-tooling/typescript/base` + tsup `dts: true` failed with:

```
error TS5074: Option '--incremental' can only be specified using tsconfig, emitting to single file or when option '--tsBuildInfoFile' is specified.
```

The **current** base preset was already fixed — it pairs `incremental` with a `tsBuildInfoFile`. But the **pinned legacy base** (`tooling/typescript/v1/tsconfig.base.json`, shipped as `typescript/base@1` and extended by every `@1` variant — `next@1`, `node@1`, `react@1`, `express@1`, `test@1`) still set `incremental: true` with no build-info file. Anyone on those presets kept hitting TS5074, so the issue wasn't fully closed.

## How

Mirror the current base's fix exactly:

```jsonc
"tsBuildInfoFile": "${configDir}/node_modules/.cache/tsconfig.tsbuildinfo",
```

`${configDir}` resolves to the consuming project's dir (TS 5.5+, which the current base already requires), giving `incremental` a resolvable file so tsup's `dts` build no longer errors. One fix on the v1 base propagates to all `@1` variants (they all `extends ./tsconfig.base.json`).

Also closes the related #97 (lint-staged `git add` + `--no-errors-on-unmatched`) — verified already fixed in `git.ts` and closed separately.

Closes #98

## Test plan
- [x] `pnpm exec tsc -p tooling/typescript/v1/tsconfig.base.json --showConfig` parses cleanly (JSONC valid, `${configDir}`/`tsBuildInfoFile` accepted)
- [x] `pnpm check`
- [x] Fix is byte-identical to the already-shipped, CI-green fix on the current base