### PR TITLE
docs: show full sibling family on landing grid

### DIFF
--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -348,27 +348,60 @@ type Sibling = {
 	href: string
 	/** Short label rendered in the card's top-right indicating where the link goes. */
 	dest: 'Docs' | 'GitHub'
+	/** Each project's brand hue used to tint the card title. */
+	accent: string
 }
 
 const SIBLINGS: Sibling[] = [
+	{
+		name: '@rtorcato/api-common',
+		tagline:
+			'Framework-agnostic building blocks for Node.js APIs — errors, auth, rate limiting, OpenAPI, Express + Hono.',
+		href: 'https://rtorcato.github.io/api-common/',
+		dest: 'Docs',
+		accent: '#e879f9',
+	},
+	{
+		name: '@rtorcato/browser-common',
+		tagline: 'Tree-shakeable TypeScript wrappers around 40+ browser Web APIs — one subpath per spec.',
+		href: 'https://rtorcato.github.io/browser-common/',
+		dest: 'Docs',
+		accent: '#58a6ff',
+	},
 	{
 		name: '@rtorcato/js-common',
 		tagline: 'Tree-shakeable TypeScript utilities — tiny bundles, full type safety, CLI included.',
 		href: 'https://rtorcato.github.io/js-common/',
 		dest: 'Docs',
+		accent: '#f2cc60',
 	},
 	{
-		name: '@rtorcato/browser-common',
-		tagline:
-			'Small, tree-shakeable TypeScript wrappers around 40+ browser Web APIs — one subpath per API.',
-		href: 'https://rtorcato.github.io/browser-common/',
+		name: '@rtorcato/db-common',
+		tagline: 'Shared, tree-shakeable TypeScript database utilities for Node projects.',
+		href: 'https://rtorcato.github.io/db-common/',
 		dest: 'Docs',
+		accent: '#a78bfa',
 	},
 	{
-		name: 'rtorcato/swift-common',
-		tagline: 'Common Swift utilities — the Apple-platform sibling of js-common and browser-common.',
-		href: 'https://github.com/rtorcato/swift-common',
+		name: '@rtorcato/cf-common',
+		tagline: 'Common helpers for Cloudflare developers — Workers, Pages, and the edge runtime.',
+		href: 'https://rtorcato.github.io/cf-common/',
+		dest: 'Docs',
+		accent: '#f6821f',
+	},
+	{
+		name: '@rtorcato/react-common',
+		tagline: 'Published React 19 component library — shared UI primitives.',
+		href: 'https://github.com/rtorcato/react-common',
 		dest: 'GitHub',
+		accent: '#818cf8',
+	},
+	{
+		name: '@rtorcato/swift-common',
+		tagline: 'SwiftUI package of reusable views and helpers to build apps faster.',
+		href: 'https://rtorcato.github.io/swift-common/',
+		dest: 'Docs',
+		accent: '#ff6f4d',
 	},
 ]
 
@@ -387,7 +420,9 @@ function Siblings(): ReactElement {
 				{SIBLINGS.map((s) => (
 					<Link key={s.name} href={s.href} className={styles.card}>
 						<div className={styles.cardHead}>
-							<div className={styles.cardName}>{s.name}</div>
+							<div className={styles.cardName} style={{ color: s.accent }}>
+								{s.name}
+							</div>
 							<div className={styles.cardCount}>{s.dest} ↗</div>
 						</div>
 						<p className={styles.cardDesc}>{s.tagline}</p>


### PR DESCRIPTION
Expands the landing Sibling projects grid to the full @rtorcato family (minus this repo) with brand-colored card titles, matching api-common.