### PR TITLE
feat(bundler): add Rollup preset as a peer to tsup/esbuild

### DIFF
--- a/apps/docs/docs/reference/rollup.md
+++ b/apps/docs/docs/reference/rollup.md
@@ -1,0 +1,66 @@
+---
+title: Rollup
+description: Rollup bundler configuration factory for TypeScript libraries.
+---
+
+Rollup is the de-facto library bundler, offered as a peer to [tsup](./tsup.md)
+and [esbuild](./esbuild.md). The preset produces unbundled, per-file ESM + CJS
+output with `.d.ts` declarations — the same shape as the tsup preset — and
+leaves every dependency external so the published library stays thin.
+
+## Usage
+
+Re-export the default config:
+
+```javascript
+// rollup.config.mjs
+export { default } from '@rtorcato/js-tooling/rollup'
+```
+
+…or customize the entry point:
+
+```javascript
+// rollup.config.mjs
+import { getConfig } from '@rtorcato/js-tooling/rollup'
+
+export default getConfig({ input: 'src/main.ts' })
+```
+
+Then wire it into `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "rollup -c",
+    "build:watch": "rollup -c --watch"
+  }
+}
+```
+
+`setup --preset library` scaffolds this for you when you pick Rollup, and
+`npx @rtorcato/js-tooling fix rollup` drops the `rollup.config.mjs` into an
+existing project.
+
+## Peer dependencies
+
+The preset expects these in your `devDependencies` (added automatically by
+`setup`/`fix`):
+
+- `rollup`
+- `@rollup/plugin-typescript`
+- `tslib`
+
+## API
+
+### `getConfig(options?)`
+
+Returns an array of two Rollup configs (ESM + CJS). Declarations are emitted
+once, from the ESM pass.
+
+| Option | Default | Meaning |
+|---|---|---|
+| `input` | `src/index.ts` | Library entry point |
+| `outDir` | `dist` | Output directory for JS + declarations |
+| `sourcemap` | `true` | Emit sourcemaps |
+| `external` | every bare import | Which ids to leave external |
+| `tsconfig` | `./tsconfig.json` | tsconfig for `@rollup/plugin-typescript` |

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
         'reference/jest',
         'reference/oxlint',
         'reference/prettier',
+        'reference/rollup',
         'reference/semantic-release',
         'reference/tsup',
         'reference/typescript',

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
 		"tooling/tests/ssr-safety.d.mts",
 		"tooling/tsup/index.mjs",
 		"tooling/tsup/index.d.mts",
+		"tooling/rollup/rollup.config.mjs",
+		"tooling/rollup/rollup.config.d.mts",
 		"tooling/docusaurus/index.mjs",
 		"tooling/docusaurus/index.d.mts",
 		"tooling/biome/biome.json",
@@ -155,6 +157,10 @@
 			"types": "./tooling/tsup/index.d.mts",
 			"import": "./tooling/tsup/index.mjs"
 		},
+		"./rollup": {
+			"types": "./tooling/rollup/rollup.config.d.mts",
+			"import": "./tooling/rollup/rollup.config.mjs"
+		},
 		"./docusaurus": {
 			"types": "./tooling/docusaurus/index.d.mts",
 			"import": "./tooling/docusaurus/index.mjs"
@@ -203,6 +209,7 @@
 		"@next/eslint-plugin-next": "^16.2.7",
 		"@playwright/test": "^1.60.0",
 		"@semantic-release/changelog": "^6.0.3",
+		"@rollup/plugin-typescript": "^12.0.0",
 		"@semantic-release/commit-analyzer": "^13.0.1",
 		"@semantic-release/exec": "^7.1.0",
 		"@semantic-release/git": "^10.0.1",
@@ -232,8 +239,10 @@
 		"lint-staged": "^17.0.8",
 		"prettier": "^3.8.3",
 		"rimraf": "6.1.3",
+		"rollup": "^4.62.0",
 		"semantic-release": "^25.0.3",
 		"ts-jest": "^29.4.11",
+		"tslib": "^2.8.0",
 		"tsup": "8.5.1",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.62.0",
@@ -247,6 +256,7 @@
 		"@eslint/js": "^9.0.0",
 		"@ianvs/prettier-plugin-sort-imports": "^4.0.0",
 		"@next/eslint-plugin-next": "^16.2.7",
+		"@rollup/plugin-typescript": "^12.0.0",
 		"@semantic-release/changelog": "^6.0.0",
 		"@semantic-release/commit-analyzer": "^13.0.0",
 		"@semantic-release/exec": "^7.0.0",
@@ -266,9 +276,11 @@
 		"eslint-plugin-jest": "^29.0.0",
 		"jest": "^29.0.0",
 		"prettier": "^3.0.0",
+		"rollup": "^4.0.0",
 		"semantic-release": "^25.0.0",
 		"size-limit": "^12.0.0",
 		"ts-jest": "^29.0.0",
+		"tslib": "^2.0.0",
 		"tsup": "^8.0.0",
 		"typescript": ">=5.0.0",
 		"typescript-eslint": "^8.0.0",
@@ -360,6 +372,15 @@
 			"optional": true
 		},
 		"ts-jest": {
+			"optional": true
+		},
+		"@rollup/plugin-typescript": {
+			"optional": true
+		},
+		"rollup": {
+			"optional": true
+		},
+		"tslib": {
 			"optional": true
 		},
 		"tsup": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
+      '@rollup/plugin-typescript':
+        specifier: ^12.0.0
+        version: 12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@5.9.3)
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.5(typescript@5.9.3))
@@ -147,12 +150,18 @@ importers:
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
+      rollup:
+        specifier: ^4.62.0
+        version: 4.62.2
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.5(typescript@5.9.3)
       ts-jest:
         specifier: ^29.4.11
         version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.0.1))(typescript@5.9.3)
+      tslib:
+        specifier: ^2.8.0
+        version: 2.8.1
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.16)(typescript@5.9.3)(yaml@2.9.0)
@@ -2909,19 +2918,31 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
-    cpu: [arm]
-    os: [android]
+  '@rollup/plugin-typescript@12.3.0':
+    resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.61.1':
-    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.62.2':
@@ -2929,19 +2950,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.62.2':
     resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.61.1':
-    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.62.2':
@@ -2949,19 +2960,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
     resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.61.1':
-    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.62.2':
@@ -2969,23 +2970,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
-    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
@@ -2993,23 +2982,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
-    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
@@ -3017,23 +2994,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
-    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
@@ -3041,23 +3006,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
-    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
@@ -3065,23 +3018,11 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
-    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
@@ -3089,21 +3030,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
-    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -3113,51 +3042,25 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.61.1':
-    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
-    cpu: [x64]
-    os: [openbsd]
-
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
-    cpu: [arm64]
-    os: [openharmony]
 
   '@rollup/rollup-openharmony-arm64@4.62.2':
     resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
-    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
-    cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
@@ -3165,18 +3068,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
     resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
-    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
     cpu: [x64]
     os: [win32]
 
@@ -5163,6 +5056,9 @@ packages:
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -8265,11 +8161,6 @@ packages:
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
-    hasBin: true
-
-  rollup@4.61.1:
-    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.62.2:
@@ -13232,151 +13123,93 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    optional: true
+  '@rollup/plugin-typescript@12.3.0(rollup@4.62.2)(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      resolve: 1.22.12
+      typescript: 5.9.3
+    optionalDependencies:
+      rollup: 4.62.2
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+    optionalDependencies:
+      rollup: 4.62.2
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.61.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    optional: true
-
   '@rollup/rollup-freebsd-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.62.2':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.61.1':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    optional: true
-
   '@rollup/rollup-openharmony-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    optional: true
-
   '@rollup/rollup-win32-x64-gnu@4.62.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
@@ -15762,6 +15595,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -16029,7 +15864,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.2
-      rollup: 4.61.1
+      rollup: 4.62.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -19581,37 +19416,6 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rollup@4.61.1:
-    dependencies:
-      '@types/estree': 1.0.9
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.61.1
-      '@rollup/rollup-android-arm64': 4.61.1
-      '@rollup/rollup-darwin-arm64': 4.61.1
-      '@rollup/rollup-darwin-x64': 4.61.1
-      '@rollup/rollup-freebsd-arm64': 4.61.1
-      '@rollup/rollup-freebsd-x64': 4.61.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
-      '@rollup/rollup-linux-arm64-gnu': 4.61.1
-      '@rollup/rollup-linux-arm64-musl': 4.61.1
-      '@rollup/rollup-linux-loong64-gnu': 4.61.1
-      '@rollup/rollup-linux-loong64-musl': 4.61.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
-      '@rollup/rollup-linux-ppc64-musl': 4.61.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
-      '@rollup/rollup-linux-riscv64-musl': 4.61.1
-      '@rollup/rollup-linux-s390x-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-musl': 4.61.1
-      '@rollup/rollup-openbsd-x64': 4.61.1
-      '@rollup/rollup-openharmony-arm64': 4.61.1
-      '@rollup/rollup-win32-arm64-msvc': 4.61.1
-      '@rollup/rollup-win32-ia32-msvc': 4.61.1
-      '@rollup/rollup-win32-x64-gnu': 4.61.1
-      '@rollup/rollup-win32-x64-msvc': 4.61.1
-      fsevents: 2.3.3
-
   rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
@@ -20384,7 +20188,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.61.1
+      rollup: 4.62.2
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -5,7 +5,7 @@ import { createPatch } from 'diff'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { installAgentRules, installAiSetup } from '../generators/agent-rules.js'
-import { generateSemanticReleaseConfig } from '../generators/build.js'
+import { generateRollupConfig, generateSemanticReleaseConfig } from '../generators/build.js'
 import { generateCommunityHealth } from '../generators/community-health.js'
 import {
 	generateCommitlintConfig,
@@ -479,6 +479,17 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			await generateSizeLimitConfig(targetDir)
 			return { filesWritten: ['.size-limit.json'] }
+		},
+	},
+	{
+		target: 'rollup',
+		description: 'Scaffold rollup.config.mjs re-exporting the shared library preset',
+		appliesTo: [],
+		outputs: ['rollup.config.mjs'],
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			await generateRollupConfig(targetDir)
+			return { filesWritten: ['rollup.config.mjs'] }
 		},
 	},
 	{

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -38,7 +38,7 @@ export interface ProjectConfig {
 	changesets?: boolean
 	oxlint?: boolean
 	securityAutomation: boolean
-	bundler: 'tsup' | 'esbuild' | 'vite' | 'none'
+	bundler: 'tsup' | 'esbuild' | 'rollup' | 'vite' | 'none'
 	treeshakeCheck?: boolean
 	/** Scaffold AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example). */
 	aiSetup?: boolean
@@ -287,6 +287,7 @@ async function promptForConfig(): Promise<ProjectConfig> {
 				const choices = [
 					{ name: '📦 tsup (TypeScript packages)', value: 'tsup' },
 					{ name: '⚡ esbuild (Fast bundling)', value: 'esbuild' },
+					{ name: '🍣 Rollup (library bundler)', value: 'rollup' },
 					{ name: '❌ None', value: 'none' },
 				]
 

--- a/src/cli/generators/build.ts
+++ b/src/cli/generators/build.ts
@@ -7,6 +7,8 @@ export async function generateBuildConfigs(config: ProjectConfig, targetDir: str
 		await generateTsupConfig(targetDir)
 	} else if (config.bundler === 'esbuild') {
 		await generateEsbuildConfig(targetDir)
+	} else if (config.bundler === 'rollup') {
+		await generateRollupConfig(targetDir)
 	} else if (config.bundler === 'vite') {
 		await generateViteConfig(config, targetDir)
 	}
@@ -64,6 +66,15 @@ console.log('Build completed!')
 `
 
 	await fs.writeFile(esbuildConfigPath, esbuildConfig)
+}
+
+export async function generateRollupConfig(targetDir: string) {
+	const rollupConfigPath = path.join(targetDir, 'rollup.config.mjs')
+
+	const rollupConfig = `export { default } from '@rtorcato/js-tooling/rollup'
+`
+
+	await fs.writeFile(rollupConfigPath, rollupConfig)
 }
 
 export async function generateViteConfig(config: ProjectConfig, targetDir: string) {

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -114,6 +114,9 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 		scripts['build:watch'] = 'tsup --watch'
 	} else if (config.bundler === 'esbuild') {
 		scripts['build'] = 'node build.mjs'
+	} else if (config.bundler === 'rollup') {
+		scripts['build'] = 'rollup -c'
+		scripts['build:watch'] = 'rollup -c --watch'
 	} else if (config.bundler === 'vite') {
 		scripts['build'] = 'vite build'
 		scripts['dev'] = 'vite'
@@ -233,6 +236,10 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['tsup'] = '^8.0.0'
 	} else if (config.bundler === 'esbuild') {
 		deps['esbuild'] = '^0.25.0'
+	} else if (config.bundler === 'rollup') {
+		deps['rollup'] = '^4.0.0'
+		deps['@rollup/plugin-typescript'] = '^12.0.0'
+		deps['tslib'] = '^2.0.0'
 	} else if (config.bundler === 'vite') {
 		deps['vite'] = '^6.0.0'
 	}

--- a/tests/cli/generators/build.test.ts
+++ b/tests/cli/generators/build.test.ts
@@ -45,6 +45,16 @@ describe('generateBuildConfigs', () => {
 		expect(await fs.pathExists(join(dir, 'tsup.config.ts'))).toBe(false)
 	})
 
+	it('writes rollup.config.mjs re-exporting the preset', async () => {
+		const dir = newTmpDir()
+		await generateBuildConfigs(baseConfig({ bundler: 'rollup' }), dir)
+
+		const content = await fs.readFile(join(dir, 'rollup.config.mjs'), 'utf-8')
+		expect(content).toContain("from '@rtorcato/js-tooling/rollup'")
+		expect(await fs.pathExists(join(dir, 'tsup.config.ts'))).toBe(false)
+		expect(await fs.pathExists(join(dir, 'build.mjs'))).toBe(false)
+	})
+
 	it('writes vite.config.ts re-exporting the preset', async () => {
 		const dir = newTmpDir()
 		await generateBuildConfigs(baseConfig({ bundler: 'vite' }), dir)
@@ -104,6 +114,7 @@ describe('generateBuildConfigs', () => {
 
 		expect(await fs.pathExists(join(dir, 'tsup.config.ts'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'build.mjs'))).toBe(false)
+		expect(await fs.pathExists(join(dir, 'rollup.config.mjs'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'vite.config.ts'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'release.config.mjs'))).toBe(false)
 		expect(await fs.pathExists(join(dir, '.changeset/config.json'))).toBe(false)

--- a/tooling/rollup/rollup.config.d.mts
+++ b/tooling/rollup/rollup.config.d.mts
@@ -1,0 +1,20 @@
+import type { RollupOptions } from 'rollup'
+
+export interface GetConfigOptions {
+	/** Library entry point. Default: `src/index.ts`. */
+	input?: string
+	/** Output directory for JS + declarations. Default: `dist`. */
+	outDir?: string
+	/** Emit sourcemaps. Default: `true`. */
+	sourcemap?: boolean
+	/** Which ids to leave external. Default: every bare (non-relative) import. */
+	external?: RollupOptions['external']
+	/** Path to the tsconfig plugin-typescript should use. Default: `./tsconfig.json`. */
+	tsconfig?: string
+}
+
+/** Build the ESM + CJS Rollup configs for a TypeScript library. */
+export declare function getConfig(options?: GetConfigOptions): RollupOptions[]
+
+declare const config: RollupOptions[]
+export default config

--- a/tooling/rollup/rollup.config.mjs
+++ b/tooling/rollup/rollup.config.mjs
@@ -1,0 +1,70 @@
+import typescript from '@rollup/plugin-typescript'
+
+/**
+ * Rollup config factory for TypeScript libraries.
+ *
+ * Mirrors the tsup preset: unbundled per-file output (`preserveModules`),
+ * dual ESM + CJS, `.d.ts` declarations emitted once from the ESM pass, and
+ * every bare import left external so dependencies aren't inlined.
+ *
+ * Consumers scaffold a `rollup.config.mjs` that re-exports the default:
+ *
+ *   export { default } from '@rtorcato/js-tooling/rollup'
+ *
+ * …or customize the entry / output:
+ *
+ *   import { getConfig } from '@rtorcato/js-tooling/rollup'
+ *   export default getConfig({ input: 'src/main.ts' })
+ *
+ * @param {import('./rollup.config.d.mts').GetConfigOptions} [options]
+ */
+export function getConfig(options = {}) {
+	const {
+		input = 'src/index.ts',
+		outDir = 'dist',
+		sourcemap = true,
+		external = isBareImport,
+		tsconfig = './tsconfig.json',
+	} = options
+
+	// Declarations are emitted once, from the ESM pass — plugin-typescript
+	// requires declarationDir to sit inside the output dir, and running it in
+	// both passes would double-write the same .d.ts files.
+	const esm = {
+		input,
+		external,
+		output: {
+			dir: outDir,
+			format: 'es',
+			entryFileNames: '[name].mjs',
+			preserveModules: true,
+			sourcemap,
+		},
+		plugins: [typescript({ tsconfig, declaration: true, declarationDir: outDir, rootDir: 'src' })],
+	}
+
+	const cjs = {
+		input,
+		external,
+		output: {
+			dir: outDir,
+			format: 'cjs',
+			entryFileNames: '[name].cjs',
+			preserveModules: true,
+			exports: 'named',
+			sourcemap,
+		},
+		plugins: [typescript({ tsconfig, declaration: false })],
+	}
+
+	return [esm, cjs]
+}
+
+// Treat every non-relative, non-absolute id as an external dependency so the
+// library ships thin and deps resolve from the consumer's node_modules.
+// (`\0`-prefixed ids are Rollup's virtual modules — never externalize those.)
+function isBareImport(id) {
+	return !id.startsWith('.') && !id.startsWith('/') && !id.startsWith('\0')
+}
+
+export default getConfig()


### PR DESCRIPTION
Closes #70.

Adds Rollup as a first-class bundler option alongside tsup and esbuild.

## What's included
- **`tooling/rollup/rollup.config.mjs`** — a `getConfig()` factory: unbundled per-file output (`preserveModules`), dual **ESM + CJS**, `.d.ts` emitted once from the ESM pass, and every bare import left external. Mirrors the shape of the tsup preset. Ships a hand-written `.d.mts`.
- **Export** `@rtorcato/js-tooling/rollup` (+ `files` entry).
- **Setup wizard** — `bundler` choice now offers Rollup (library-oriented).
- **`generateBuildConfigs`** scaffolds a `rollup.config.mjs` that re-exports the preset.
- **`fix rollup`** scaffolder (`safe-add`).
- **`package.json` generator** — `build`/`build:watch` scripts + `rollup` / `@rollup/plugin-typescript` / `tslib` devDeps for the consumer.
- **Peer deps** (all optional): `rollup`, `@rollup/plugin-typescript`, `tslib`.
- **Docs** — `docs/reference/rollup.md` + sidebar entry.

## Verification
- Ran a **real Rollup build** against a scratch TS fixture — produced `index.mjs`, `index.cjs`, and `index.d.ts` with no errors (confirms the declaration-dir setup doesn't conflict across the dual output).
- `pnpm typecheck`, `pnpm check`, and the full vitest suite (**297 tests**) pass. Added `build.test.ts` coverage for the rollup branch.

## Lockfile note
Adding the explicit `rollup@^4.62` devDep consolidated a redundant `rollup@4.61.1` tree onto the already-present `4.62.2` — hence the net line reduction. All platform binaries for `4.62.2` are retained; `pnpm install --frozen-lockfile` passes and a duplicate-key scan is clean.