### PR TITLE
fix(peers): allow @commitlint/cli 21 to match config-conventional peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
 	},
 	"peerDependencies": {
 		"@biomejs/biome": "^2.0.0",
-		"@commitlint/cli": "^20.0.0",
+		"@commitlint/cli": "^20.0.0 || ^21.0.0",
 		"@commitlint/config-conventional": "^21.0.2",
 		"@commitlint/types": "^21.1.0",
 		"@eslint/js": "^9.0.0",


### PR DESCRIPTION
## Problem
The `peerDependencies` are internally inconsistent:

| peer | range |
|------|-------|
| `@commitlint/cli` | `^20.0.0` ← stale |
| `@commitlint/config-conventional` | `^21.0.2` |
| `@commitlint/types` | `^21.1.0` |

This package's own devDependency is `@commitlint/cli@^21.2.0`. Since commitlint's `cli` and `config-conventional` must share a major version, any consumer running the correct pairing (cli 21 + config 21) gets an **unmet-peer warning** on install.

## Fix
Widen the `@commitlint/cli` peer to `^20.0.0 || ^21.0.0` — backward-compatible for consumers still on 20, and silences the warning for those on 21.

## Impact
Clears the warning for every repo consuming js-tooling — api-common, browser-common, cf-common, db-common, react-common.

Reported in rtorcato/api-common#99.