### PR TITLE
chore(biome): align remaining schema refs to 2.5.0

### DIFF
--- a/apps/docs/biome.json
+++ b/apps/docs/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "root": false,
   "extends": ["@rtorcato/js-tooling/biome"],
   "files": {

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -117,7 +117,7 @@ $ npx @rtorcato/js-tooling fix biome --diff
     -  "rules": { "noConsole": "error" }
     -}
     +{
-    +  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+    +  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
     +  "extends": ["@rtorcato/js-tooling/biome"],
     +  …
     +}


### PR DESCRIPTION
Closes #163.

## Finding
The core of #163 — the **shared `@rtorcato/js-tooling/biome` preset** consumers extend — is **already at `2.5.0`** (`tooling/biome/biome.json`), as is the generator (`linting.ts`). Verified locally that a 2.5.0 schema does **not** warn under the installed 2.5.1 CLI (Biome tolerates the patch gap; the warning only fires on minor/major drift like 2.4.x → 2.5.x). So consumers are already unaffected.

## Change
Two stragglers still referenced the old `2.4.16`:
- `apps/docs/biome.json` — this repo's docs-workspace config (would warn once it resolves the preset).
- The `fix biome --diff` **example** in `guides/cli.md` — now shows the version the generator actually writes.

Both bumped to `2.5.0`. No functional change; `pnpm check` passes and no `2.4.16` references remain.