### PR TITLE
feat(publint): add publint preset, doctor check, and fix scaffolder

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -154,6 +154,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `dependabot` | `Dependabot` | `.github/dependabot.yml` |
 | `codeql` | `CodeQL` | `.github/workflows/codeql.yml` |
 | `attw` | `are-the-types-wrong` | adds `@arethetypeswrong/cli` + an `attw` script (esm-only profile when applicable), wires it into `verify` |
+| `publint` | `publint` | adds `publint` + a `publint --strict` script, wires it into `verify` |
 | `claude-skill` | _(opt-in)_ | installs the Claude Code skill at `.claude/skills/js-tooling.md` |
 | `cursor-rules` | _(opt-in)_ | installs the rules for Cursor at `.cursor/rules/js-tooling.mdc` |
 | `copilot-instructions` | _(opt-in)_ | upserts the rules block into `.github/copilot-instructions.md` |

--- a/apps/docs/docs/reference/publint.md
+++ b/apps/docs/docs/reference/publint.md
@@ -1,0 +1,57 @@
+---
+title: publint
+description: Lint your package for common publishing mistakes before you ship it.
+---
+
+[publint](https://publint.dev) checks a package's `package.json` and built
+output for the mistakes that break consumers after publish — wrong `main`,
+missing `exports`, absent type declarations, ESM/CJS mismatches, and files that
+point at paths that aren't shipped. It pairs naturally with
+[are-the-types-wrong](https://github.com/arethetypeswrong/arethetypeswrong.github.io):
+publint validates the package shape, attw validates the type resolution.
+
+## Setup
+
+`setup --preset library` asks whether to add publint (default **yes** for
+libraries). To add it to an existing project:
+
+```bash
+npx @rtorcato/js-tooling fix publint
+```
+
+This installs `publint`, adds a `publint --strict` script, and appends
+`pnpm publint` to your `verify` chain. It's scoped to publishable libraries —
+private packages and apps skip it.
+
+## What it produces
+
+```json
+{
+  "scripts": {
+    "publint": "publint --strict"
+  },
+  "devDependencies": {
+    "publint": "^0.3.0"
+  }
+}
+```
+
+`--strict` treats warnings (not just errors) as failures, so a problem fails
+`verify` and CI rather than slipping into a release.
+
+## CI
+
+When publint is enabled, the generated GitHub Actions workflow runs
+`pnpm publint` in the build job **after** the build step — the built `dist/`
+must exist for publint to resolve `exports` and `main`.
+
+## Doctor
+
+`doctor` reports publint's status for publishable libraries:
+
+- **ok** — `publint` installed and wired into a script
+- **drift** — installed but no script runs it
+- **not configured** — not installed (run `fix publint`)
+
+On private packages or those with no published exports, the check is reported
+as not applicable.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
         'reference/jest',
         'reference/oxlint',
         'reference/prettier',
+        'reference/publint',
         'reference/rollup',
         'reference/semantic-release',
         'reference/tsup',

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1001,6 +1001,49 @@ async function checkAreTheTypesWrong(_dir: string, pkg: Pkg | null): Promise<Che
 	}
 }
 
+async function checkPublint(_dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	if (!isPublishableLibrary(pkg)) {
+		return {
+			check: 'publint',
+			status: 'ok',
+			detail: 'not applicable (private or no published exports)',
+		}
+	}
+
+	const deps = {
+		...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
+		...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
+	}
+	const scripts = (pkg?.scripts as Record<string, string> | undefined) ?? {}
+
+	const hasDep = !!deps['publint']
+	const hasScript = Object.values(scripts).some((s) => /\bpublint\b/.test(s))
+
+	if (hasDep && hasScript) {
+		return {
+			check: 'publint',
+			status: 'ok',
+			detail: 'publint installed and wired into a script',
+		}
+	}
+
+	if (hasDep) {
+		return {
+			check: 'publint',
+			status: 'drift',
+			detail: 'publint installed but no script runs it',
+			hint: 'Run `npx @rtorcato/js-tooling fix publint` to add a `publint` script and wire it into verify',
+		}
+	}
+
+	return {
+		check: 'publint',
+		status: 'optional-missing',
+		detail: 'publint not configured',
+		hint: 'Run `npx @rtorcato/js-tooling fix publint` to lint your package before publishing',
+	}
+}
+
 async function checkTreeshakeSetup(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const appCheckPath = path.join(dir, 'apps', 'treeshake-check', 'check.mjs')
 	if (await fs.pathExists(appCheckPath)) {
@@ -1165,6 +1208,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkAiSetup(targetDir))
 	results.push(await checkTypedoc(targetDir, pkg))
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
+	results.push(await checkPublint(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 
 	// Lockfile-driven demotion: if the lock records an intentional opt-out for a

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -29,6 +29,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	lockfile: 'lockfile',
 	'.js-tooling.json': 'lockfile',
 	'are-the-types-wrong': 'attw',
+	publint: 'publint',
 	TypeDoc: 'typedoc',
 	'AI setup': 'ai',
 }
@@ -75,6 +76,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 		case 'Dependabot':
 		case 'CodeQL':
 			return c.securityAutomation === false
+		case 'publint':
+			return c.publint === false
 		case 'AI setup':
 			return c.aiSetup === false
 		default:
@@ -129,6 +132,8 @@ export function lockfilePatchForTarget(
 			return c.typescript.enabled ? null : { typescript: { enabled: true, config: 'base' } }
 		case 'treeshake-check':
 			return c.treeshakeCheck ? null : { treeshakeCheck: true }
+		case 'publint':
+			return c.publint ? null : { publint: true }
 		case 'ai':
 			return c.aiSetup ? null : { aiSetup: true }
 		default:

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -596,6 +596,37 @@ const FIXERS: Fixer[] = [
 		},
 	},
 	{
+		target: 'publint',
+		description: 'Install publint + add a `publint --strict` script and wire it into verify',
+		appliesTo: ['publint'],
+		outputs: ['package.json (devDependencies + scripts.publint)'],
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir, pkg }) {
+			const pkgPath = path.join(targetDir, 'package.json')
+			if (!pkg) {
+				console.log(chalk.yellow('   no package.json found — skipping'))
+				return { filesWritten: [] }
+			}
+			const updated = { ...pkg }
+			const devDeps = {
+				...((updated.devDependencies as Record<string, string> | undefined) ?? {}),
+			}
+			if (!devDeps['publint']) devDeps['publint'] = '^0.3.0'
+			updated.devDependencies = devDeps
+
+			const scripts = { ...((updated.scripts as Record<string, string> | undefined) ?? {}) }
+			scripts.publint = 'publint --strict'
+			if (scripts.verify && !/\bpublint\b/.test(scripts.verify)) {
+				scripts.verify = `${scripts.verify} && pnpm publint`
+			}
+			updated.scripts = scripts
+
+			await fs.writeJson(pkgPath, updated, { spaces: 2 })
+			return { filesWritten: ['package.json'] }
+		},
+	},
+	{
 		target: 'ai',
 		description:
 			'Install all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example)',

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -31,6 +31,7 @@ export function buildPresetConfig(name: PresetName, projectName: string): Projec
 				typescript: { enabled: true, config: 'base' },
 				semanticRelease: true,
 				bundler: 'tsup',
+				publint: true,
 			}
 		case 'web-app':
 			return {
@@ -136,8 +137,9 @@ export const CONFIG_SCHEMA = {
 		changesets: { type: 'boolean' },
 		oxlint: { type: 'boolean' },
 		securityAutomation: { type: 'boolean' },
-		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'vite', 'none'] },
+		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'rollup', 'vite', 'none'] },
 		treeshakeCheck: { type: 'boolean' },
+		publint: { type: 'boolean' },
 		aiSetup: { type: 'boolean' },
 	},
 } as const
@@ -203,6 +205,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 	}
 	if (config.bundler === 'tsup') files.push('tsup.config.ts')
 	else if (config.bundler === 'esbuild') files.push('build.mjs')
+	else if (config.bundler === 'rollup') files.push('rollup.config.mjs')
 	else if (config.bundler === 'vite') files.push('vite.config.ts')
 	if (config.semanticRelease) files.push('release.config.mjs')
 	if (config.changesets) files.push('.changeset/config.json')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -40,6 +40,8 @@ export interface ProjectConfig {
 	securityAutomation: boolean
 	bundler: 'tsup' | 'esbuild' | 'rollup' | 'vite' | 'none'
 	treeshakeCheck?: boolean
+	/** Add publint (validates package.json + dist for publishing mistakes). */
+	publint?: boolean
 	/** Scaffold AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example). */
 	aiSetup?: boolean
 }
@@ -269,6 +271,13 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		},
 		{
 			type: 'confirm',
+			name: 'publint',
+			message: '📦 Add publint to lint your package before publishing?',
+			default: true,
+			when: (answers: any) => answers.projectType === 'library',
+		},
+		{
+			type: 'confirm',
 			name: 'securityAutomation',
 			message: '🛡️  Include security automation (Dependabot + CodeQL)?',
 			default: true,
@@ -332,6 +341,7 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		securityAutomation: answers.securityAutomation ?? false,
 		bundler: answers.bundler || 'none',
 		treeshakeCheck: answers.treeshakeCheck || false,
+		publint: answers.publint ?? false,
 		aiSetup: answers.aiSetup ?? false,
 	}
 }

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -211,7 +211,7 @@ ${
 
       - name: 🏗️ Build project
         run: pnpm build
-
+${config.publint ? '\n      - name: 🔍 Validate package with publint\n        run: pnpm exec publint --strict\n' : ''}
       - name: 📦 Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -126,6 +126,11 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 	// knip is part of the universal baseline (knip.json is always generated).
 	scripts['knip'] = 'knip'
 
+	// publint validates the published package (exports, types, main) against dist.
+	if (config.publint) {
+		scripts['publint'] = 'publint --strict'
+	}
+
 	// Git hooks
 	if (config.gitHooks) {
 		scripts['prepare'] = 'husky'
@@ -168,6 +173,7 @@ export function composeVerifyScript(
 		cmds.push('pnpm test:e2e')
 	}
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
+	if (config.publint) cmds.push('pnpm publint')
 	return cmds.length >= 2 ? cmds.join(' && ') : null
 }
 
@@ -193,6 +199,7 @@ export function composeVerifyScriptFromPkg(
 	else if (deps.jest) cmds.push('pnpm test --ci')
 	else if (deps['@playwright/test']) cmds.push('pnpm test:e2e')
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
+	if (deps.publint || scripts.publint) cmds.push('pnpm publint')
 	return cmds.length >= 2 ? cmds.join(' && ') : null
 }
 
@@ -242,6 +249,11 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['tslib'] = '^2.0.0'
 	} else if (config.bundler === 'vite') {
 		deps['vite'] = '^6.0.0'
+	}
+
+	// Publishing hygiene
+	if (config.publint) {
+		deps['publint'] = '^0.3.0'
 	}
 
 	// Git hooks

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -850,3 +850,58 @@ describe('nextStepSuggestions', () => {
 		expect(rt?.status).toBe('ok')
 	})
 })
+
+describe('doctor publint check', () => {
+	it('flags a publishable library with no publint as not configured', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			exports: { '.': './dist/index.js' },
+		})
+		const results = await runDoctor(dir)
+		const p = results.find((r) => r.check === 'publint')
+		expect(p?.status).toBe('optional-missing')
+	})
+
+	it('reports ok when publint is installed and wired into a script', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			exports: { '.': './dist/index.js' },
+			scripts: { publint: 'publint --strict' },
+			devDependencies: { publint: '^0.3.0' },
+		})
+		const results = await runDoctor(dir)
+		const p = results.find((r) => r.check === 'publint')
+		expect(p?.status).toBe('ok')
+	})
+
+	it('flags drift when publint is installed but no script runs it', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			exports: { '.': './dist/index.js' },
+			devDependencies: { publint: '^0.3.0' },
+		})
+		const results = await runDoctor(dir)
+		const p = results.find((r) => r.check === 'publint')
+		expect(p?.status).toBe('drift')
+	})
+
+	it('is not applicable for a private package', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			private: true,
+			exports: { '.': './dist/index.js' },
+		})
+		const results = await runDoctor(dir)
+		const p = results.find((r) => r.check === 'publint')
+		expect(p?.status).toBe('ok')
+		expect(p?.detail).toMatch(/not applicable/)
+	})
+})

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -372,6 +372,38 @@ describe('fix targeted', () => {
 		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm attw')
 	})
 
+	it('fix publint --yes installs publint, adds a script, and appends to verify', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			type: 'module',
+			exports: { '.': { import: './dist/index.js', require: './dist/index.cjs' } },
+			scripts: { verify: 'pnpm typecheck && pnpm check' },
+			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
+		})
+		await fixCommand('publint', { directory: dir, yes: true })
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.publint).toBe('publint --strict')
+		expect(pkg.devDependencies['publint']).toBeDefined()
+		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm check && pnpm publint')
+	})
+
+	it('fix publint --yes does not duplicate publint in verify', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			exports: { '.': './dist/index.js' },
+			scripts: { verify: 'pnpm typecheck && pnpm publint' }, // already wired
+			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
+		})
+		await fixCommand('publint', { directory: dir, yes: true })
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.publint).toBe('publint --strict')
+		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm publint')
+	})
+
 	it('fix claude-skill --yes installs the skill into .claude/skills/', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -39,6 +39,23 @@ describe('generateGitHubActions', () => {
 		expect(content).not.toContain("node-version: '20'")
 	})
 
+	it('adds a publint step to the build job when publint is enabled', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig({ bundler: 'tsup', publint: true }), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).toContain('Validate package with publint')
+		expect(content).toContain('pnpm exec publint --strict')
+	})
+
+	it('omits the publint step when publint is disabled', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig({ bundler: 'tsup', publint: false }), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).not.toContain('publint')
+	})
+
 	it('includes typecheck job when TypeScript is enabled', async () => {
 		const dir = newTmpDir()
 		await generateGitHubActions(baseConfig({ typescript: { enabled: true, config: 'base' } }), dir)

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -197,6 +197,32 @@ describe('generatePackageJson', () => {
 		const pkg = await fs.readJson(join(dir, 'package.json'))
 		expect(pkg.scripts.verify).toBeUndefined()
 	})
+
+	it('adds publint dep, script, and verify step when publint is enabled', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(
+			baseConfig({
+				typescript: { enabled: true, config: 'base' },
+				linting: { tool: 'biome' },
+				publint: true,
+			}),
+			dir
+		)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.devDependencies.publint).toBe('^0.3.0')
+		expect(pkg.scripts.publint).toBe('publint --strict')
+		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm check && pnpm publint')
+	})
+
+	it('omits publint when not enabled', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(baseConfig({ publint: false }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.publint).toBeUndefined()
+		expect(pkg.devDependencies.publint).toBeUndefined()
+	})
 })
 
 describe('composeVerifyScript', () => {


### PR DESCRIPTION
Closes #69.

Adds [publint](https://publint.dev) — validates `package.json` + built `dist` for common publishing mistakes (wrong `main`, missing `exports`/types, ESM/CJS mismatches). Integrated the same way as `are-the-types-wrong` (attw), which it complements.

## What's included
- **Setup wizard** — opt-in prompt for **library** projects (default **on**); `setup --preset library` enables it.
- **Verify chain** — `publint --strict` script, and `pnpm publint` appended to `verify` when enabled (both the config-driven and pkg-driven verify composers).
- **CI** — the build job runs `pnpm exec publint --strict` **after** the build step (dist must exist), gated on the flag. Uses `exec` so it doesn't depend on the script surviving a standalone workflow regen.
- **Doctor** — a `publint` check for publishable libraries (`ok` / `drift` / `not configured`), not-applicable for private/app packages, with lockfile opt-out (`declinedInLock`).
- **`fix publint`** — installs `publint`, adds the script, wires verify. `safe-merge`, `canFixDrift`.
- **Docs** — `docs/reference/publint.md`, sidebar entry, and a row in the CLI guide's fix-target table.

## Also fixes two latent gaps from #70 (Rollup)
While wiring publint through the same config plumbing I found the merged Rollup PR missed two spots:
- `rollup` was absent from the lockfile config schema `bundler` enum (`additionalProperties: false` ⇒ a rollup project's `.js-tooling.json` would fail validation).
- `rollup` was absent from the scaffold-file list.
Both added here.

## Verification
- `pnpm typecheck`, `pnpm check`, full vitest suite — **307 tests pass** (+10 new: fix, doctor, package-json, CI-step).
- **Real CLI smoke test** on a temp publishable package: `fix --list` shows publint; `doctor --json` reports `optional-missing`; `fix publint --yes` produced `scripts.publint = "publint --strict"`, `verify = "pnpm typecheck && pnpm publint"`, and `devDependencies.publint = "^0.3.0"`.

## Note on scope
Doctor reports publint's *configuration* status (installed + wired), matching attw — it doesn't execute publint live. Running it in-process could be a follow-up (and should move attw + publint together).