### PR TITLE
feat(cli): grouped dependabot defaults + drift detection

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -809,7 +809,20 @@ async function checkReleaseToken(dir: string): Promise<CheckResult> {
 
 async function checkDependabot(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
-		if (await fs.pathExists(path.join(dir, candidate))) {
+		const candidatePath = path.join(dir, candidate)
+		if (await fs.pathExists(candidatePath)) {
+			// A config with no `groups:` predates the grouping/ignore defaults — a lone
+			// react-dom or TypeScript-major bump can never pass CI. Flag as drift so
+			// `fix dependabot` can bring it up to standard.
+			const content = await fs.readFile(candidatePath, 'utf8')
+			if (!/^\s*groups:/m.test(content)) {
+				return {
+					check: 'Dependabot',
+					status: 'drift',
+					detail: `${candidate} missing recommended dependency grouping`,
+					hint: 'Run `npx @rtorcato/js-tooling fix dependabot` to add grouping + ignore rules',
+				}
+			}
 			return {
 				check: 'Dependabot',
 				status: 'ok',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -343,9 +343,10 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'dependabot',
-		description: 'Scaffold .github/dependabot.yml (weekly npm + actions updates)',
+		description: 'Scaffold .github/dependabot.yml (weekly npm + actions updates, grouped)',
 		appliesTo: ['Dependabot'],
 		outputs: ['.github/dependabot.yml'],
+		canFixDrift: true,
 		async run({ targetDir }) {
 			await generateDependabotConfig(targetDir)
 			return { filesWritten: ['.github/dependabot.yml'] }

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -16,6 +16,28 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # TypeScript majors remove config options (7.0 dropped baseUrl) — a deliberate
+    # migration, not a dependabot bump. Take minor/patch only.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+    groups:
+      # react + react-dom must move in lockstep (React errors on mismatched versions),
+      # so group them; a lone react-dom bump can never pass CI. Inert in non-React repos.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # Fold every other minor/patch bump into one weekly PR to cut noise.
+      # Majors stay as individual PRs so breaking changes are reviewed on their own.
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -60,10 +60,7 @@ describe('doctor', () => {
 	it('detects biome.jsonc and eslint configs that import our presets', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.writeFile(
-			join(dir, 'biome.jsonc'),
-			'{ "extends": ["@rtorcato/js-tooling/biome"] }\n'
-		)
+		await fs.writeFile(join(dir, 'biome.jsonc'), '{ "extends": ["@rtorcato/js-tooling/biome"] }\n')
 		await fs.writeFile(
 			join(dir, 'eslint.config.mjs'),
 			"export { default } from '@rtorcato/js-tooling/eslint/base'\n"
@@ -243,7 +240,10 @@ describe('doctor extended checks', () => {
 		let results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('optional-missing')
 
-		await fs.writeFile(join(dir, 'AGENTS.md'), '<!-- js-tooling:start -->\nx\n<!-- js-tooling:end -->\n')
+		await fs.writeFile(
+			join(dir, 'AGENTS.md'),
+			'<!-- js-tooling:start -->\nx\n<!-- js-tooling:end -->\n'
+		)
 		results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('ok')
 	})
@@ -520,10 +520,7 @@ describe('doctor extended checks', () => {
 			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
 		})
 		await fs.ensureDir(join(dir, 'apps', 'treeshake-check'))
-		await fs.writeFile(
-			join(dir, 'apps', 'treeshake-check', 'check.mjs'),
-			'// stub\n'
-		)
+		await fs.writeFile(join(dir, 'apps', 'treeshake-check', 'check.mjs'), '// stub\n')
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Tree-shake check')?.status).toBe('ok')
 	})
@@ -547,11 +544,25 @@ describe('doctor security checks', () => {
 		expect(dep?.hint).toMatch(/fix dependabot/)
 	})
 
-	it('reports Dependabot ok when .github/dependabot.yml exists', async () => {
+	it('reports Dependabot drift when dependabot.yml exists but has no grouping', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.github'))
 		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
+		const results = await runDoctor(dir)
+		const dep = results.find((r) => r.check === 'Dependabot')
+		expect(dep?.status).toBe('drift')
+		expect(dep?.hint).toMatch(/fix dependabot/)
+	})
+
+	it('reports Dependabot ok when dependabot.yml has a groups block', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github'))
+		await fs.writeFile(
+			join(dir, '.github', 'dependabot.yml'),
+			'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    groups:\n      all:\n        patterns: ["*"]\n'
+		)
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('ok')
 	})
@@ -628,10 +639,7 @@ describe('doctor CODEOWNERS', () => {
 })
 
 describe('doctor + lockfile', () => {
-	async function writeLock(
-		dir: string,
-		configPatch: Record<string, unknown> = {}
-	): Promise<void> {
+	async function writeLock(dir: string, configPatch: Record<string, unknown> = {}): Promise<void> {
 		const config = {
 			projectName: 'demo',
 			projectType: 'library',
@@ -775,12 +783,8 @@ describe('nextStepSuggestions', () => {
 			{ check: 'ESLint', status: 'optional-missing', detail: '' },
 			{ check: 'TypeScript', status: 'missing', detail: '' },
 		])
-		expect(suggestions).toContain(
-			'Run `npx @rtorcato/js-tooling fix biome` to align Biome'
-		)
-		expect(suggestions).toContain(
-			'Run `npx @rtorcato/js-tooling fix eslint` to scaffold ESLint'
-		)
+		expect(suggestions).toContain('Run `npx @rtorcato/js-tooling fix biome` to align Biome')
+		expect(suggestions).toContain('Run `npx @rtorcato/js-tooling fix eslint` to scaffold ESLint')
 		expect(suggestions).toContain(
 			'Run `npx @rtorcato/js-tooling fix tsconfig` to scaffold TypeScript'
 		)
@@ -815,9 +819,7 @@ describe('nextStepSuggestions', () => {
 	})
 
 	it('skips checks with no registered fix target', () => {
-		const suggestions = nextStepSuggestions([
-			{ check: 'Node', status: 'drift', detail: '' },
-		])
+		const suggestions = nextStepSuggestions([{ check: 'Node', status: 'drift', detail: '' }])
 		expect(suggestions).toEqual([])
 	})
 

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -12,6 +12,11 @@ vi.mock('inquirer', () => ({
 const promptMock = vi.mocked(inquirer.prompt)
 const newTmpDir = useTmpDir()
 
+// A dependabot.yml with a `groups:` block reads as up-to-date (no drift), so the
+// fixer treats it as already-ok and leaves it alone.
+const GROUPED_DEPENDABOT =
+	'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    groups:\n      all:\n        patterns: ["*"]\n'
+
 async function seedPackageJson(dir: string, extra: Record<string, unknown> = {}) {
 	await fs.writeJson(join(dir, 'package.json'), {
 		name: 'demo',
@@ -59,7 +64,9 @@ describe('fix --list', () => {
 			const payload = JSON.parse(lastJson)
 			expect(Array.isArray(payload.targets)).toBe(true)
 			expect(payload.targets.length).toBeGreaterThan(10)
-			expect(payload.targets.find((t: { target: string }) => t.target === 'codeowners')).toBeTruthy()
+			expect(
+				payload.targets.find((t: { target: string }) => t.target === 'codeowners')
+			).toBeTruthy()
 		} finally {
 			logSpy.mockRestore()
 		}
@@ -119,11 +126,21 @@ describe('fix targeted', () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.writeJson(join(dir, 'renovate.json'), { extends: ['config:recommended'] })
-		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
+		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
 		await fixCommand('dependabot', { directory: dir, yes: true })
 		// dependabot.yml should remain untouched (no overwrite) and no error thrown.
 		const yaml = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
-		expect(yaml).toBe('version: 2\n')
+		expect(yaml).toBe(GROUPED_DEPENDABOT)
+	})
+
+	it('fix dependabot upgrades an existing config that lacks grouping', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
+		await fixCommand('dependabot', { directory: dir, yes: true })
+		const yaml = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
+		expect(yaml).toMatch(/^\s*groups:/m)
+		expect(yaml).toMatch(/dependency-name: "typescript"/)
 	})
 
 	it('fix unknown-target exits non-zero', async () => {
@@ -527,9 +544,7 @@ describe('fix targeted', () => {
 			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
 		})
 		await fixCommand('treeshake-check', { directory: dir, yes: true })
-		expect(
-			await fs.pathExists(join(dir, 'apps', 'treeshake-check', 'check.mjs'))
-		).toBe(true)
+		expect(await fs.pathExists(join(dir, 'apps', 'treeshake-check', 'check.mjs'))).toBe(true)
 		const entry = await fs.readFile(
 			join(dir, 'apps', 'treeshake-check', 'src', 'entry.ts'),
 			'utf-8'
@@ -546,9 +561,7 @@ describe('fix targeted', () => {
 			devDependencies: { '@rtorcato/js-tooling': '^2.0.0' },
 		})
 		await fixCommand('treeshake-check', { directory: dir, yes: true })
-		expect(
-			await fs.pathExists(join(dir, 'apps', 'treeshake-check'))
-		).toBe(false)
+		expect(await fs.pathExists(join(dir, 'apps', 'treeshake-check'))).toBe(false)
 	})
 
 	it('fix verify --yes appends pnpm treeshake when apps/treeshake-check exists', async () => {
@@ -583,7 +596,7 @@ describe('fix targeted', () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.github'))
-		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
+		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
 		// Should not call inquirer at all.
 		await fixCommand('dependabot', { directory: dir })
 		expect(promptMock).not.toHaveBeenCalled()
@@ -623,9 +636,9 @@ describe('fix --json', () => {
 			throw new Error('exit')
 		}) as never)
 		try {
-			await expect(
-				fixCommand('not-a-target', { directory: dir, json: true })
-			).rejects.toThrow('exit')
+			await expect(fixCommand('not-a-target', { directory: dir, json: true })).rejects.toThrow(
+				'exit'
+			)
 			const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
 			expect(payload.error).toBe('unknown-target')
 			expect(payload.target).toBe('not-a-target')
@@ -672,7 +685,7 @@ describe('fix --json', () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.github'))
-		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
+		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await fixCommand('dependabot', { directory: dir, json: true })
@@ -685,10 +698,7 @@ describe('fix --json', () => {
 })
 
 describe('fix + lockfile', () => {
-	async function writeLock(
-		dir: string,
-		configPatch: Record<string, unknown> = {}
-	): Promise<void> {
+	async function writeLock(dir: string, configPatch: Record<string, unknown> = {}): Promise<void> {
 		const config = {
 			projectName: 'demo',
 			projectType: 'library',
@@ -811,9 +821,7 @@ describe('fix --resync', () => {
 		}) as never)
 		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 		try {
-			await expect(fixCommand(undefined, { directory: dir, resync: true })).rejects.toThrow(
-				'exit'
-			)
+			await expect(fixCommand(undefined, { directory: dir, resync: true })).rejects.toThrow('exit')
 			expect(exitSpy).toHaveBeenCalledWith(1)
 			expect(errSpy.mock.calls.flat().join('\n')).toMatch(/No \.js-tooling\.json/)
 		} finally {

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -21,6 +21,17 @@ describe('generateDependabotConfig', () => {
 		expect(content).toMatch(/package-ecosystem: "github-actions"/)
 		expect(content).toMatch(/interval: "weekly"/)
 	})
+
+	it('groups react + react-dom and minor/patch bumps, and ignores typescript majors', async () => {
+		const dir = newTmpDir()
+		await generateDependabotConfig(dir)
+		const content = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
+		expect(content).toMatch(/^\s*groups:/m)
+		expect(content).toMatch(/react-dom/)
+		expect(content).toMatch(/minor-and-patch/)
+		expect(content).toMatch(/dependency-name: "typescript"/)
+		expect(content).toMatch(/version-update:semver-major/)
+	})
 })
 
 describe('generateCodeQLWorkflow', () => {


### PR DESCRIPTION
## What & why

Dependabot noise/failures keep hitting @rtorcato repos:
- A lone `react-dom` bump can never pass — React requires react + react-dom at the exact same version.
- A `typescript` major (7.0) breaks CI because it removed `baseUrl`.
- ~10 individual minor/patch PRs per repo per week is pure noise.

Fix it at the source: the config js-tooling scaffolds into every repo.

## Changes
- **`generators/security.ts`** — generated `.github/dependabot.yml` now:
  - groups `react`/`react-dom`/`@types/react*` (inert in non-React repos),
  - folds all other minor/patch bumps into one `minor-and-patch` PR (majors stay individual),
  - ignores `typescript` majors.
- **`doctor.ts` `checkDependabot`** — now content-aware: an existing config with no `groups:` block reports **drift** (was: any existing file = ok), so it's flagged for update.
- **`fix.ts`** — dependabot fixer marked `canFixDrift: true`; `fix dependabot` offers to overwrite a drifted config (existing destructive-overwrite confirm prompt applies).

## Rollout
Existing repos already have a `dependabot.yml`, so they adopt via `npx @rtorcato/js-tooling fix dependabot` (doctor now flags the drift). react-common already carries the equivalent config by hand (its react grouping is already proven live).

## Tests
337 pass. Added: generator asserts groups/ignore; doctor asserts drift vs ok; fix asserts a bare config gets upgraded. Build + lint + typecheck green.