### PR TITLE
feat(badges): generate README status badges (opt-in, visibility-aware)

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -155,6 +155,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `codeql` | `CodeQL` | `.github/workflows/codeql.yml` |
 | `attw` | `are-the-types-wrong` | adds `@arethetypeswrong/cli` + an `attw` script (esm-only profile when applicable), wires it into `verify` |
 | `publint` | `publint` | adds `publint` + a `publint --strict` script, wires it into `verify` |
+| `badges` | `README badges` | inserts a status-badge row (CI, npm, coverage, license) into `README.md`, derived from `package.json` |
 | `claude-skill` | _(opt-in)_ | installs the Claude Code skill at `.claude/skills/js-tooling.md` |
 | `cursor-rules` | _(opt-in)_ | installs the rules for Cursor at `.cursor/rules/js-tooling.mdc` |
 | `copilot-instructions` | _(opt-in)_ | upserts the rules block into `.github/copilot-instructions.md` |

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
+import { BADGE_START, hasPublicOnlyBadges } from '../generators/badges.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
 
@@ -1044,6 +1045,42 @@ async function checkPublint(_dir: string, pkg: Pkg | null): Promise<CheckResult>
 	}
 }
 
+async function checkReadmeBadges(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const readmePath = path.join(dir, 'README.md')
+	const readme = (await fs.pathExists(readmePath)) ? await fs.readFile(readmePath, 'utf8') : ''
+	const isPrivate = !pkg || pkg.private === true
+
+	if (isPrivate) {
+		// Only a problem if a private/app repo carries badges that would 404.
+		if (readme && hasPublicOnlyBadges(readme)) {
+			return {
+				check: 'README badges',
+				status: 'drift',
+				detail: 'README has npm/coverage badges but the package is private (they 404)',
+				hint: 'Run `npx @rtorcato/js-tooling fix badges` to rebuild badges for a private repo',
+			}
+		}
+		return { check: 'README badges', status: 'ok', detail: 'not applicable (private package)' }
+	}
+
+	if (!isPublishableLibrary(pkg)) {
+		return { check: 'README badges', status: 'ok', detail: 'not applicable (no published exports)' }
+	}
+
+	const hasBadges =
+		readme.includes(BADGE_START) ||
+		/img\.shields\.io|badge\.svg|badge\.fury\.io|codecov\.io/.test(readme)
+	if (hasBadges) {
+		return { check: 'README badges', status: 'ok', detail: 'README carries status badges' }
+	}
+	return {
+		check: 'README badges',
+		status: 'optional-missing',
+		detail: 'no status badges in README',
+		hint: 'Run `npx @rtorcato/js-tooling fix badges` to add CI/npm/coverage/license badges',
+	}
+}
+
 async function checkTreeshakeSetup(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const appCheckPath = path.join(dir, 'apps', 'treeshake-check', 'check.mjs')
 	if (await fs.pathExists(appCheckPath)) {
@@ -1209,6 +1246,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkTypedoc(targetDir, pkg))
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkPublint(targetDir, pkg))
+	results.push(await checkReadmeBadges(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 
 	// Lockfile-driven demotion: if the lock records an intentional opt-out for a

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -30,6 +30,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'.js-tooling.json': 'lockfile',
 	'are-the-types-wrong': 'attw',
 	publint: 'publint',
+	'README badges': 'badges',
 	TypeDoc: 'typedoc',
 	'AI setup': 'ai',
 }
@@ -78,6 +79,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			return c.securityAutomation === false
 		case 'publint':
 			return c.publint === false
+		case 'README badges':
+			return c.badges === false
 		case 'AI setup':
 			return c.aiSetup === false
 		default:
@@ -134,6 +137,8 @@ export function lockfilePatchForTarget(
 			return c.treeshakeCheck ? null : { treeshakeCheck: true }
 		case 'publint':
 			return c.publint ? null : { publint: true }
+		case 'badges':
+			return c.badges ? null : { badges: true }
 		case 'ai':
 			return c.aiSetup ? null : { aiSetup: true }
 		default:

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -5,6 +5,7 @@ import { createPatch } from 'diff'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { installAgentRules, installAiSetup } from '../generators/agent-rules.js'
+import { buildBadgeBlock, parseRepository, upsertBadges } from '../generators/badges.js'
 import { generateRollupConfig, generateSemanticReleaseConfig } from '../generators/build.js'
 import { generateCommunityHealth } from '../generators/community-health.js'
 import {
@@ -624,6 +625,41 @@ const FIXERS: Fixer[] = [
 
 			await fs.writeJson(pkgPath, updated, { spaces: 2 })
 			return { filesWritten: ['package.json'] }
+		},
+	},
+	{
+		target: 'badges',
+		description: 'Add or refresh the status-badge block in README.md (derived from package.json)',
+		appliesTo: ['README badges'],
+		outputs: ['README.md'],
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir, pkg }) {
+			if (!pkg) {
+				console.log(chalk.yellow('   no package.json found — skipping'))
+				return { filesWritten: [] }
+			}
+			const p = pkg as Record<string, unknown>
+			const name = typeof p.name === 'string' ? p.name : undefined
+			const parsed = parseRepository(p.repository)
+			const block = buildBadgeBlock({
+				name,
+				owner: parsed?.owner,
+				repo: parsed?.repo,
+				isPrivate: p.private === true,
+			})
+			if (!block) {
+				console.log(
+					chalk.yellow('   package.json has no name/repository to build badges from — skipping')
+				)
+				return { filesWritten: [] }
+			}
+			const readmePath = path.join(targetDir, 'README.md')
+			const existing = (await fs.pathExists(readmePath))
+				? await fs.readFile(readmePath, 'utf8')
+				: `# ${name ?? 'project'}\n`
+			await fs.writeFile(readmePath, upsertBadges(existing, block))
+			return { filesWritten: ['README.md'] }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -18,6 +18,7 @@ const BASE: Omit<ProjectConfig, 'projectName' | 'projectType' | 'typescript' | '
 	commitLint: true,
 	semanticRelease: false,
 	securityAutomation: true,
+	badges: true,
 	aiSetup: true,
 }
 
@@ -140,6 +141,7 @@ export const CONFIG_SCHEMA = {
 		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'rollup', 'vite', 'none'] },
 		treeshakeCheck: { type: 'boolean' },
 		publint: { type: 'boolean' },
+		badges: { type: 'boolean' },
 		aiSetup: { type: 'boolean' },
 	},
 } as const

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -42,6 +42,8 @@ export interface ProjectConfig {
 	treeshakeCheck?: boolean
 	/** Add publint (validates package.json + dist for publishing mistakes). */
 	publint?: boolean
+	/** Add a status-badge block to the generated README. */
+	badges?: boolean
 	/** Scaffold AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example). */
 	aiSetup?: boolean
 }
@@ -278,6 +280,12 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		},
 		{
 			type: 'confirm',
+			name: 'badges',
+			message: '🔖 Add status badges (CI, npm, coverage, license) to the README?',
+			default: true,
+		},
+		{
+			type: 'confirm',
 			name: 'securityAutomation',
 			message: '🛡️  Include security automation (Dependabot + CodeQL)?',
 			default: true,
@@ -342,6 +350,7 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		bundler: answers.bundler || 'none',
 		treeshakeCheck: answers.treeshakeCheck || false,
 		publint: answers.publint ?? false,
+		badges: answers.badges ?? false,
 		aiSetup: answers.aiSetup ?? false,
 	}
 }

--- a/src/cli/generators/badges.ts
+++ b/src/cli/generators/badges.ts
@@ -1,0 +1,122 @@
+// Shared badge-block builder. All URLs are derived from package.json (name +
+// repository) — no hardcoded owner/repo — so it works for any consumer.
+
+export const BADGE_START = '<!-- js-tooling:badges:start -->'
+export const BADGE_END = '<!-- js-tooling:badges:end -->'
+
+export interface BadgeInputs {
+	/** Package name — drives the npm version/downloads/bundle-size badges. */
+	name?: string
+	/** GitHub owner + repo — drive the CI + coverage badges. */
+	owner?: string
+	repo?: string
+	/** Default branch used by the coverage badge. Default: `main`. */
+	branch?: string
+	/** Private or unpublished: skip npm/bundlephobia/coverage (they would 404). */
+	isPrivate?: boolean
+}
+
+/**
+ * Parse a package.json `repository` field into `{ owner, repo }`.
+ * Handles the shorthand (`owner/repo`, `github:owner/repo`) and full git URLs
+ * (`git+https://github.com/owner/repo.git`, `git@github.com:owner/repo.git`).
+ * Returns null for non-GitHub or unparseable values.
+ */
+export function parseRepository(repository: unknown): { owner: string; repo: string } | null {
+	const url =
+		typeof repository === 'string'
+			? repository
+			: repository && typeof repository === 'object'
+				? (repository as { url?: unknown }).url
+				: undefined
+	if (typeof url !== 'string' || url.length === 0) return null
+
+	// `owner/repo` or `github:owner/repo` shorthand (no scheme, no host).
+	if (!url.includes('://') && !url.includes('@')) {
+		const short = url.replace(/^github:/, '').match(/^([\w.-]+)\/([\w.-]+?)(?:\.git)?$/)
+		if (short) return { owner: short[1], repo: short[2] }
+	}
+
+	const m = url.match(/github\.com[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:$|[/#?])/)
+	return m ? { owner: m[1], repo: m[2] } : null
+}
+
+/**
+ * Build the badge markdown row (no delimiter comments). Returns '' when only
+ * the always-on license badge would render — i.e. nothing package- or
+ * repo-specific is derivable, so a badge row isn't worth adding.
+ */
+export function buildBadgeRow(inputs: BadgeInputs): string {
+	const { name, owner, repo, branch = 'main', isPrivate = false } = inputs
+	const slug = owner && repo ? `${owner}/${repo}` : null
+	const badges: string[] = []
+	let specific = false
+
+	if (slug) {
+		specific = true
+		badges.push(
+			`[![CI](https://github.com/${slug}/actions/workflows/ci.yml/badge.svg)](https://github.com/${slug}/actions/workflows/ci.yml)`
+		)
+	}
+	if (!isPrivate && name) {
+		specific = true
+		badges.push(
+			`[![npm version](https://img.shields.io/npm/v/${name})](https://www.npmjs.com/package/${name})`
+		)
+		badges.push(
+			`[![npm downloads](https://img.shields.io/npm/dm/${name})](https://www.npmjs.com/package/${name})`
+		)
+		badges.push(
+			`[![Bundle size](https://img.shields.io/bundlephobia/minzip/${name})](https://bundlephobia.com/package/${name})`
+		)
+	}
+	if (!isPrivate && slug) {
+		badges.push(
+			`[![Coverage](https://codecov.io/gh/${slug}/branch/${branch}/graph/badge.svg)](https://codecov.io/gh/${slug})`
+		)
+	}
+	badges.push(
+		'[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)'
+	)
+
+	return specific ? badges.join('\n') : ''
+}
+
+/** Build the full delimited badge block, or '' when there's nothing worth showing. */
+export function buildBadgeBlock(inputs: BadgeInputs): string {
+	const row = buildBadgeRow(inputs)
+	return row ? `${BADGE_START}\n${row}\n${BADGE_END}` : ''
+}
+
+/** True when the text carries npm/bundlephobia/codecov badges (which 404 on private/unpublished). */
+export function hasPublicOnlyBadges(text: string): boolean {
+	return /img\.shields\.io\/npm\/|bundlephobia|codecov\.io/.test(text)
+}
+
+/**
+ * Insert or refresh the badge block in a README. Replaces an existing delimited
+ * block in place; otherwise inserts right after the first H1 (or prepends when
+ * there is none). Passing an empty block strips any existing one. Idempotent.
+ */
+export function upsertBadges(readme: string, block: string): string {
+	const start = readme.indexOf(BADGE_START)
+	const end = readme.indexOf(BADGE_END)
+	const hasBlock = start !== -1 && end !== -1 && end > start
+
+	if (!block) {
+		if (!hasBlock) return readme
+		// Strip the block plus the blank line that follows it, if any.
+		const after = readme.slice(end + BADGE_END.length).replace(/^\n\n/, '\n')
+		return (readme.slice(0, start).replace(/\n\n$/, '\n') + after).replace(/^\n+/, '')
+	}
+
+	if (hasBlock) {
+		return readme.slice(0, start) + block + readme.slice(end + BADGE_END.length)
+	}
+
+	const lines = readme.split('\n')
+	const h1 = lines.findIndex((l) => /^#\s+/.test(l))
+	if (h1 === -1) return `${block}\n\n${readme}`
+	lines.splice(h1 + 1, 0, '', block)
+	return lines.join('\n')
+}

--- a/src/cli/generators/readme.ts
+++ b/src/cli/generators/readme.ts
@@ -1,12 +1,14 @@
 import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
+import { buildBadgeBlock, parseRepository } from './badges.js'
 
 export async function generateReadme(config: ProjectConfig, targetDir: string) {
 	const readmePath = path.join(targetDir, 'README.md')
+	const badges = config.badges ? await buildReadmeBadgeBlock(config, targetDir) : ''
 
 	const readme = `# ${config.projectName}
-
+${badges ? `\n${badges}\n` : ''}
 > Generated with [@rtorcato/js-tooling](https://www.npmjs.com/package/@rtorcato/js-tooling)
 
 ## Description
@@ -104,6 +106,32 @@ This project follows [Conventional Commits](https://conventionalcommits.org/):
 `
 
 	await fs.writeFile(readmePath, readme)
+}
+
+/**
+ * Build the badge block for a generated README. URLs are derived from the
+ * target's package.json (name + repository); visibility falls back to the
+ * project type (libraries are public, apps private) when `private` is unset.
+ */
+export async function buildReadmeBadgeBlock(
+	config: ProjectConfig,
+	targetDir: string
+): Promise<string> {
+	let repository: unknown
+	let isPrivate = config.projectType !== 'library'
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (await fs.pathExists(pkgPath)) {
+		const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+		repository = pkg.repository
+		if (typeof pkg.private === 'boolean') isPrivate = pkg.private
+	}
+	const parsed = parseRepository(repository)
+	return buildBadgeBlock({
+		name: config.projectName,
+		owner: parsed?.owner,
+		repo: parsed?.repo,
+		isPrivate,
+	})
 }
 
 function generateDevelopmentSection(config: ProjectConfig): string {

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -905,3 +905,50 @@ describe('doctor publint check', () => {
 		expect(p?.detail).toMatch(/not applicable/)
 	})
 })
+
+describe('doctor README badges check', () => {
+	it('flags a public library with no badges as not configured', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			exports: { '.': './dist/index.js' },
+		})
+		await fs.writeFile(join(dir, 'README.md'), '# demo\n\nNo badges here.\n')
+		const results = await runDoctor(dir)
+		const b = results.find((r) => r.check === 'README badges')
+		expect(b?.status).toBe('optional-missing')
+	})
+
+	it('reports ok when the README already carries badges', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			exports: { '.': './dist/index.js' },
+		})
+		await fs.writeFile(
+			join(dir, 'README.md'),
+			'# demo\n\n![npm](https://img.shields.io/npm/v/demo)\n'
+		)
+		const results = await runDoctor(dir)
+		const b = results.find((r) => r.check === 'README badges')
+		expect(b?.status).toBe('ok')
+	})
+
+	it('flags drift when a private package carries npm/coverage badges', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			private: true,
+		})
+		await fs.writeFile(
+			join(dir, 'README.md'),
+			'# demo\n\n![npm](https://img.shields.io/npm/v/demo)\n'
+		)
+		const results = await runDoctor(dir)
+		const b = results.find((r) => r.check === 'README badges')
+		expect(b?.status).toBe('drift')
+	})
+})

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -404,6 +404,22 @@ describe('fix targeted', () => {
 		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm publint')
 	})
 
+	it('fix badges --yes inserts a badge block into the README', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			repository: 'git+https://github.com/rtorcato/demo.git',
+			exports: { '.': './dist/index.js' },
+		})
+		await fs.writeFile(join(dir, 'README.md'), '# demo\n\nHello.\n')
+		await fixCommand('badges', { directory: dir, yes: true })
+		const readme = await fs.readFile(join(dir, 'README.md'), 'utf8')
+		expect(readme).toContain('<!-- js-tooling:badges:start -->')
+		expect(readme).toContain('actions/workflows/ci.yml')
+		expect(readme).toContain('img.shields.io/npm/v/demo')
+	})
+
 	it('fix claude-skill --yes installs the skill into .claude/skills/', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/badges.test.ts
+++ b/tests/cli/generators/badges.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+	BADGE_END,
+	BADGE_START,
+	buildBadgeBlock,
+	buildBadgeRow,
+	parseRepository,
+	upsertBadges,
+} from '../../../src/cli/generators/badges.js'
+
+describe('parseRepository', () => {
+	it('parses a git+https url', () => {
+		expect(parseRepository('git+https://github.com/rtorcato/js-tooling.git')).toEqual({
+			owner: 'rtorcato',
+			repo: 'js-tooling',
+		})
+	})
+
+	it('parses an { url } object and an scp-style git url', () => {
+		expect(parseRepository({ url: 'git@github.com:owner/repo.git' })).toEqual({
+			owner: 'owner',
+			repo: 'repo',
+		})
+	})
+
+	it('parses the owner/repo and github: shorthands', () => {
+		expect(parseRepository('owner/repo')).toEqual({ owner: 'owner', repo: 'repo' })
+		expect(parseRepository('github:owner/repo')).toEqual({ owner: 'owner', repo: 'repo' })
+	})
+
+	it('returns null for non-GitHub or missing values', () => {
+		expect(parseRepository('https://gitlab.com/owner/repo.git')).toBeNull()
+		expect(parseRepository(undefined)).toBeNull()
+		expect(parseRepository({})).toBeNull()
+	})
+})
+
+describe('buildBadgeRow', () => {
+	it('includes CI, npm, coverage, and license for a public repo', () => {
+		const row = buildBadgeRow({ name: 'my-lib', owner: 'o', repo: 'r' })
+		expect(row).toContain('actions/workflows/ci.yml/badge.svg')
+		expect(row).toContain('img.shields.io/npm/v/my-lib')
+		expect(row).toContain('img.shields.io/npm/dm/my-lib')
+		expect(row).toContain('bundlephobia/minzip/my-lib')
+		expect(row).toContain('codecov.io/gh/o/r')
+		expect(row).toContain('License-MIT')
+	})
+
+	it('drops npm/bundlephobia/coverage for a private repo, keeps CI + license', () => {
+		const row = buildBadgeRow({ name: 'my-lib', owner: 'o', repo: 'r', isPrivate: true })
+		expect(row).toContain('actions/workflows/ci.yml')
+		expect(row).toContain('License-MIT')
+		expect(row).not.toContain('shields.io/npm')
+		expect(row).not.toContain('bundlephobia')
+		expect(row).not.toContain('codecov')
+	})
+
+	it('returns empty when only the license badge would render', () => {
+		// Private and no repo → nothing package/repo-specific.
+		expect(buildBadgeRow({ name: 'x', isPrivate: true })).toBe('')
+	})
+})
+
+describe('upsertBadges', () => {
+	const block = buildBadgeBlock({ name: 'my-lib', owner: 'o', repo: 'r' })
+
+	it('inserts the block right after the first H1', () => {
+		const out = upsertBadges('# Title\n\nBody', block)
+		const lines = out.split('\n')
+		expect(lines[0]).toBe('# Title')
+		expect(lines[2]).toBe(BADGE_START)
+		expect(out).toContain('Body')
+	})
+
+	it('replaces an existing block in place (idempotent)', () => {
+		const once = upsertBadges('# Title\n\nBody', block)
+		const twice = upsertBadges(once, block)
+		expect(twice).toBe(once)
+		expect(twice.match(new RegExp(BADGE_START, 'g'))).toHaveLength(1)
+	})
+
+	it('strips the block when passed an empty string', () => {
+		const withBadges = upsertBadges('# Title\n\nBody', block)
+		const stripped = upsertBadges(withBadges, '')
+		expect(stripped).not.toContain(BADGE_START)
+		expect(stripped).not.toContain(BADGE_END)
+		expect(stripped).toContain('# Title')
+		expect(stripped).toContain('Body')
+	})
+})

--- a/tests/cli/generators/readme.test.ts
+++ b/tests/cli/generators/readme.test.ts
@@ -33,6 +33,28 @@ describe('generateReadme', () => {
 		expect(content).toContain('@rtorcato/js-tooling')
 	})
 
+	it('inserts a badge block after the title when badges is enabled', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'my-lib',
+			repository: 'git+https://github.com/rtorcato/my-lib.git',
+		})
+		await generateReadme(baseConfig({ projectName: 'my-lib', badges: true }), dir)
+
+		const content = await fs.readFile(join(dir, 'README.md'), 'utf-8')
+		expect(content).toContain('<!-- js-tooling:badges:start -->')
+		expect(content).toContain('actions/workflows/ci.yml')
+		expect(content).toContain('img.shields.io/npm/v/my-lib')
+	})
+
+	it('omits the badge block when badges is disabled', async () => {
+		const dir = newTmpDir()
+		await generateReadme(baseConfig({ badges: false }), dir)
+
+		const content = await fs.readFile(join(dir, 'README.md'), 'utf-8')
+		expect(content).not.toContain('js-tooling:badges:start')
+	})
+
 	it('includes Biome in the tooling list when linting tool is biome', async () => {
 		const dir = newTmpDir()
 		await generateReadme(baseConfig({ linting: { tool: 'biome' } }), dir)


### PR DESCRIPTION
Closes #142.

Adds README status badges — the same row js-tooling has — for scaffolded/audited projects. All URLs are derived from `package.json` (`name` + `repository`); **no hardcoded owner/repo**.

## What's included
- **`src/cli/generators/badges.ts`** — shared, pure badge module: `parseRepository` (git URLs + `owner/repo`/`github:` shorthands), `buildBadgeRow`/`buildBadgeBlock`, and `upsertBadges` (insert after H1 / replace in place / strip — idempotent via `<!-- js-tooling:badges:start/end -->` markers).
- **Setup wizard** — a badge prompt (default **on**); presets enable it via `BASE`.
- **`generateReadme`** — inserts the delimited badge block right after the title when enabled; visibility falls back to project type (libraries public, apps private) when `package.json` `private` is unset.
- **`fix badges`** — adds/refreshes the block on an existing README (`safe-merge`, `canFixDrift`).
- **doctor `README badges`** — nudges a public library with no badges (`optional-missing`), and flags a **private** package that carries npm/coverage badges (they 404) as `drift`; not-applicable otherwise. Lockfile opt-out wired.
- **CLI guide** — new fix-target row.

## Visibility rules (per #142)
Private / unpublished → **drop** npm, bundlephobia, and codecov badges (they'd 404); keep CI + license. Public → the full set, filtered by what's derivable (CI/coverage need `repository`; npm badges need `name`).

## Verification
- `pnpm typecheck`, `pnpm check`, full vitest — **323 tests pass** (+16: badge module, README gen, fix, doctor).
- **Real CLI smoke test**: `fix badges` on a temp public package inserted the full row (CI/npm/downloads/bundle/coverage/license) with URLs derived from `package.json`, right after the H1.

## Scope note
This delivers the **README** half. **#169** (same badges on the generated docs homepage) has nothing to hook into yet — there's no consumer docs-site generator until **#100/#106** land — so #169 stays open. Per-badge selection (a checkbox instead of one on/off prompt) is a possible refinement; the current prompt records the on/off intent and emits the full applicable set.