### PR TITLE
docs: add Projects family nav dropdown + GitHub profile link

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -155,7 +155,7 @@ const config: Config = {
               label: 'License (MIT)',
               href: 'https://github.com/rtorcato/js-tooling/blob/main/LICENSE',
             },
-            { label: 'GitHub profile', href: GITHUB_PROFILE },
+            { label: '@rtorcato', href: GITHUB_PROFILE },
           ],
         },
       ],

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -2,6 +2,21 @@ import type * as Preset from '@docusaurus/preset-classic'
 import type { Config } from '@docusaurus/types'
 import { themes as prismThemes } from 'prism-react-renderer'
 
+// The @rtorcato open-source family. Surfaced as a navbar "Projects" dropdown
+// (Docusaurus renders navbar items in the mobile menu too) and in the footer,
+// so every sibling site cross-links to the rest. Keep in sync across repos.
+const GITHUB_PROFILE = 'https://github.com/rtorcato'
+const PROJECT_FAMILY = [
+  { label: 'js-common', href: 'https://rtorcato.github.io/js-common/' },
+  { label: 'api-common', href: 'https://rtorcato.github.io/api-common/' },
+  { label: 'browser-common', href: 'https://rtorcato.github.io/browser-common/' },
+  { label: 'db-common', href: 'https://rtorcato.github.io/db-common/' },
+  { label: 'cf-common', href: 'https://rtorcato.github.io/cf-common/' },
+  { label: 'react-common', href: 'https://github.com/rtorcato/react-common' },
+  { label: 'swift-common', href: 'https://rtorcato.github.io/swift-common/' },
+  { label: 'js-tooling', href: 'https://rtorcato.github.io/js-tooling/' },
+]
+
 const config: Config = {
   title: 'js-tooling',
   tagline: 'JavaScript and TypeScript tooling for Node.js, React, Next.js, and Vitest.',
@@ -90,6 +105,12 @@ const config: Config = {
         { to: '/docs/guides', position: 'left', label: 'Guides' },
         { to: '/docs/reference', position: 'left', label: 'Reference' },
         {
+          type: 'dropdown',
+          label: 'Projects',
+          position: 'left',
+          items: [{ label: 'All on GitHub →', href: GITHUB_PROFILE }, ...PROJECT_FAMILY],
+        },
+        {
           href: 'https://github.com/rtorcato/js-tooling',
           label: 'GitHub',
           position: 'right',
@@ -123,12 +144,8 @@ const config: Config = {
           ],
         },
         {
-          title: 'Sibling projects',
-          items: [
-            { label: 'js-common', href: 'https://rtorcato.github.io/js-common/' },
-            { label: 'browser-common', href: 'https://rtorcato.github.io/browser-common/' },
-            { label: 'swift-common', href: 'https://github.com/rtorcato/swift-common' },
-          ],
+          title: 'Projects',
+          items: PROJECT_FAMILY,
         },
         {
           title: 'Community',
@@ -138,6 +155,7 @@ const config: Config = {
               label: 'License (MIT)',
               href: 'https://github.com/rtorcato/js-tooling/blob/main/LICENSE',
             },
+            { label: 'GitHub profile', href: GITHUB_PROFILE },
           ],
         },
       ],


### PR DESCRIPTION
Adds a Projects navbar dropdown (also shown on mobile) and footer section linking the @rtorcato family, plus a GitHub profile link. Mirrors api-common.

Closes #175