### PR TITLE
fix(setup): close 4 CI scaffold gaps in generated workflows (#180)

### DIFF
--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -502,6 +502,7 @@ const FIXERS: Fixer[] = [
 			'apps/treeshake-check/package.json',
 			'apps/treeshake-check/check.mjs',
 			'apps/treeshake-check/src/entry.ts',
+			'pnpm-workspace.yaml',
 		],
 		riskLevel: 'safe-add',
 		canFixDrift: false,

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -216,7 +216,8 @@ export function computeFileList(config: ProjectConfig): string[] {
 		files.push(
 			'apps/treeshake-check/package.json',
 			'apps/treeshake-check/check.mjs',
-			'apps/treeshake-check/src/entry.ts'
+			'apps/treeshake-check/src/entry.ts',
+			'pnpm-workspace.yaml'
 		)
 	}
 	if (config.aiSetup) {

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -63,8 +63,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Generate cache key
         id: cache-key
@@ -98,8 +96,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -132,8 +128,6 @@ ${
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -165,8 +159,6 @@ ${
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -198,8 +190,6 @@ ${
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -253,8 +243,6 @@ ${
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -7,7 +7,7 @@ import { generateBuildConfigs } from './build.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
 import { generateLintingConfigs } from './linting.js'
-import { generateMiscBaseline } from './misc.js'
+import { generateKnipConfig, generateMiscBaseline } from './misc.js'
 import { generatePackageJson } from './package-json.js'
 import { generateReadme } from './readme.js'
 import { generateSecurityConfigs } from './security.js'
@@ -70,6 +70,10 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 				allowedSubpath: defaultAllowed,
 				forbiddenSubpaths: allCandidates.filter((s) => s !== defaultAllowed),
 			})
+			// treeshake-check writes pnpm-workspace.yaml; regenerate knip so it
+			// picks up the workspaces form (the baseline pass above ran before the
+			// workspace file existed and emitted the flat single-package form).
+			await generateKnipConfig(targetDir)
 		}
 	}
 

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -144,6 +144,30 @@ export async function ensureEnginesNode(
  *     trace and flag genuinely unreachable modules.
  * `.tsx` is included so React libraries aren't silently skipped.
  */
+/**
+ * Extract package globs from a pnpm-workspace.yaml `packages:` list without a
+ * YAML dependency. Matches `- 'apps/*'` / `- "apps/*"` / `- apps/*` entries
+ * under the `packages:` key, stopping at the next top-level key.
+ */
+function parseWorkspacePackages(yaml: string): string[] {
+	const globs: string[] = []
+	let inPackages = false
+	for (const line of yaml.split('\n')) {
+		if (/^packages:\s*$/.test(line)) {
+			inPackages = true
+			continue
+		}
+		if (!inPackages) continue
+		const item = line.match(/^\s*-\s*['"]?([^'"#]+?)['"]?\s*$/)
+		if (item) {
+			globs.push(item[1].trim())
+			continue
+		}
+		if (/^\S/.test(line)) break // a new top-level key ends the list
+	}
+	return globs
+}
+
 export async function buildKnipConfig(targetDir: string) {
 	const pkgPath = path.join(targetDir, 'package.json')
 	let multiEntry = false
@@ -156,11 +180,25 @@ export async function buildKnipConfig(targetDir: string) {
 			multiEntry = subpaths.length > 1
 		}
 	}
-	return {
-		$schema: 'https://unpkg.com/knip@6/schema.json',
-		entry: multiEntry ? ['src/**/*.{ts,tsx}'] : ['src/index.{ts,tsx}'],
-		project: ['src/**/*.{ts,tsx}'],
+
+	const $schema = 'https://unpkg.com/knip@6/schema.json'
+	const entry = multiEntry ? ['src/**/*.{ts,tsx}'] : ['src/index.{ts,tsx}']
+	const project = ['src/**/*.{ts,tsx}']
+
+	// In a pnpm workspace, the flat entry/project form makes `knip` mis-analyze
+	// the sub-packages (it treats the whole repo as one package). Emit the
+	// `workspaces` form instead: the root keeps the build-model globs, and each
+	// declared package glob gets `{}` so knip auto-detects its entries.
+	const wsPath = path.join(targetDir, 'pnpm-workspace.yaml')
+	if (await fs.pathExists(wsPath)) {
+		const workspaces: Record<string, unknown> = { '.': { entry, project } }
+		for (const glob of parseWorkspacePackages(await fs.readFile(wsPath, 'utf-8'))) {
+			workspaces[glob] = {}
+		}
+		return { $schema, workspaces }
 	}
+
+	return { $schema, entry, project }
 }
 
 export async function generateKnipConfig(targetDir: string) {

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -2,6 +2,11 @@ import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
 
+// Exact pnpm version for the `packageManager` field — corepack requires a
+// pinned `pnpm@x.y.z` (not a range), and it's the single source of truth for
+// pnpm/action-setup, so the generated workflows drop their `version:` inputs.
+const PNPM_VERSION = '11.1.3'
+
 export async function generatePackageJson(config: ProjectConfig, targetDir: string) {
 	const packageJsonPath = path.join(targetDir, 'package.json')
 
@@ -17,6 +22,7 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 		version: '0.1.0',
 		description: '',
 		type: 'module',
+		packageManager: `pnpm@${PNPM_VERSION}`,
 		...existingPackageJson,
 		scripts: {
 			...getScripts(config, { includeTreeshake }),

--- a/src/cli/generators/treeshake.ts
+++ b/src/cli/generators/treeshake.ts
@@ -92,6 +92,38 @@ function renderEntry(workspaceName: string, allowedSubpath: string): string {
 	return `export * from '${workspaceName}/${allowedSubpath}'\n`
 }
 
+// The treeshake-check app lives under apps/ and depends on the root package via
+// `workspace:*`, which only resolves when a pnpm-workspace.yaml declares apps/*.
+// pnpm 11 fails install (ERR_PNPM_IGNORED_BUILDS) on any dependency with an
+// unlisted build script, so approve the ones this monorepo shape needs:
+//   - esbuild: the tree-shake check builds with it
+//   - sharp:   pulled in by the common apps/docs (Docusaurus) path; built
+//   - core-js: also pulled by apps/docs, but its postinstall is unwanted → ignore
+// Listing a package that isn't installed is a harmless no-op, so seeding the
+// docs-path entries keeps `pnpm install` green the moment an apps/docs is added.
+const WORKSPACE_YAML = `packages:
+  - 'apps/*'
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+
+ignoredBuiltDependencies:
+  - core-js
+`
+
+/**
+ * Ensure a pnpm-workspace.yaml exists that globs apps/* (needed for the
+ * treeshake-check app's `workspace:*` dep to resolve). Never clobbers an
+ * existing file. Returns the relative path if written, else null.
+ */
+async function ensureWorkspaceYaml(targetDir: string): Promise<string | null> {
+	const wsPath = path.join(targetDir, 'pnpm-workspace.yaml')
+	if (await fs.pathExists(wsPath)) return null
+	await fs.writeFile(wsPath, WORKSPACE_YAML)
+	return 'pnpm-workspace.yaml'
+}
+
 export async function generateTreeshakeCheck(
 	targetDir: string,
 	opts: TreeshakeOptions
@@ -125,9 +157,14 @@ export async function generateTreeshakeCheck(
 	await fs.writeFile(checkPath, renderCheckScript(opts))
 	await fs.writeFile(entryPath, renderEntry(opts.workspaceName, opts.allowedSubpath))
 
-	return [
+	const written = [
 		path.join(appDir, 'package.json'),
 		path.join(appDir, 'check.mjs'),
 		path.join(appDir, 'src', 'entry.ts'),
 	]
+
+	const workspaceFile = await ensureWorkspaceYaml(targetDir)
+	if (workspaceFile) written.push(workspaceFile)
+
+	return written
 }

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -46,8 +46,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Generate cache key
         id: cache-key
@@ -81,8 +79,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -113,8 +109,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -142,8 +136,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -171,8 +163,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -222,8 +212,6 @@ jobs:
 
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: 📦 Restore dependencies cache
         uses: actions/cache@v5
@@ -253,6 +241,7 @@ exports[`generator output snapshots > package.json (library) 1`] = `
   "version": "0.1.0",
   "description": "",
   "type": "module",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -39,6 +39,15 @@ describe('generateGitHubActions', () => {
 		expect(content).not.toContain("node-version: '20'")
 	})
 
+	it('sets up pnpm without a version input (packageManager is the source of truth)', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig(), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).toContain('uses: pnpm/action-setup@v6')
+		expect(content).not.toContain('version: latest')
+	})
+
 	it('adds a publint step to the build job when publint is enabled', async () => {
 		const dir = newTmpDir()
 		await generateGitHubActions(baseConfig({ bundler: 'tsup', publint: true }), dir)

--- a/tests/cli/generators/misc.test.ts
+++ b/tests/cli/generators/misc.test.ts
@@ -110,6 +110,32 @@ describe('generateKnipConfig', () => {
 		expect(knip.entry).toEqual(['src/**/*.{ts,tsx}'])
 		expect(knip.project).toEqual(['src/**/*.{ts,tsx}'])
 	})
+
+	it('emits the workspaces form when a pnpm-workspace.yaml is present', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			exports: { '.': './dist/index.js' },
+		})
+		await fs.writeFile(
+			join(dir, 'pnpm-workspace.yaml'),
+			"packages:\n  - 'apps/*'\n  - 'packages/*'\n\nonlyBuiltDependencies:\n  - esbuild\n"
+		)
+		await generateKnipConfig(dir)
+		const knip = await fs.readJson(join(dir, 'knip.json'))
+		// flat entry/project are dropped in favour of per-workspace config
+		expect(knip.entry).toBeUndefined()
+		expect(knip.project).toBeUndefined()
+		expect(knip.workspaces['.']).toEqual({
+			entry: ['src/index.{ts,tsx}'],
+			project: ['src/**/*.{ts,tsx}'],
+		})
+		// package globs from `packages:` become workspace keys, not the
+		// unrelated onlyBuiltDependencies list below it
+		expect(knip.workspaces['apps/*']).toEqual({})
+		expect(knip.workspaces['packages/*']).toEqual({})
+		expect(knip.workspaces.esbuild).toBeUndefined()
+	})
 })
 
 describe('generateMiscBaseline', () => {

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -36,6 +36,8 @@ describe('generatePackageJson', () => {
 		expect(pkg.version).toBe('0.1.0')
 		expect(pkg.type).toBe('module')
 		expect(pkg.devDependencies['@rtorcato/js-tooling']).toBe('latest')
+		// packageManager is the single source of truth for pnpm/action-setup
+		expect(pkg.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+$/)
 	})
 
 	it('merges into an existing package.json, preserving existing name and version', async () => {
@@ -44,6 +46,7 @@ describe('generatePackageJson', () => {
 			name: 'existing-pkg',
 			version: '1.2.3',
 			description: 'keep me',
+			packageManager: 'pnpm@10.0.0',
 		})
 
 		await generatePackageJson(baseConfig(), dir)
@@ -53,6 +56,7 @@ describe('generatePackageJson', () => {
 		expect(pkg.name).toBe('existing-pkg')
 		expect(pkg.version).toBe('1.2.3')
 		expect(pkg.description).toBe('keep me')
+		expect(pkg.packageManager).toBe('pnpm@10.0.0')
 		// new devDependencies are still injected
 		expect(pkg.devDependencies['@rtorcato/js-tooling']).toBe('latest')
 	})

--- a/tests/cli/generators/treeshake.test.ts
+++ b/tests/cli/generators/treeshake.test.ts
@@ -51,10 +51,42 @@ describe('generateTreeshakeCheck', () => {
 			'apps/treeshake-check/package.json',
 			'apps/treeshake-check/check.mjs',
 			'apps/treeshake-check/src/entry.ts',
+			'pnpm-workspace.yaml',
 		])
 		expect(await fs.pathExists(join(dir, 'apps', 'treeshake-check', 'package.json'))).toBe(true)
 		expect(await fs.pathExists(join(dir, 'apps', 'treeshake-check', 'check.mjs'))).toBe(true)
 		expect(await fs.pathExists(join(dir, 'apps', 'treeshake-check', 'src', 'entry.ts'))).toBe(true)
+	})
+
+	it('writes a pnpm-workspace.yaml globbing apps/* so workspace:* resolves', async () => {
+		const dir = newTmpDir()
+		await generateTreeshakeCheck(dir, {
+			workspaceName: '@my-org/my-lib',
+			allowedSubpath: 'clipboard',
+			forbiddenSubpaths: [],
+		})
+		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
+		expect(ws).toContain("- 'apps/*'")
+		// esbuild must be build-approved workspace-wide (pnpm 11 ERR_PNPM_IGNORED_BUILDS)
+		expect(ws).toContain('onlyBuiltDependencies')
+		expect(ws).toContain('esbuild')
+		// docs-path (apps/docs) build approvals are seeded ahead of need
+		expect(ws).toContain('sharp')
+		expect(ws).toContain('ignoredBuiltDependencies')
+		expect(ws).toContain('core-js')
+	})
+
+	it('does not clobber an existing pnpm-workspace.yaml', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n")
+		const written = await generateTreeshakeCheck(dir, {
+			workspaceName: '@my-org/my-lib',
+			allowedSubpath: 'clipboard',
+			forbiddenSubpaths: [],
+		})
+		expect(written).not.toContain('pnpm-workspace.yaml')
+		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
+		expect(ws).toContain("- 'packages/*'")
 	})
 
 	it('bakes the workspace name + allowed subpath into entry.ts', async () => {


### PR DESCRIPTION
Closes #180.

Fresh `setup --preset library` output (js-tooling 2.29.1) plus a Docusaurus `apps/docs` app failed CI in four ways — each a scaffold bug, not consumer code. All four are fixed here.

## Changes

**1 — `packageManager` + `version: latest` (every generated repo)**
- `package-json.ts` writes `"packageManager": "pnpm@11.1.3"` (an existing value wins on merge).
- `github-actions.ts` drops all 6 `version: latest` inputs, so `packageManager` is the single source of truth for `pnpm/action-setup@v6`. Fixes both `No pnpm version is specified` (bare action-setup) and `ERR_PNPM_BAD_PM_VERSION` (double-specified).

**2 — missing `pnpm-workspace.yaml`**
- `treeshake.ts` scaffolded `apps/treeshake-check` with a `workspace:*` dep but never wrote a `pnpm-workspace.yaml`, so `pnpm install` couldn't resolve it. It now writes one (`packages: ['apps/*']`), **only when absent** — an existing file is never clobbered.

**3 — build approvals for the `apps/docs` path**
- The generated `pnpm-workspace.yaml` seeds `onlyBuiltDependencies: [esbuild, sharp]` + `ignoredBuiltDependencies: [core-js]`, so `pnpm install` stays green (`ERR_PNPM_IGNORED_BUILDS`) the moment a Docusaurus docs app is added. Listing absent packages is a no-op. Uses the real pnpm fields (not the invalid `allowBuilds` map).

**4 — knip `workspaces` form in a monorepo**
- `misc.ts` `buildKnipConfig` now detects `pnpm-workspace.yaml`, parses its `packages:` globs (no YAML dep), and emits knip's `workspaces` form (root keeps the build-model globs; each glob → `{}`).
- `setup` regenerates knip after the workspace file is created; `fix knip` picks it up on any existing monorepo.

Consistency: `computeFileList` (`--dry-run`) and the `treeshake-check` fix-target `outputs` both list `pnpm-workspace.yaml`.

## Note on part 2's report
The report's literal `pnpm-workspace.yaml` placeholder (`esbuild: set this to true or false`) is **not** emitted by js-tooling 2.29.1 — grepping the tree finds no generator producing that file or string. The real gap was the missing workspace file when the tree-shake check is enabled; that's what this fixes.

## Verification
- 330 tests pass (new tests for all four behaviors)
- `tsc --noEmit` clean
- `biome check` clean
- snapshot regenerated