### PR TITLE
fix(deps): drop duplicated fdir entry from pnpm-lock.yaml (unblocks CI)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15938,10 +15938,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fdir@6.5.0(picomatch@4.0.5):
-    optionalDependencies:
-      picomatch: 4.0.5
-
   feed@4.2.2:
     dependencies:
       xml-js: 1.6.11


### PR DESCRIPTION
## Problem

CI fails at the install step on **every** PR (including #166):

```
[ERR_PNPM_BROKEN_LOCKFILE] The lockfile at ".../pnpm-lock.yaml"
is broken: duplicated mapping key (15941:3)
```

A bad merge of the recent dependabot bumps (#123 knip, #127 commitlint)
left two byte-identical `fdir@6.5.0(picomatch@4.0.5)` blocks in the
`snapshots:` section. Locally, lenient pnpm (v11.1.3) tolerates the
duplicate YAML key (last-one-wins), which is why it wasn't caught before
merge — but CI's stricter parser rejects it outright.

## Fix

Remove the second, identical block. A section-aware scan confirms this
was the **only** duplicate key in the file, and the blocks are
byte-identical so resolution is unchanged. `pnpm install
--frozen-lockfile` passes after the edit.

Diff is 4 deletions.

## Merge order

Merge this first — it unblocks #166 (docs) and any other open PR, which
will go green on top once this lands on `main`.