### PR TITLE
chore(generator): ignore .claude worktrees in gitignore + vitest preset

### DIFF
--- a/src/cli/generators/git.ts
+++ b/src/cli/generators/git.ts
@@ -119,6 +119,10 @@ out/
 *.swp
 *.swo
 
+# Claude Code (worktrees + local settings are per-machine; agents/commands are shared)
+.claude/worktrees/
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db

--- a/tests/cli/generators/git.test.ts
+++ b/tests/cli/generators/git.test.ts
@@ -131,4 +131,17 @@ describe('generateGitConfigs', () => {
 		expect(gitignore).toContain('.vite/')
 		expect(gitignore).toContain('/playwright-report/')
 	})
+
+	it('ignores Claude Code worktrees and local settings (but not shared agents/commands)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateGitConfigs(baseConfig(), dir)
+
+		const gitignore = await fs.readFile(join(dir, '.gitignore'), 'utf-8')
+		expect(gitignore).toContain('.claude/worktrees/')
+		expect(gitignore).toContain('.claude/settings.local.json')
+		// Shared config must NOT be ignored.
+		expect(gitignore).not.toContain('.claude/agents')
+		expect(gitignore).not.toMatch(/^\.claude\/$/m)
+	})
 })

--- a/tests/vitest/config-exclude.test.ts
+++ b/tests/vitest/config-exclude.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { configDefaults } from 'vitest/config'
+// @ts-expect-error — .mjs preset ships no types; we only read runtime values here.
+import config from '../../tooling/vitest/vitest.config.mjs'
+
+describe('vitest preset exclude', () => {
+	it('ignores Claude Code worktrees so mirrored test files are not collected twice', () => {
+		const exclude = config.test?.exclude ?? []
+		expect(exclude).toContain('.claude/**')
+		// still keeps vitest's built-in defaults (node_modules, dist, …).
+		for (const def of configDefaults.exclude) {
+			expect(exclude).toContain(def)
+		}
+	})
+})

--- a/tooling/vitest/vitest.config.mjs
+++ b/tooling/vitest/vitest.config.mjs
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -8,6 +8,9 @@ export default defineConfig({
 	test: {
 		globals: true,
 		environment: 'node',
+		// Keep vitest's defaults, plus ignore Claude Code worktrees so mirrored
+		// test files under .claude/worktrees/ aren't collected twice.
+		exclude: [...configDefaults.exclude, '.claude/**'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json', 'html', 'json-summary'],


### PR DESCRIPTION
## What

Propagates the `.claude/` worktree fix into the generator templates (issue #84).

## Why

Claude Code leaves worktrees under `.claude/worktrees/` that mirror the repo's test files. vitest then collects the duplicates, and `.claude/settings.local.json` churns per machine. js-tooling's own root config was patched during a CI unblock (8f4a700), but the **generator templates** weren't — so every newly-scaffolded project hits the same papercut.

## How

- **`.gitignore` template** (`src/cli/generators/git.ts`): new `# Claude Code` block ignoring `.claude/worktrees/` and `.claude/settings.local.json`. Shared config (`.claude/agents/`, `.claude/commands/`) stays tracked.
- **Shared vitest preset** (`tooling/vitest/vitest.config.mjs`): `exclude` now extends `configDefaults.exclude` with `.claude/**` (preserving vitest's built-in ignores). The react preset inherits it automatically — `mergeConfig` concatenates the `exclude` arrays.

## Test plan
- [x] `pnpm typecheck`, `pnpm check`
- [x] New tests: gitignore contains the `.claude/worktrees/` + `settings.local.json` lines (and does *not* blanket-ignore `.claude/`); vitest preset `exclude` contains `.claude/**` plus all `configDefaults.exclude`

Closes #84