### PR TITLE
test(ci): integration test for the library preset lifecycle (#99)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,40 @@ jobs:
           files: ./coverage/coverage-summary.json
           fail_ci_if_error: false
 
+  # Integration: scaffold the library preset and run its full consumer
+  # lifecycle (install → format → build → verify) against a pack of THIS tree.
+  # Catches scaffold defects that only surface on a real install/build — the
+  # class of bug that unit tests miss (#99). Runs on every supported Node major.
+  integration:
+    runs-on: ubuntu-latest
+    needs: [check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["22", "24"]
+    name: integration (node ${{ matrix.node-version }})
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🏗️ Build CLI
+        run: pnpm build-cli
+
+      - name: 🧩 Scaffold + install + verify the library preset
+        run: node scripts/integration/preset-lifecycle.mjs library
+
   # Build
   build:
     runs-on: ubuntu-latest
@@ -272,7 +306,7 @@ jobs:
   # Release and publish
   release:
     runs-on: ubuntu-latest
-    needs: [dependencies, lint, typecheck, test, build, varcheck, check-skip]
+    needs: [dependencies, lint, typecheck, test, integration, build, varcheck, check-skip]
     if: |
       always() &&
       needs.check-skip.outputs.should-skip != 'true' &&
@@ -281,6 +315,7 @@ jobs:
       needs.lint.result == 'success' &&
       needs.typecheck.result == 'success' &&
       needs.test.result == 'success' &&
+      needs.integration.result == 'success' &&
       needs.build.result == 'success' &&
       needs.varcheck.result == 'success'
     permissions:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"typecheck": "tsc --noEmit --project src/cli/tsconfig.json",
 		"test": "vitest",
 		"test:watch": "vitest --watch",
+		"test:integration": "pnpm build-cli && node scripts/integration/preset-lifecycle.mjs library",
 		"coverage": "vitest run --coverage",
 		"knip": "knip",
 		"commit": "cz",

--- a/scripts/integration/preset-lifecycle.mjs
+++ b/scripts/integration/preset-lifecycle.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Integration test: scaffold a preset with the CURRENT working tree, then run
+// the full consumer lifecycle (install → build → verify) against it. Catches
+// scaffold defects that only surface on a real install/build — the class of
+// bug tracked in #91–#99 that no unit test exercises.
+//
+// The scaffold's `@rtorcato/js-tooling` dep is repointed at a `pnpm pack`
+// tarball of this repo, so the test validates THIS branch's generated output +
+// presets, not whatever `latest` is on npm.
+//
+// Usage: node scripts/integration/preset-lifecycle.mjs [preset]   (default: library)
+// Requires: `pnpm build-cli` first, and network access to the npm registry.
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const REPO = process.cwd()
+const CLI = path.join(REPO, 'dist', 'cli', 'index.js')
+const PRESET = process.argv[2] ?? 'library'
+
+// Only `library` is wired end-to-end today; other presets join once green (#99).
+const SUPPORTED = new Set(['library'])
+
+function run(cmd, args, cwd) {
+	console.log(`\n$ ${cmd} ${args.join(' ')}${cwd && cwd !== REPO ? `  (cwd=${cwd})` : ''}`)
+	execFileSync(cmd, args, { stdio: 'inherit', cwd: cwd ?? REPO })
+}
+
+function fail(msg) {
+	console.error(`\n❌ ${msg}`)
+	process.exit(1)
+}
+
+if (!SUPPORTED.has(PRESET))
+	fail(`preset "${PRESET}" is not wired for integration yet (have: ${[...SUPPORTED].join(', ')})`)
+if (!fs.existsSync(CLI)) fail(`CLI not built at ${CLI} — run "pnpm build-cli" first`)
+
+const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jst-pack-'))
+const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `jst-${PRESET}-`))
+
+try {
+	// 1. Pack the working tree so the scaffold tests local code, not npm's latest.
+	run('pnpm', ['pack', '--pack-destination', packDir])
+	const tgz = fs.readdirSync(packDir).find((f) => f.endsWith('.tgz'))
+	if (!tgz) fail('pnpm pack produced no tarball')
+	const tarball = path.join(packDir, tgz)
+
+	// 2. Scaffold the preset (files only; we install ourselves after repointing the dep).
+	run('node', [CLI, 'setup', '--preset', PRESET, '--directory', projectDir, '--skip-install'])
+
+	// 3. Repoint @rtorcato/js-tooling at the local tarball.
+	const pkgPath = path.join(projectDir, 'package.json')
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+	if (!pkg.devDependencies?.['@rtorcato/js-tooling'])
+		fail('scaffold has no @rtorcato/js-tooling devDependency')
+	pkg.devDependencies['@rtorcato/js-tooling'] = `file:${tarball}`
+	fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
+
+	// 4. Seed what a real consumer writes: an entry module + one test. The base
+	// tsconfig excludes *.test.ts, so the test is exercised by vitest, not tsc.
+	const srcDir = path.join(projectDir, 'src')
+	fs.mkdirSync(srcDir, { recursive: true })
+	fs.writeFileSync(
+		path.join(srcDir, 'index.ts'),
+		'export const greet = (name: string): string => `hello ${name}`\n'
+	)
+	fs.writeFileSync(
+		path.join(srcDir, 'index.test.ts'),
+		"import { expect, it } from 'vitest'\nimport { greet } from './index'\n\nit('greets', () => {\n\texpect(greet('world')).toBe('hello world')\n})\n"
+	)
+
+	// 5. git init so husky's `prepare` hook has a repo to attach to.
+	run('git', ['init', '-q'], projectDir)
+
+	// 6. Install (fresh scaffold has no lockfile, so not --frozen).
+	run('pnpm', ['install'], projectDir)
+
+	// 7. Format generated files — mirrors what `setup` does post-install (the
+	//    scaffold's biome/prettier config; templates are hand-written).
+	run('pnpm', ['exec', 'biome', 'check', '--write', '.'], projectDir)
+
+	// 8. Build.
+	run('pnpm', ['build'], projectDir)
+
+	// 9. Every path the package advertises (main/module/types/exports) must exist
+	//    on disk after the build — the #92 exports/output mismatch class.
+	const built = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+	const advertised = new Set()
+	for (const field of ['main', 'module', 'types']) {
+		if (typeof built[field] === 'string') advertised.add(built[field])
+	}
+	const collect = (v) => {
+		if (typeof v === 'string') {
+			if (v.startsWith('./')) advertised.add(v)
+		} else if (v && typeof v === 'object') {
+			for (const inner of Object.values(v)) collect(inner)
+		}
+	}
+	collect(built.exports)
+	const missing = [...advertised].filter((rel) => !fs.existsSync(path.join(projectDir, rel)))
+	if (missing.length > 0)
+		fail(`package.json points at files that don't exist after build:\n  ${missing.join('\n  ')}`)
+	console.log(`\n✅ all ${advertised.size} advertised entry paths exist`)
+
+	// 10. Full verify chain (typecheck + lint + test + publint for the library preset).
+	run('pnpm', ['verify'], projectDir)
+
+	console.log(`\n✅ ${PRESET} preset lifecycle passed`)
+	fs.rmSync(packDir, { recursive: true, force: true })
+	fs.rmSync(projectDir, { recursive: true, force: true })
+} catch (err) {
+	// Leave the throwaway dirs in place on failure for debugging.
+	console.error(`\n❌ ${PRESET} preset lifecycle failed. Inspect: ${projectDir}`)
+	console.error(err instanceof Error ? err.message : err)
+	process.exit(1)
+}

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -216,9 +216,15 @@ export function computeFileList(config: ProjectConfig): string[] {
 		files.push(
 			'apps/treeshake-check/package.json',
 			'apps/treeshake-check/check.mjs',
-			'apps/treeshake-check/src/entry.ts',
-			'pnpm-workspace.yaml'
+			'apps/treeshake-check/src/entry.ts'
 		)
+	}
+	// pnpm-workspace.yaml carries pnpm 11 build-script approvals (esbuild) and,
+	// for the treeshake path, the apps/* glob. Written whenever either applies.
+	const bundlerNeedsEsbuild =
+		config.bundler === 'tsup' || config.bundler === 'esbuild' || config.bundler === 'vite'
+	if (bundlerNeedsEsbuild || (config.treeshakeCheck && config.projectType === 'library')) {
+		files.push('pnpm-workspace.yaml')
 	}
 	if (config.aiSetup) {
 		files.push(

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { generateConfigs } from '../generators/index.js'
+import { formatGeneratedFiles } from '../utils/format.js'
 import { installDependencies } from '../utils/install.js'
 import { LOCKFILE_NAME, writeLockfile } from '../utils/lockfile.js'
 import {
@@ -119,6 +120,10 @@ export async function setupProject(options: SetupOptions) {
 		if (!options.skipInstall) {
 			console.log(chalk.cyan('\n📦 Installing dependencies...\n'))
 			await installDependencies(config, targetDir)
+			// Format now that the linter/formatter is installed, so the scaffold
+			// passes its own `pnpm check` out of the box (templates are written by
+			// hand and don't match biome/prettier whitespace).
+			await formatGeneratedFiles(config, targetDir)
 		}
 
 		console.log(chalk.green('\n✅ Setup completed successfully!\n'))

--- a/src/cli/generators/build.ts
+++ b/src/cli/generators/build.ts
@@ -2,6 +2,40 @@ import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
 
+// tsup, esbuild, and vite all pull in esbuild, whose install-time build script
+// pnpm 11 refuses to run until it's approved — otherwise `pnpm install` fails
+// with ERR_PNPM_IGNORED_BUILDS.
+export function bundlerNeedsEsbuild(config: ProjectConfig): boolean {
+	return config.bundler === 'tsup' || config.bundler === 'esbuild' || config.bundler === 'vite'
+}
+
+// pnpm 11 reads build-script approvals from the `allowBuilds` map (package →
+// boolean), NOT the older `onlyBuiltDependencies` list — verified against the
+// pinned pnpm@11.1.3, which ignores the list form and errors with
+// ERR_PNPM_IGNORED_BUILDS.
+const SINGLE_PACKAGE_BUILD_APPROVALS = `allowBuilds:
+  esbuild: true
+`
+
+/**
+ * pnpm 11 no longer reads build-script approvals from package.json's `pnpm`
+ * field — they live in pnpm-workspace.yaml. For a single-package esbuild-backed
+ * build, write a minimal pnpm-workspace.yaml approving esbuild. Never clobbers
+ * an existing file (the treeshake-check path writes a richer one that already
+ * lists esbuild). Must run after that path so its file wins. Returns the
+ * relative path if written, else null.
+ */
+export async function ensureBuildApprovals(
+	config: ProjectConfig,
+	targetDir: string
+): Promise<string | null> {
+	if (!bundlerNeedsEsbuild(config)) return null
+	const wsPath = path.join(targetDir, 'pnpm-workspace.yaml')
+	if (await fs.pathExists(wsPath)) return null
+	await fs.writeFile(wsPath, SINGLE_PACKAGE_BUILD_APPROVALS)
+	return 'pnpm-workspace.yaml'
+}
+
 export async function generateBuildConfigs(config: ProjectConfig, targetDir: string) {
 	if (config.bundler === 'tsup') {
 		await generateTsupConfig(targetDir)

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { ProjectConfig } from '../commands/setup.js'
 import { installAiSetup } from './agent-rules.js'
-import { generateBuildConfigs } from './build.js'
+import { ensureBuildApprovals, generateBuildConfigs } from './build.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
 import { generateLintingConfigs } from './linting.js'
@@ -76,6 +76,11 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 			await generateKnipConfig(targetDir)
 		}
 	}
+
+	// Approve esbuild's build script for pnpm 11 via pnpm-workspace.yaml. Runs
+	// after the treeshake-check path so its richer workspace file (if written)
+	// is never clobbered.
+	await ensureBuildApprovals(config, targetDir)
 
 	// AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example)
 	if (config.aiSetup) {

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -62,15 +62,9 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 		}
 	}
 
-	// pnpm 11 refuses to run a dependency's build script unless it's approved.
-	// esbuild (pulled in by tsup/esbuild/vite) has one, so `pnpm install` exits
-	// 1 with ERR_PNPM_IGNORED_BUILDS until it's whitelisted here.
-	if (config.bundler === 'tsup' || config.bundler === 'esbuild' || config.bundler === 'vite') {
-		packageJson.pnpm = {
-			...(packageJson.pnpm as Record<string, unknown> | undefined),
-			onlyBuiltDependencies: ['esbuild'],
-		}
-	}
+	// Build-script approvals (esbuild etc.) are NOT written here: pnpm 11 ignores
+	// package.json's `pnpm` field and reads them from pnpm-workspace.yaml instead
+	// (see ensureBuildApprovals in build.ts).
 
 	await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 })
 }

--- a/src/cli/generators/treeshake.ts
+++ b/src/cli/generators/treeshake.ts
@@ -95,21 +95,21 @@ function renderEntry(workspaceName: string, allowedSubpath: string): string {
 // The treeshake-check app lives under apps/ and depends on the root package via
 // `workspace:*`, which only resolves when a pnpm-workspace.yaml declares apps/*.
 // pnpm 11 fails install (ERR_PNPM_IGNORED_BUILDS) on any dependency with an
-// unlisted build script, so approve the ones this monorepo shape needs:
+// unapproved build script, approved via the `allowBuilds` map (package →
+// boolean — pnpm 11 ignores the older `onlyBuiltDependencies` list). Approve
+// the ones this monorepo shape needs:
 //   - esbuild: the tree-shake check builds with it
 //   - sharp:   pulled in by the common apps/docs (Docusaurus) path; built
-//   - core-js: also pulled by apps/docs, but its postinstall is unwanted → ignore
-// Listing a package that isn't installed is a harmless no-op, so seeding the
+//   - core-js: also pulled by apps/docs, but its postinstall is unwanted → false
+// Naming a package that isn't installed is a harmless no-op, so seeding the
 // docs-path entries keeps `pnpm install` green the moment an apps/docs is added.
 const WORKSPACE_YAML = `packages:
   - 'apps/*'
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
-
-ignoredBuiltDependencies:
-  - core-js
+allowBuilds:
+  esbuild: true
+  sharp: true
+  core-js: false
 `
 
 /**

--- a/src/cli/utils/format.ts
+++ b/src/cli/utils/format.ts
@@ -1,0 +1,40 @@
+import chalk from 'chalk'
+import { spawn } from 'node:child_process'
+import type { ProjectConfig } from '../commands/setup.js'
+
+function run(cmd: string, args: string[], cwd: string): Promise<number> {
+	return new Promise((resolve) => {
+		const child = spawn(cmd, args, { cwd, stdio: 'inherit', shell: true })
+		child.on('close', (code) => resolve(code ?? 1))
+		child.on('error', () => resolve(1))
+	})
+}
+
+/**
+ * Generated config files come from hand-built templates whose whitespace doesn't
+ * match the project's shipped formatter (biome collapses JSON arrays and uses
+ * tabs + trailing commas). Run the formatter once, post-install, so a fresh
+ * scaffold passes its own `pnpm check` / lint out of the box instead of failing
+ * on the consumer's first verify. Best-effort: never fails setup.
+ */
+export async function formatGeneratedFiles(
+	config: ProjectConfig,
+	targetDir: string
+): Promise<void> {
+	const usesBiome = config.linting.tool === 'biome' || config.linting.tool === 'both'
+	const usesEslint = config.linting.tool === 'eslint' || config.linting.tool === 'both'
+
+	if (usesBiome) {
+		await run('pnpm', ['exec', 'biome', 'check', '--write', '.'], targetDir)
+	}
+	if (config.formatting.tool === 'prettier') {
+		await run('pnpm', ['exec', 'prettier', '--write', '.'], targetDir)
+	}
+	if (usesEslint) {
+		await run('pnpm', ['exec', 'eslint', '.', '--fix'], targetDir)
+	}
+
+	if (usesBiome || usesEslint || config.formatting.tool === 'prettier') {
+		console.log(chalk.green('✨ Formatted generated files'))
+	}
+}

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -295,11 +295,6 @@ exports[`generator output snapshots > package.json (library) 1`] = `
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }
 "

--- a/tests/cli/generators/build.test.ts
+++ b/tests/cli/generators/build.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
-import { generateBuildConfigs } from '../../../src/cli/generators/build.js'
+import { ensureBuildApprovals, generateBuildConfigs } from '../../../src/cli/generators/build.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -118,5 +118,45 @@ describe('generateBuildConfigs', () => {
 		expect(await fs.pathExists(join(dir, 'vite.config.ts'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'release.config.mjs'))).toBe(false)
 		expect(await fs.pathExists(join(dir, '.changeset/config.json'))).toBe(false)
+	})
+})
+
+describe('ensureBuildApprovals', () => {
+	it('writes pnpm-workspace.yaml with an allowBuilds map for esbuild bundlers', async () => {
+		for (const bundler of ['tsup', 'esbuild', 'vite'] as const) {
+			const dir = newTmpDir()
+			const written = await ensureBuildApprovals(baseConfig({ bundler }), dir)
+			expect(written).toBe('pnpm-workspace.yaml')
+			const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
+			// pnpm 11 reads the allowBuilds map, not the onlyBuiltDependencies list.
+			expect(ws).toContain('allowBuilds:')
+			expect(ws).toContain('esbuild: true')
+			expect(ws).not.toContain('onlyBuiltDependencies')
+		}
+	})
+
+	it('does nothing for bundlers without an esbuild build script', async () => {
+		const dir = newTmpDir()
+		expect(await ensureBuildApprovals(baseConfig({ bundler: 'rollup' }), dir)).toBeNull()
+		expect(await ensureBuildApprovals(baseConfig({ bundler: 'none' }), dir)).toBeNull()
+		expect(await fs.pathExists(join(dir, 'pnpm-workspace.yaml'))).toBe(false)
+	})
+
+	it('never clobbers an existing pnpm-workspace.yaml (treeshake path owns it)', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		const written = await ensureBuildApprovals(baseConfig({ bundler: 'tsup' }), dir)
+		expect(written).toBeNull()
+		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
+		expect(ws).toBe("packages:\n  - 'apps/*'\n")
+	})
+
+	it('the shipped tsup preset applies customOptions (regression: dropped entry)', async () => {
+		const preset = await fs.readFile(join(process.cwd(), 'tooling/tsup/index.mjs'), 'utf-8')
+		// The old `defineConfig((options = customOptions) => ...)` default was
+		// bypassed by tsup and silently dropped the consumer's config; the
+		// callback must take tsup's options and spread customOptions in explicitly.
+		expect(preset).not.toMatch(/defineConfig\(\(options = customOptions\)/)
+		expect(preset).toContain('...customOptions')
 	})
 })

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -77,7 +77,7 @@ describe('generatePackageJson', () => {
 		expect(pkg.publishConfig.access).toBe('public')
 	})
 
-	it('approves esbuild build and installs release plugins for a library', async () => {
+	it('installs release plugins and does NOT write build approvals to package.json', async () => {
 		const dir = newTmpDir()
 		await generatePackageJson(
 			baseConfig({ projectType: 'library', bundler: 'tsup', semanticRelease: true }),
@@ -85,8 +85,9 @@ describe('generatePackageJson', () => {
 		)
 
 		const pkg = await fs.readJson(join(dir, 'package.json'))
-		// pnpm 11 blocks esbuild's build script (pulled via tsup) unless approved.
-		expect(pkg.pnpm.onlyBuiltDependencies).toContain('esbuild')
+		// Build approvals live in pnpm-workspace.yaml (allowBuilds) — pnpm 11
+		// ignores the package.json `pnpm` field — so it must not be written here.
+		expect(pkg.pnpm).toBeUndefined()
 		// The github release preset activates the changelog + git plugins.
 		expect(pkg.devDependencies['@semantic-release/changelog']).toBeDefined()
 		expect(pkg.devDependencies['@semantic-release/git']).toBeDefined()

--- a/tests/cli/generators/treeshake.test.ts
+++ b/tests/cli/generators/treeshake.test.ts
@@ -67,13 +67,13 @@ describe('generateTreeshakeCheck', () => {
 		})
 		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
 		expect(ws).toContain("- 'apps/*'")
-		// esbuild must be build-approved workspace-wide (pnpm 11 ERR_PNPM_IGNORED_BUILDS)
-		expect(ws).toContain('onlyBuiltDependencies')
-		expect(ws).toContain('esbuild')
+		// Build approvals use the allowBuilds map (pnpm 11 ignores the older
+		// onlyBuiltDependencies list → ERR_PNPM_IGNORED_BUILDS).
+		expect(ws).toContain('allowBuilds')
+		expect(ws).toContain('esbuild: true')
 		// docs-path (apps/docs) build approvals are seeded ahead of need
-		expect(ws).toContain('sharp')
-		expect(ws).toContain('ignoredBuiltDependencies')
-		expect(ws).toContain('core-js')
+		expect(ws).toContain('sharp: true')
+		expect(ws).toContain('core-js: false')
 	})
 
 	it('does not clobber an existing pnpm-workspace.yaml', async () => {

--- a/tooling/tsup/index.mjs
+++ b/tooling/tsup/index.mjs
@@ -1,8 +1,16 @@
 import { defineConfig } from 'tsup'
 
 export const getConfig = (customOptions, env) => {
-	return defineConfig((options = customOptions) => {
-		return baseOptions(options, env)
+	// tsup invokes this callback with its own CLI options, so `customOptions`
+	// must be merged in explicitly — a `(options = customOptions)` default is
+	// bypassed and silently drops the consumer's config (e.g. `entry`). Layer
+	// only the DEFINED CLI overrides on top so flags like `--watch` still win
+	// without an absent `entry: undefined` clobbering the consumer's entry.
+	return defineConfig((cliOptions) => {
+		const overrides = Object.fromEntries(
+			Object.entries(cliOptions ?? {}).filter(([, value]) => value !== undefined)
+		)
+		return baseOptions({ ...customOptions, ...overrides }, env)
 	})
 }
 
@@ -11,7 +19,9 @@ export const baseOptions = (options, env) => {
 		treeshake: true,
 		splitting: true,
 		format: ['cjs', 'esm'], // generate cjs and esm files
-		entry: ['src/**/*.ts'],
+		// Default to all of src EXCEPT tests, so a consumer that doesn't pass an
+		// explicit entry never ships compiled *.test.* / *.spec.* files in dist.
+		entry: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.spec.ts'],
 		skipNodeModulesBundle: true, // Skips building dependencies for node modules
 		minify: !options.watch && env === 'production',
 		bundle: false,


### PR DESCRIPTION
Closes #99.

## What

Adds a CI integration test that scaffolds the `library` preset against a `pnpm pack` of the working tree, then runs the full consumer lifecycle on **Node 22 and 24**:

`setup --preset library` → repoint `@rtorcato/js-tooling` at the local tarball → seed `src/index.ts` + a test → `pnpm install` → format → `pnpm build` → assert every `main`/`module`/`types`/`exports` path exists → `pnpm verify` (typecheck + biome + vitest + publint).

- Harness: `scripts/integration/preset-lifecycle.mjs` (`pnpm test:integration`)
- CI: new `integration (node 22|24)` job; **release is gated on it**.

## Defects the harness caught (and this PR fixes)

Writing the test immediately surfaced three real, currently-shipping defects — exactly the point of #99:

1. **pnpm 11 build approvals used the wrong setting.** pnpm 11.1.3 reads the `allowBuilds` map, **not** the `onlyBuiltDependencies` list, so esbuild's build was ignored and `pnpm install` failed with `ERR_PNPM_IGNORED_BUILDS`. Approvals now go to `pnpm-workspace.yaml` via `ensureBuildApprovals` (dead package.json `pnpm` field removed). This also corrects the treeshake path's workspace file, which #180 had written with the list form.
2. **Generated config files failed the scaffold's own `biome check`** (hand-written whitespace vs biome's tabs/array-collapsing). `setup` now formats generated files post-install, so a fresh scaffold is clean out of the box — fixes all presets, not just library.
3. **Shared `tooling/tsup` `getConfig` dropped the consumer's options.** tsup invokes the callback with its own options, so the `(options = customOptions)` default was bypassed and `entry` fell back to `src/**/*.ts`, compiling **test files into `dist/`** (which vitest then picked up). Now merges `customOptions` explicitly and excludes `*.test`/`*.spec` from the default entry.

## Verification

- `pnpm test:integration` → **library preset lifecycle passes** locally.
- 334 unit tests, typecheck, biome all green. Snapshot + affected generator tests updated.

## Follow-ups

Other presets (`node`, `react`, `next`, `web-app`) should join the matrix once library is green — they likely have analogous gaps.