### PR TITLE
fix(tsconfig): anchor preset paths with ${configDir} to drop deprecated baseUrl

### DIFF
--- a/src/cli/generators/tsconfig.ts
+++ b/src/cli/generators/tsconfig.ts
@@ -5,16 +5,12 @@ import type { ProjectConfig } from '../commands/setup.js'
 export async function generateTSConfig(config: ProjectConfig, targetDir: string) {
 	const tsconfigPath = path.join(targetDir, 'tsconfig.json')
 
-	// Base configuration extends our tooling
+	// Base configuration extends our tooling. The shared presets anchor `paths`
+	// with ${configDir}, so no local baseUrl/paths is needed (baseUrl is
+	// deprecated in TS 5.9, removed in TS 7.0). Refs: https://aka.ms/ts6
 	const tsconfig: any = {
 		extends: `@rtorcato/js-tooling/typescript/${config.typescript.config}`,
-		compilerOptions: {
-			baseUrl: '.',
-			paths: {
-				'@/*': ['./src/*'],
-				'~/*': ['./src/*'],
-			},
-		},
+		compilerOptions: {},
 		include: ['src/**/*', 'reset.d.ts'],
 		exclude: ['node_modules', 'dist', 'build'],
 	}

--- a/tests/cli/generators/tsconfig.test.ts
+++ b/tests/cli/generators/tsconfig.test.ts
@@ -30,7 +30,10 @@ describe('generateTSConfig', () => {
 
 		const tsconfig = await fs.readJson(join(dir, 'tsconfig.json'))
 		expect(tsconfig.extends).toBe('@rtorcato/js-tooling/typescript/react')
-		expect(tsconfig.compilerOptions.paths['@/*']).toEqual(['./src/*'])
+		// paths/baseUrl are inherited from the shared preset (anchored via ${configDir}),
+		// not redeclared per project — baseUrl is deprecated in TS 7.0.
+		expect(tsconfig.compilerOptions.baseUrl).toBeUndefined()
+		expect(tsconfig.compilerOptions.paths).toBeUndefined()
 		expect(tsconfig.include).toContain('reset.d.ts')
 	})
 

--- a/tooling/typescript/README.md
+++ b/tooling/typescript/README.md
@@ -36,12 +36,9 @@ These are base shared `tsconfig.json` files from which all other `tsconfig.json`
 ```jsonc
 {
   "extends": "../tooling/typescript/tsconfig.react.json",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
+  // `~/*` and `@/*` → `./src/*` are inherited from the preset, anchored to this
+  // project via ${configDir} — no `baseUrl`/`paths` needed (baseUrl is deprecated
+  // in TS 5.9, removed in TS 7.0).
   "include": ["src"]
 }
 ```

--- a/tooling/typescript/tsconfig.base.json
+++ b/tooling/typescript/tsconfig.base.json
@@ -56,9 +56,12 @@
     "noEmit": true, // Do not emit output files
     "sourceMap": true, // Generate sourcemaps for .ts files
     
+    // ${configDir} anchors paths to the consuming project (TS 5.5+), so
+    // downstream repos no longer need `baseUrl` + a redeclared `paths` block
+    // (baseUrl is deprecated in TS 5.9, removed in TS 7.0). Refs: https://aka.ms/ts6
     "paths": { // Path mapping for module resolution
-      "~/*": ["./src/*"],
-      "@/*": ["./src/*"]
+      "~/*": ["${configDir}/src/*"],
+      "@/*": ["${configDir}/src/*"]
     }
   },
   "include": ["src/**/*", "index.d.ts"], // Include files in the src directory and index.d.ts

--- a/tooling/typescript/tsconfig.next.json
+++ b/tooling/typescript/tsconfig.next.json
@@ -9,9 +9,10 @@
     "esModuleInterop": true, // Interop for CommonJS/ESM
     "types": ["react", "tailwindcss", "vitest"],
     "plugins": [ { "name": "next" } ], // Next.js plugin for TypeScript
+    // ${configDir} anchors paths to the consuming project (drops deprecated baseUrl)
     "paths": {
-      "~/*": ["./src/*"],
-      "@/*": ["./src/*"]
+      "~/*": ["${configDir}/src/*"],
+      "@/*": ["${configDir}/src/*"]
     }
   },
   "include": ["next-env.d.ts", "src", "pages", "app", "components", "types", "index.d.ts"],

--- a/tooling/typescript/tsconfig.react.json
+++ b/tooling/typescript/tsconfig.react.json
@@ -4,9 +4,10 @@
     "jsx": "react-jsx", // Use the new JSX transform for React 17+
     "lib": ["DOM", "DOM.Iterable", "ESNext"],// Include DOM types for browser APIs
     "types": ["react", "react-dom", "tailwindcss", "vitest"],
+    // ${configDir} anchors paths to the consuming project (drops deprecated baseUrl)
     "paths": {
-      "~/*": ["./src/*"],
-      "@/*": ["./src/*"]
+      "~/*": ["${configDir}/src/*"],
+      "@/*": ["${configDir}/src/*"]
     }
   },
   "include": ["src", "index.d.ts", "types"],


### PR DESCRIPTION
Closes #179.

Shared `base`/`next`/`react` TypeScript presets now anchor `~/*` and `@/*` to the consuming project via `${configDir}` (TS 5.5+), so downstream projects no longer need `baseUrl: "."` + a redeclared `paths` block. That per-project `baseUrl` is what triggered the TS 5.9 deprecation warning (removed in TS 7.0) across all repos.

**Changes**
- `tooling/typescript/tsconfig.base.json`, `.next.json`, `.react.json`: paths use `${configDir}/src/*`.
- `src/cli/generators/tsconfig.ts`: scaffolded `tsconfig.json` no longer emits `baseUrl`/`paths` (inherited from preset).
- Updated generator test + tooling README example.

All 337 tests pass; typecheck + lint clean.