### PR TITLE
feat: unified AI setup (fix ai + setup prompt: AGENTS.md, CLAUDE.md, MCP, doctor)

### DIFF
--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -1,0 +1,66 @@
+---
+title: AI Setup
+description: Scaffold AI agent rules — AGENTS.md, CLAUDE.md, Cursor, Copilot, the Claude skill, and an MCP template — from one source of truth, in one command.
+---
+
+`js-tooling` can scaffold the instruction files that AI coding tools read, so
+every agent (Claude Code, Cursor, GitHub Copilot, or anything that reads
+`AGENTS.md`) gets the same guidance for driving this project's tooling.
+
+All of it derives from **one source of truth** — the shipped Claude skill
+(`tooling/claude/js-tooling.md`) — so the rules never drift between tools.
+
+## What gets written
+
+| File | For | How it's written |
+| --- | --- | --- |
+| `AGENTS.md` | The cross-tool standard | Merge-safe delimited block |
+| `CLAUDE.md` | Claude Code | Pointer: `@AGENTS.md` (no duplication) |
+| `.cursor/rules/js-tooling.mdc` | Cursor | Generated rule file |
+| `.github/copilot-instructions.md` | GitHub Copilot | Merge-safe delimited block |
+| `.claude/skills/js-tooling.md` | Claude Code skill | Copied verbatim |
+| `.mcp.json.example` | Model Context Protocol | Commented template (see below) |
+
+Every file is either a merge-safe **delimited block** (`<!-- js-tooling:start -->`
+… `<!-- js-tooling:end -->`) or a `.example`, so re-running never clobbers your
+own content and is fully idempotent.
+
+## Install it
+
+During scaffolding, `setup` asks:
+
+```
+🤖 Add AI agent rules (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill)?
+```
+
+Or install / repair them any time on an existing repo:
+
+```bash
+npx @rtorcato/js-tooling fix ai
+```
+
+`doctor` reports whether they're present (`AI setup` → `ok` /
+`optional-missing`), and the choice is recorded in `.js-tooling.json`, so
+`doctor` won't nag if you intentionally opt out.
+
+## CLAUDE.md is a pointer, not a copy
+
+`CLAUDE.md` contains a single `@AGENTS.md` import rather than a second copy of
+the guidance. Claude Code reads both files, and the import keeps `AGENTS.md` as
+the one place the rules live — no two files to keep in sync.
+
+## MCP: a template, not an active config
+
+`.mcp.json` (the file Claude Code actually loads) is **strict JSON** — it can't
+hold comments, and an unconfigured server entry can fail `pnpm install` or add a
+redundant server. So the feature ships a commented **`.mcp.json.example`**
+instead. It's never loaded, so it's a safe place to document servers.
+
+To activate MCP, copy it and remove the comments:
+
+```bash
+cp .mcp.json.example .mcp.json
+```
+
+Then add only the servers you actually need — most GitHub work is already
+covered by the `gh` CLI, so a GitHub MCP server is usually redundant.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'guides/cli',
         'guides/for-ai-agents',
+        'guides/ai-setup',
         'guides/library-style',
         'guides/dependabot-strategy',
         'guides/git-flow',

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"tooling/semantic-release/*.mjs",
 		"tooling/semantic-release/*.d.mts",
 		"tooling/claude/*.md",
+		"tooling/mcp/mcp.json.example",
 		"README.md"
 	],
 	"exports": {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1091,6 +1091,29 @@ async function checkCommunityHealth(dir: string): Promise<CheckResult> {
 	}
 }
 
+async function checkAiSetup(dir: string): Promise<CheckResult> {
+	// Consider AI setup present if AGENTS.md carries the js-tooling block or the
+	// Claude skill is installed — the two primary markers `fix ai` writes.
+	const agentsPath = path.join(dir, 'AGENTS.md')
+	const hasAgentsBlock =
+		(await fs.pathExists(agentsPath)) &&
+		(await fs.readFile(agentsPath, 'utf8')).includes('<!-- js-tooling:start -->')
+	const hasSkill = await fs.pathExists(path.join(dir, '.claude', 'skills', 'js-tooling.md'))
+	if (hasAgentsBlock || hasSkill) {
+		return {
+			check: 'AI setup',
+			status: 'ok',
+			detail: hasAgentsBlock ? 'AGENTS.md has the js-tooling block' : '.claude skill installed',
+		}
+	}
+	return {
+		check: 'AI setup',
+		status: 'optional-missing',
+		detail: 'no AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill)',
+		hint: 'Run `npx @rtorcato/js-tooling fix ai` to scaffold agent rules for every AI tool',
+	}
+}
+
 async function checkGitLabCI(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -1139,6 +1162,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkGitLabCI(targetDir))
 	results.push(await checkCodeowners(targetDir))
 	results.push(await checkCommunityHealth(targetDir))
+	results.push(await checkAiSetup(targetDir))
 	results.push(await checkTypedoc(targetDir, pkg))
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -30,6 +30,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'.js-tooling.json': 'lockfile',
 	'are-the-types-wrong': 'attw',
 	TypeDoc: 'typedoc',
+	'AI setup': 'ai',
 }
 
 export function getFixTargetForCheck(checkName: string): string | null {
@@ -74,6 +75,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 		case 'Dependabot':
 		case 'CodeQL':
 			return c.securityAutomation === false
+		case 'AI setup':
+			return c.aiSetup === false
 		default:
 			return false
 	}
@@ -126,6 +129,8 @@ export function lockfilePatchForTarget(
 			return c.typescript.enabled ? null : { typescript: { enabled: true, config: 'base' } }
 		case 'treeshake-check':
 			return c.treeshakeCheck ? null : { treeshakeCheck: true }
+		case 'ai':
+			return c.aiSetup ? null : { aiSetup: true }
 		default:
 			return null
 	}

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import { createPatch } from 'diff'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
-import { installAgentRules } from '../generators/agent-rules.js'
+import { installAgentRules, installAiSetup } from '../generators/agent-rules.js'
 import { generateSemanticReleaseConfig } from '../generators/build.js'
 import { generateCommunityHealth } from '../generators/community-health.js'
 import {
@@ -582,6 +582,28 @@ const FIXERS: Fixer[] = [
 
 			await fs.writeJson(pkgPath, updated, { spaces: 2 })
 			return { filesWritten: ['package.json'] }
+		},
+	},
+	{
+		target: 'ai',
+		description:
+			'Install all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example)',
+		appliesTo: ['AI setup'],
+		outputs: [
+			'AGENTS.md',
+			'CLAUDE.md',
+			'.cursor/rules/js-tooling.mdc',
+			'.github/copilot-instructions.md',
+			'.claude/skills/js-tooling.md',
+			'.mcp.json.example',
+		],
+		// Every output is a delimited-block upsert or a `.example` file — existing
+		// user content is never clobbered.
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const filesWritten = await installAiSetup(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -18,6 +18,7 @@ const BASE: Omit<ProjectConfig, 'projectName' | 'projectType' | 'typescript' | '
 	commitLint: true,
 	semanticRelease: false,
 	securityAutomation: true,
+	aiSetup: true,
 }
 
 export function buildPresetConfig(name: PresetName, projectName: string): ProjectConfig {
@@ -137,6 +138,7 @@ export const CONFIG_SCHEMA = {
 		securityAutomation: { type: 'boolean' },
 		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'vite', 'none'] },
 		treeshakeCheck: { type: 'boolean' },
+		aiSetup: { type: 'boolean' },
 	},
 } as const
 
@@ -210,6 +212,16 @@ export function computeFileList(config: ProjectConfig): string[] {
 			'apps/treeshake-check/package.json',
 			'apps/treeshake-check/check.mjs',
 			'apps/treeshake-check/src/entry.ts'
+		)
+	}
+	if (config.aiSetup) {
+		files.push(
+			'AGENTS.md',
+			'CLAUDE.md',
+			'.cursor/rules/js-tooling.mdc',
+			'.github/copilot-instructions.md',
+			'.claude/skills/js-tooling.md',
+			'.mcp.json.example'
 		)
 	}
 	files.push('README.md')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -40,6 +40,8 @@ export interface ProjectConfig {
 	securityAutomation: boolean
 	bundler: 'tsup' | 'esbuild' | 'vite' | 'none'
 	treeshakeCheck?: boolean
+	/** Scaffold AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example). */
+	aiSetup?: boolean
 }
 
 export interface SetupOptions {
@@ -272,6 +274,12 @@ async function promptForConfig(): Promise<ProjectConfig> {
 			default: true,
 		},
 		{
+			type: 'confirm',
+			name: 'aiSetup',
+			message: '🤖 Add AI agent rules (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill)?',
+			default: true,
+		},
+		{
 			type: 'list',
 			name: 'bundler',
 			message: '📦 Which bundler/build tool?',
@@ -323,6 +331,7 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		securityAutomation: answers.securityAutomation ?? false,
 		bundler: answers.bundler || 'none',
 		treeshakeCheck: answers.treeshakeCheck || false,
+		aiSetup: answers.aiSetup ?? false,
 	}
 }
 

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import fs from 'fs-extra'
-import { getPackageRoot } from '../utils/copy-preset.js'
+import { copyPreset, getPackageRoot } from '../utils/copy-preset.js'
 
 /**
  * All agent rule files are generated from one source of truth — the shipped
@@ -33,7 +33,7 @@ async function readSkill(): Promise<Skill> {
  * existing block, appends if the file exists without one, creates otherwise.
  * Never clobbers surrounding content.
  */
-async function upsertBlock(filePath: string, body: string): Promise<void> {
+export async function upsertBlock(filePath: string, body: string): Promise<void> {
 	const block = `${BLOCK_START}\n${body}\n${BLOCK_END}`
 	if (await fs.pathExists(filePath)) {
 		const existing = await fs.readFile(filePath, 'utf8')
@@ -49,6 +49,36 @@ async function upsertBlock(filePath: string, body: string): Promise<void> {
 	}
 	await fs.ensureDir(path.dirname(filePath))
 	await fs.writeFile(filePath, `${block}\n`)
+}
+
+/**
+ * Write CLAUDE.md as a thin pointer to AGENTS.md rather than duplicating the
+ * guidance — Claude Code reads both, and `@AGENTS.md` keeps a single source of
+ * truth. Merge-safe: only the delimited block is touched.
+ */
+export async function installClaudeMd(targetDir: string): Promise<string> {
+	const rel = 'CLAUDE.md'
+	const body =
+		'See @AGENTS.md for project and agent guidance (kept in sync by `js-tooling fix ai`).'
+	await upsertBlock(path.join(targetDir, rel), body)
+	return rel
+}
+
+/**
+ * Umbrella: install every AI agent file in one pass — AGENTS.md, the CLAUDE.md
+ * pointer, Cursor + Copilot rules, the Claude skill, and the commented MCP
+ * template. All are merge-safe or `.example`, so re-running is idempotent.
+ * Returns the written paths (relative to targetDir).
+ */
+export async function installAiSetup(targetDir: string): Promise<string[]> {
+	const written: string[] = []
+	written.push(await installAgentRules(targetDir, 'agents-md'))
+	written.push(await installClaudeMd(targetDir))
+	written.push(await installAgentRules(targetDir, 'cursor'))
+	written.push(await installAgentRules(targetDir, 'copilot'))
+	written.push((await copyPreset('claude-skill', targetDir)).target)
+	written.push((await copyPreset('mcp-example', targetDir)).target)
+	return written
 }
 
 /** Install the js-tooling rules for one agent. Returns the written path (relative). */

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ProjectConfig } from '../commands/setup.js'
+import { installAiSetup } from './agent-rules.js'
 import { generateBuildConfigs } from './build.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
@@ -70,6 +71,11 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 				forbiddenSubpaths: allCandidates.filter((s) => s !== defaultAllowed),
 			})
 		}
+	}
+
+	// AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example)
+	if (config.aiSetup) {
+		await installAiSetup(targetDir)
 	}
 
 	// Generate README

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -227,6 +227,12 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		exports: [],
 		fixTarget: 'codeql',
 	},
+	{
+		name: 'AI Agent Setup',
+		description: 'Scaffold AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill, MCP example',
+		exports: [],
+		fixTarget: 'ai',
+	},
 ]
 
 program

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -1,7 +1,13 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 
-export type PresetName = 'biome' | 'changesets' | 'oxlint' | 'tsconfig' | 'claude-skill'
+export type PresetName =
+	| 'biome'
+	| 'changesets'
+	| 'oxlint'
+	| 'tsconfig'
+	| 'claude-skill'
+	| 'mcp-example'
 
 export interface PresetDefinition {
 	source: string
@@ -34,6 +40,11 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/claude/js-tooling.md',
 		target: '.claude/skills/js-tooling.md',
 		desc: 'Claude Code skill for driving the js-tooling CLI',
+	},
+	'mcp-example': {
+		source: 'tooling/mcp/mcp.json.example',
+		target: '.mcp.json.example',
+		desc: 'Commented MCP server template (copy to .mcp.json to activate)',
 	},
 }
 

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -237,6 +237,25 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'Husky')?.status).toBe('ok')
 	})
 
+	it('AI setup: optional-missing on a bare project, ok once AGENTS.md has the block', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		let results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('optional-missing')
+
+		await fs.writeFile(join(dir, 'AGENTS.md'), '<!-- js-tooling:start -->\nx\n<!-- js-tooling:end -->\n')
+		results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('ok')
+	})
+
+	it('AI setup: ok when the Claude skill is present without AGENTS.md', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.claude', 'skills', 'js-tooling.md'), '# skill\n')
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('ok')
+	})
+
 	it('detects lint-staged in package.json', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
@@ -716,6 +735,14 @@ describe('doctor + lockfile', () => {
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('ok')
 		expect(results.find((r) => r.check === 'CodeQL')?.status).toBe('ok')
+	})
+
+	it('demotes AI setup to ok when the lock records aiSetup=false', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await writeLock(dir, { aiSetup: false })
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('ok')
 	})
 
 	it('only ever demotes optional-missing to ok, never makes anything worse', async () => {

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -170,6 +170,28 @@ describe('fix targeted', () => {
 		expect(content.trim()).toBe('22')
 	})
 
+	it('fix ai --yes installs every AI agent file and is idempotent', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('ai', { directory: dir, yes: true })
+		for (const rel of [
+			'AGENTS.md',
+			'CLAUDE.md',
+			'.cursor/rules/js-tooling.mdc',
+			'.github/copilot-instructions.md',
+			'.claude/skills/js-tooling.md',
+			'.mcp.json.example',
+		]) {
+			expect(await fs.pathExists(join(dir, rel))).toBe(true)
+		}
+		expect(await fs.pathExists(join(dir, '.mcp.json'))).toBe(false)
+		expect(await fs.readFile(join(dir, 'CLAUDE.md'), 'utf8')).toContain('@AGENTS.md')
+		// second run must not duplicate the AGENTS.md block
+		await fixCommand('ai', { directory: dir, yes: true })
+		const agents = await fs.readFile(join(dir, 'AGENTS.md'), 'utf8')
+		expect(agents.match(/<!-- js-tooling:start -->/g)).toHaveLength(1)
+	})
+
 	it('fix node-version --yes rewrites hardcoded workflow versions to node-version-file', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir, { engines: { node: '>=22' } })

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -40,6 +40,22 @@ describe('setup-presets', () => {
 		expect(config.linting.eslintConfig).toBe('nextjs')
 		expect(config.bundler).toBe('none')
 	})
+
+	it('enables aiSetup by default and lists AI files when on', () => {
+		const config = buildPresetConfig('library', 'demo')
+		expect(config.aiSetup).toBe(true)
+		const files = computeFileList(config)
+		expect(files).toContain('AGENTS.md')
+		expect(files).toContain('CLAUDE.md')
+		expect(files).toContain('.mcp.json.example')
+	})
+
+	it('omits AI files from the list when aiSetup is off', () => {
+		const config = { ...buildPresetConfig('library', 'demo'), aiSetup: false }
+		const files = computeFileList(config)
+		expect(files).not.toContain('AGENTS.md')
+		expect(files).not.toContain('.mcp.json.example')
+	})
 })
 
 describe('validateProjectConfig', () => {

--- a/tests/cli/generators/agent-rules.test.ts
+++ b/tests/cli/generators/agent-rules.test.ts
@@ -1,0 +1,69 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { installAiSetup, installClaudeMd } from '../../../src/cli/generators/agent-rules.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const AI_FILES = [
+	'AGENTS.md',
+	'CLAUDE.md',
+	'.cursor/rules/js-tooling.mdc',
+	'.github/copilot-instructions.md',
+	'.claude/skills/js-tooling.md',
+	'.mcp.json.example',
+]
+
+describe('installAiSetup', () => {
+	it('writes every AI agent file and returns their paths', async () => {
+		const dir = newTmpDir()
+		const written = await installAiSetup(dir)
+		expect(written).toEqual(AI_FILES)
+		for (const rel of AI_FILES) {
+			expect(await fs.pathExists(join(dir, rel))).toBe(true)
+		}
+	})
+
+	it('makes CLAUDE.md a pointer to AGENTS.md, not a duplicate', async () => {
+		const dir = newTmpDir()
+		await installAiSetup(dir)
+		const claude = await fs.readFile(join(dir, 'CLAUDE.md'), 'utf8')
+		expect(claude).toContain('@AGENTS.md')
+		expect(claude).toContain('<!-- js-tooling:start -->')
+	})
+
+	it('ships the MCP template as .example and never an active .mcp.json', async () => {
+		const dir = newTmpDir()
+		await installAiSetup(dir)
+		expect(await fs.pathExists(join(dir, '.mcp.json.example'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.mcp.json'))).toBe(false)
+		// The active file must be strict JSON, so the template keeps servers empty.
+		const example = await fs.readFile(join(dir, '.mcp.json.example'), 'utf8')
+		expect(example).toContain('"mcpServers": {}')
+	})
+
+	it('preserves existing user content and is idempotent (single block)', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'AGENTS.md'), '# My project rules\n\nKeep these.\n')
+		await installAiSetup(dir)
+		await installAiSetup(dir) // run twice
+		const agents = await fs.readFile(join(dir, 'AGENTS.md'), 'utf8')
+		expect(agents).toContain('# My project rules')
+		expect(agents).toContain('Keep these.')
+		// exactly one delimited block, not duplicated by the second run
+		expect(agents.match(/<!-- js-tooling:start -->/g)).toHaveLength(1)
+	})
+})
+
+describe('installClaudeMd', () => {
+	it('does not clobber an existing CLAUDE.md, only upserts the block', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'CLAUDE.md'), '# Existing\n\nUser notes.\n')
+		await installClaudeMd(dir)
+		const claude = await fs.readFile(join(dir, 'CLAUDE.md'), 'utf8')
+		expect(claude).toContain('# Existing')
+		expect(claude).toContain('User notes.')
+		expect(claude).toContain('@AGENTS.md')
+	})
+})

--- a/tooling/mcp/mcp.json.example
+++ b/tooling/mcp/mcp.json.example
@@ -1,0 +1,27 @@
+{
+  // Model Context Protocol servers for this project.
+  //
+  // This is a TEMPLATE (.mcp.json.example) — it is never loaded, so comments are
+  // safe here. To activate: copy it to `.mcp.json`, remove the comments (real
+  // .mcp.json is strict JSON), and fill in the servers you actually want.
+  //
+  //   cp .mcp.json.example .mcp.json
+  //
+  // Only add servers you need — most GitHub work is already covered by the `gh`
+  // CLI, so a GitHub MCP server is usually redundant.
+  //
+  // Example entries (uncomment and adapt in the real .mcp.json):
+  //
+  // "mcpServers": {
+  //   "filesystem": {
+  //     "command": "npx",
+  //     "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+  //   },
+  //   "postgres": {
+  //     "command": "npx",
+  //     "args": ["-y", "@modelcontextprotocol/server-postgres"],
+  //     "env": { "DATABASE_URL": "${DATABASE_URL}" }
+  //   }
+  // }
+  "mcpServers": {}
+}


### PR DESCRIPTION
## What

A unified "AI setup" feature that scaffolds the instruction files AI coding tools read — in one command, from one source of truth. Closes #159.

## Why

The agent-rule files already existed as four **separate opt-in `fix` targets** (`agents-md`, `cursor-rules`, `copilot-instructions`, `claude-skill`), invisible to `setup` and `doctor`, with no `CLAUDE.md` and no MCP starting point. This unifies them (Model B — both `setup` and `fix`).

## How

- **Umbrella `fix ai`** — installs every agent file in one pass, reusing the existing `installAgentRules` / `copyPreset` (idempotent, merge-safe delimited blocks).
- **`CLAUDE.md` = pointer** (`@AGENTS.md`), not a duplicate — single source of truth, no drift.
- **MCP = `.mcp.json.example`** (commented template), never an active `.mcp.json`: strict JSON can't hold comments, and an unconfigured server would recreate the #93 install-break and the redundancy removed in #158. `cp .mcp.json.example .mcp.json` to activate.
- **`setup` prompt + `ProjectConfig.aiSetup`** — lockfile-tracked and opt-out-aware (`declinedInLock` / `lockfilePatchForTarget`).
- **`doctor` check** `AI setup` — `optional-missing` when absent (never fails CI), `ok` once `AGENTS.md` has the block or the Claude skill is present.
- `TOOL_CATALOG` row + docs guide (`guides/ai-setup`).

Managed files (all merge-safe or `.example`, so re-running is idempotent): `AGENTS.md`, `CLAUDE.md`, `.cursor/rules/js-tooling.mdc`, `.github/copilot-instructions.md`, `.claude/skills/js-tooling.md`, `.mcp.json.example`.

## Test plan
- [x] `pnpm typecheck`, `pnpm check`, `pnpm build`
- [x] `pnpm exec vitest run` — 296 pass; new coverage for the generator (all six paths, CLAUDE.md pointer, merge-safety/idempotency, no active `.mcp.json`), `fix ai`, the doctor check + lockfile demotion, and schema/`computeFileList`
- [x] Drove the built CLI on a temp dir: `fix ai` writes all six files (no `.mcp.json`), is idempotent (one AGENTS.md block after two runs), `doctor` → `AI setup: ok`, `list` shows the new row