### PR TITLE
test: snapshot generator output (package.json, ci.yml, vitest config)

### DIFF
--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,330 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generator output snapshots > .github/workflows/ci.yml (library) 1`] = `
+"name: 🚀 CI/CD Pipeline
+
+on:
+  push:
+    branches: [main, release, develop]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: \${{ github.workflow }}-\${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-skip:
+    runs-on: ubuntu-latest
+    outputs:
+      should-skip: \${{ steps.skip-check.outputs.should-skip }}
+    steps:
+      - name: Check for skip CI
+        id: skip-check
+        run: |
+          if [[ "\${{ github.event.head_commit.message }}" =~ \\[(ci skip|skip ci)\\] ]]; then
+            echo "should-skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-skip=false" >> $GITHUB_OUTPUT
+          fi
+
+  dependencies:
+    runs-on: ubuntu-latest
+    needs: check-skip
+    if: needs.check-skip.outputs.should-skip != 'true'
+    outputs:
+      cache-key: \${{ steps.cache-key.outputs.key }}
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 📦 Generate cache key
+        id: cache-key
+        run: echo "key=\${{ runner.os }}-pnpm-\${{ hashFiles('**/pnpm-lock.yaml') }}" >> $GITHUB_OUTPUT
+
+      - name: 📦 Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: \${{ steps.cache-key.outputs.key }}
+          restore-keys: |
+            \${{ runner.os }}-pnpm-
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: [dependencies, check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 📦 Restore dependencies cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: \${{ needs.dependencies.outputs.cache-key }}
+
+      - name: 🔍 Run linting
+        run: pnpm check
+
+      - name: 🧹 Check for unused files, exports, and dependencies
+        run: pnpm knip
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: [dependencies, check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 📦 Restore dependencies cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: \${{ needs.dependencies.outputs.cache-key }}
+
+      - name: 🔍 Type check
+        run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [dependencies, check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 📦 Restore dependencies cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: \${{ needs.dependencies.outputs.cache-key }}
+
+      - name: 🧪 Run tests
+        run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [dependencies, check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 📦 Restore dependencies cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: \${{ needs.dependencies.outputs.cache-key }}
+
+      - name: 🏗️ Build project
+        run: pnpm build
+
+      - name: 📦 Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-artifacts
+          path: |
+            dist/
+            package.json
+            README.md
+          retention-days: 7
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [dependencies, lint, typecheck, test, build, check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          # RELEASE_TOKEN (admin PAT) lets semantic-release push the version
+          # commit + tag to a protected main; GITHUB_TOKEN can't bypass branch
+          # protection. Falls back to GITHUB_TOKEN when no PAT is set.
+          token: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest
+
+      - name: 📦 Restore dependencies cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pnpm-store
+            node_modules
+          key: \${{ needs.dependencies.outputs.cache-key }}
+
+      - name: 🔧 Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: 🚀 Run semantic-release
+        env:
+          GITHUB_TOKEN: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release
+"
+`;
+
+exports[`generator output snapshots > package.json (library) 1`] = `
+"{
+  "name": "snapshot-lib",
+  "version": "0.1.0",
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "format": "biome format .",
+    "check": "biome check .",
+    "check:fix": "biome check --fix .",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:ui": "vitest --ui",
+    "coverage": "vitest run --coverage",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
+    "knip": "knip",
+    "prepare": "husky",
+    "release": "semantic-release",
+    "verify": "pnpm typecheck && pnpm check && pnpm exec vitest run"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@rtorcato/js-tooling": "latest",
+    "knip": "^6.0.0",
+    "typescript": "^5.9.3",
+    "@types/node": "^26.0.1",
+    "@biomejs/biome": "^2.5.1",
+    "vitest": "^4.1.9",
+    "tsup": "^8.0.0",
+    "husky": "^9.0.0",
+    "lint-staged": "^16.0.0",
+    "@commitlint/cli": "^20.0.0",
+    "@commitlint/config-conventional": "^20.0.0",
+    "semantic-release": "^25.0.0",
+    "@semantic-release/github": "^12.0.0",
+    "@semantic-release/changelog": "^6.0.0",
+    "@semantic-release/git": "^10.0.0"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
+}
+"
+`;
+
+exports[`generator output snapshots > vitest.config.ts (node library) 1`] = `
+"import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./vitest.setup.ts']
+  }
+})
+"
+`;

--- a/tests/cli/generators/snapshot.test.ts
+++ b/tests/cli/generators/snapshot.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs-extra'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
+import { generateGitHubActions } from '../../../src/cli/generators/github-actions.js'
+import { generatePackageJson } from '../../../src/cli/generators/package-json.js'
+import { generateVitestConfig } from '../../../src/cli/generators/testing.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+// A representative library config. Snapshots lock the exact file contents these
+// generators produce, so any unintended change to generator output shows up as
+// a failing snapshot in review rather than slipping through unnoticed.
+function libConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+	return {
+		projectName: 'snapshot-lib',
+		projectType: 'library',
+		typescript: { enabled: true, config: 'base' },
+		linting: { tool: 'biome' },
+		formatting: { tool: 'biome' },
+		testing: { framework: 'vitest', environment: 'node' },
+		gitHooks: true,
+		commitLint: true,
+		semanticRelease: true,
+		securityAutomation: true,
+		bundler: 'tsup',
+		...overrides,
+	}
+}
+
+describe('generator output snapshots', () => {
+	it('package.json (library)', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(libConfig(), dir)
+		const content = await fs.readFile(join(dir, 'package.json'), 'utf-8')
+		expect(content).toMatchSnapshot()
+	})
+
+	it('.github/workflows/ci.yml (library)', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(libConfig(), dir)
+		const content = await fs.readFile(join(dir, '.github/workflows/ci.yml'), 'utf-8')
+		expect(content).toMatchSnapshot()
+	})
+
+	it('vitest.config.ts (node library)', async () => {
+		const dir = newTmpDir()
+		await generateVitestConfig(libConfig(), dir)
+		const content = await fs.readFile(join(dir, 'vitest.config.ts'), 'utf-8')
+		expect(content).toMatchSnapshot()
+	})
+})


### PR DESCRIPTION
Closes #82.

Adds vitest snapshot tests that run the generators into a temp dir and snapshot the resulting file contents, so a regression in any generator surfaces as a failing snapshot in review rather than needing manual spot-checks.

## Covered (highest-value per the issue)
- `package.json` (via `generatePackageJson`)
- `.github/workflows/ci.yml` (via `generateGitHubActions`)
- `vitest.config.ts` (via `generateVitestConfig`)

All for one representative library config. Output is deterministic (static templates + config; no timestamps or machine paths — verified the committed `.snap`).

Pure addition — no source changes, independent of the other open PRs. Full suite: **310 tests pass** (+3).

Follow-up (not blocking): biome.jsonc + tsconfig snapshots could be added once their generator entry points are wired the same way.