### PR TITLE
fix(husky): scaffold v10 hook format, drop deprecated v9 bootstrap

### DIFF
--- a/src/cli/generators/git.ts
+++ b/src/cli/generators/git.ts
@@ -29,13 +29,11 @@ export async function generateHuskyConfig(config: ProjectConfig, targetDir: stri
 	const huskyDir = path.join(targetDir, '.husky')
 	await fs.ensureDir(huskyDir)
 
-	// Pre-commit hook
+	// Pre-commit hook. husky v10 format: just the command — the v9 shebang +
+	// `. "$(dirname ...)/_/husky.sh"` bootstrap is deprecated (warns on every
+	// hook run in v9, fails outright in v10).
 	const preCommitPath = path.join(huskyDir, 'pre-commit')
-	const preCommitContent = `#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged
-`
+	const preCommitContent = 'npx lint-staged\n'
 	await fs.writeFile(preCommitPath, preCommitContent)
 	await fs.chmod(preCommitPath, 0o755)
 
@@ -52,14 +50,11 @@ npx lint-staged
 		}
 	}
 
-	// Commit-msg hook (if commitlint is enabled)
+	// Commit-msg hook (if commitlint is enabled). husky v10 format — no v9
+	// bootstrap. $1 is still the commit-message file path git passes through.
 	if (config.commitLint) {
 		const commitMsgPath = path.join(huskyDir, 'commit-msg')
-		const commitMsgContent = `#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx --no -- commitlint --edit $1
-`
+		const commitMsgContent = 'npx --no -- commitlint --edit $1\n'
 		await fs.writeFile(commitMsgPath, commitMsgContent)
 		await fs.chmod(commitMsgPath, 0o755)
 	}

--- a/tests/cli/generators/git.test.ts
+++ b/tests/cli/generators/git.test.ts
@@ -36,9 +36,14 @@ describe('generateGitConfigs', () => {
 
 		const preCommit = await fs.readFile(join(dir, '.husky', 'pre-commit'), 'utf-8')
 		expect(preCommit).toContain('lint-staged')
+		// husky v10 format: no deprecated v9 bootstrap (shebang + husky.sh source)
+		// which warns in v9 and fails in v10.
+		expect(preCommit).not.toContain('husky.sh')
+		expect(preCommit).not.toContain('#!/usr/bin/env sh')
 
 		const commitMsg = await fs.readFile(join(dir, '.husky', 'commit-msg'), 'utf-8')
 		expect(commitMsg).toContain('commitlint --edit')
+		expect(commitMsg).not.toContain('husky.sh')
 
 		const pkg = await fs.readJson(join(dir, 'package.json'))
 		const lintStaged = pkg['lint-staged']


### PR DESCRIPTION
## What

Generated husky hooks now use the v10 format (just the command) instead of the deprecated v9 bootstrap (issue #135).

## Why

`generateHuskyConfig` wrote `.husky/pre-commit` and `.husky/commit-msg` starting with:

```sh
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"
```

husky v9 prints a `DEPRECATED` warning on **every** hook invocation (commit, push), and these lines **fail outright in husky v10**. Every `@rtorcato/*` repo scaffolded with `gitHooks: true` was affected (symptom fixed manually in db-common#16; this is the root cause so it doesn't regress on re-scaffold).

## How

Hook files now contain only the command:
- `.husky/pre-commit` → `npx lint-staged`
- `.husky/commit-msg` → `npx --no -- commitlint --edit $1` (`$1` is still the message-file path git passes through)

The pre-push hook was already bootstrap-free. Since `fix husky` regenerates these files wholesale, re-running it on an existing repo upgrades stale v9 hooks to v10 — the remediation path for the rest of the family.

Closes #135

## Test plan
- [x] `pnpm typecheck`, `pnpm check`
- [x] `pnpm exec vitest run` — git.test.ts now asserts hooks contain neither `husky.sh` nor the shebang; existing husky/lint-staged/fix tests still green