### PR TITLE
feat(generator): recommend VS Code extensions matching enabled tools

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -56,7 +56,7 @@ Each row reports one of:
 | Group | Checks |
 |---|---|
 | Environment | Node version (vs. minimum + LTS patch level), `engines.node` field |
-| Repo baseline | `package.json`, `.editorconfig`, `.nvmrc` / `.node-version` |
+| Repo baseline | `package.json`, `.editorconfig`, `.nvmrc` / `.node-version`, `.vscode/extensions.json` |
 | Tooling presets | TypeScript, Biome, ESLint, Prettier, Vitest, Commitlint |
 | Automation | Husky, `lint-staged`, semantic-release, knip |
 | CI / supply chain | GitHub Actions, Dependabot, CodeQL, GitLab CI |
@@ -140,6 +140,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `package-json` | `package.json` | adds `@rtorcato/js-tooling` to `devDependencies` |
 | `engines` | `engines.node` | sets `engines.node` (never overwrites) |
 | `editorconfig` | `EditorConfig` | `.editorconfig` |
+| `vscode-extensions` | `VS Code extensions` | `.vscode/extensions.json` (merge-friendly) |
 | `nvmrc` | `Node version pin` | `.nvmrc` |
 | `tsconfig` | `TypeScript` | `tsconfig.json` |
 | `biome` | `Biome` | `biome.json` |

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -81,7 +81,7 @@ Running `setup` (or its alias `init`) launches an interactive wizard:
 | Security automation (Dependabot + CodeQL)? | yes/no |
 | Bundler | `tsup`, `esbuild`, `vite` *(web apps)*, `none` |
 
-A universal baseline (`.editorconfig`, `.nvmrc`, `engines.node`, `knip.json`) is scaffolded automatically — no prompt — because these are safe defaults for every project.
+A universal baseline (`.editorconfig`, `.nvmrc`, `engines.node`, `knip.json`, `.vscode/extensions.json`) is scaffolded automatically — no prompt — because these are safe defaults for every project.
 
 ## Non-interactive setup (CI / scripts)
 
@@ -105,6 +105,7 @@ npx @rtorcato/js-tooling setup --config project.json -d ./my-lib --skip-install
 
 - `package.json` — merged with chosen devDependencies, scripts, and `engines.node`
 - `.editorconfig`, `.nvmrc`, `knip.json` — universal baseline
+- `.vscode/extensions.json` — recommends the editor extensions matching your enabled tools (merge-friendly)
 - `tsconfig.json` — extends the matching preset
 - `biome.json` / `eslint.config.js` + `prettier.config.js` — based on linting choice
 - `vitest.config.js` / `jest.config.js` — testing config

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -246,6 +246,75 @@ async function checkEditorConfig(dir: string): Promise<CheckResult> {
 	}
 }
 
+// Maps a present tool-config file to the VS Code extension that should be
+// recommended for it. Mirrors recommendedExtensions() in the generator, but
+// keyed off files on disk (doctor audits an existing repo, not a config object).
+const EXTENSION_SIGNALS: Array<{ candidates: string[]; ext: string }> = [
+	{ candidates: ['.editorconfig'], ext: 'EditorConfig.EditorConfig' },
+	{ candidates: ['biome.json', 'biome.jsonc'], ext: 'biomejs.biome' },
+	{
+		candidates: ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs'],
+		ext: 'dbaeumer.vscode-eslint',
+	},
+	{
+		candidates: ['prettier.config.js', 'prettier.config.mjs', 'prettier.config.cjs'],
+		ext: 'esbenp.prettier-vscode',
+	},
+	{ candidates: ['.oxlintrc.json', 'oxlintrc.json'], ext: 'oxc.oxc-vscode' },
+	{
+		candidates: ['vitest.config.ts', 'vitest.config.js', 'vitest.config.mjs'],
+		ext: 'vitest.explorer',
+	},
+	{ candidates: ['playwright.config.ts', 'playwright.config.js'], ext: 'ms-playwright.playwright' },
+]
+
+async function checkVscodeExtensions(dir: string): Promise<CheckResult> {
+	const wanted: string[] = []
+	for (const { candidates, ext } of EXTENSION_SIGNALS) {
+		for (const c of candidates) {
+			if (await fs.pathExists(path.join(dir, c))) {
+				wanted.push(ext)
+				break
+			}
+		}
+	}
+	if (wanted.length === 0) {
+		return {
+			check: 'VS Code extensions',
+			status: 'ok',
+			detail: 'no tool configs that map to an editor extension',
+		}
+	}
+
+	let recommended: string[] = []
+	const extPath = path.join(dir, '.vscode', 'extensions.json')
+	if (await fs.pathExists(extPath)) {
+		try {
+			const json = (await fs.readJson(extPath)) as { recommendations?: unknown }
+			if (Array.isArray(json.recommendations)) {
+				recommended = json.recommendations.filter((r): r is string => typeof r === 'string')
+			}
+		} catch {
+			recommended = []
+		}
+	}
+
+	const missing = wanted.filter((ext) => !recommended.includes(ext))
+	if (missing.length === 0) {
+		return {
+			check: 'VS Code extensions',
+			status: 'ok',
+			detail: '.vscode/extensions.json recommends the matching extensions',
+		}
+	}
+	return {
+		check: 'VS Code extensions',
+		status: 'optional-missing',
+		detail: `enabled tools without a recommended extension: ${missing.join(', ')}`,
+		hint: 'Run `npx @rtorcato/js-tooling fix vscode-extensions` to recommend matching editor extensions',
+	}
+}
+
 async function checkNodeVersionPin(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.nvmrc', '.node-version']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -1236,6 +1305,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(checkLockfile(lock))
 	results.push(checkEnginesNode(pkg))
 	results.push(await checkEditorConfig(targetDir))
+	results.push(await checkVscodeExtensions(targetDir))
 	results.push(await checkNodeVersionPin(targetDir))
 	results.push(await checkNodeVersionConsistency(targetDir, pkg))
 	for (const spec of FILE_CHECKS) {

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -5,6 +5,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'package.json': 'package-json',
 	'engines.node': 'engines',
 	EditorConfig: 'editorconfig',
+	'VS Code extensions': 'vscode-extensions',
 	'Node version pin': 'nvmrc',
 	'Node version consistency': 'node-version',
 	TypeScript: 'tsconfig',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -24,6 +24,7 @@ import {
 	generateKnipConfig,
 	generateNvmrc,
 	generateSizeLimitConfig,
+	generateVscodeExtensions,
 } from '../generators/misc.js'
 import { generateConfigs } from '../generators/index.js'
 import { composeVerifyScriptFromPkg } from '../generators/package-json.js'
@@ -423,6 +424,20 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			await generateEditorConfig(targetDir)
 			return { filesWritten: ['.editorconfig'] }
+		},
+	},
+	{
+		target: 'vscode-extensions',
+		description:
+			'Recommend the VS Code extensions matching the enabled tools (.vscode/extensions.json)',
+		appliesTo: ['VS Code extensions'],
+		outputs: ['.vscode/extensions.json'],
+		// Preserves any recommendations already present; only appends ours.
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir, pkg }) {
+			const written = await generateVscodeExtensions(inferProjectConfig(pkg), targetDir)
+			return { filesWritten: written ? [written] : [] }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -173,7 +173,7 @@ export function validateProjectConfig(input: unknown): ConfigValidationResult {
 
 export function computeFileList(config: ProjectConfig): string[] {
 	const files: string[] = ['package.json', '.js-tooling.json']
-	files.push('.editorconfig', '.nvmrc', 'knip.json')
+	files.push('.editorconfig', '.nvmrc', 'knip.json', '.vscode/extensions.json')
 	if (config.typescript.enabled) {
 		files.push('tsconfig.json', 'reset.d.ts')
 	}

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -7,7 +7,7 @@ import { ensureBuildApprovals, generateBuildConfigs } from './build.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
 import { generateLintingConfigs } from './linting.js'
-import { generateKnipConfig, generateMiscBaseline } from './misc.js'
+import { generateKnipConfig, generateMiscBaseline, generateVscodeExtensions } from './misc.js'
 import { generatePackageJson } from './package-json.js'
 import { generateReadme } from './readme.js'
 import { generateSecurityConfigs } from './security.js'
@@ -25,6 +25,9 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 
 	// Universal baseline: .editorconfig, .nvmrc, engines.node, knip.json
 	await generateMiscBaseline(targetDir)
+
+	// Recommend the editor extensions matching the enabled tools
+	await generateVscodeExtensions(config, targetDir)
 
 	// Generate TypeScript configuration
 	if (config.typescript.enabled) {

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fs from 'fs-extra'
+import type { ProjectConfig } from '../commands/setup.js'
 
 const EDITORCONFIG_CONTENT = `root = true
 
@@ -50,6 +51,52 @@ export async function generateEditorConfig(targetDir: string) {
 
 export async function generateNvmrc(targetDir: string) {
 	await fs.writeFile(path.join(targetDir, '.nvmrc'), NVMRC_CONTENT)
+}
+
+/**
+ * The VS Code extension IDs recommended for the tools this config enables.
+ * EditorConfig is always included — the baseline always writes .editorconfig.
+ */
+export function recommendedExtensions(config: ProjectConfig): string[] {
+	const ids = new Set<string>(['EditorConfig.EditorConfig'])
+	const lint = config.linting.tool
+	if (lint === 'biome' || lint === 'both' || config.formatting.tool === 'biome') {
+		ids.add('biomejs.biome')
+	}
+	if (lint === 'eslint' || lint === 'both') ids.add('dbaeumer.vscode-eslint')
+	if (config.formatting.tool === 'prettier') ids.add('esbenp.prettier-vscode')
+	if (config.oxlint) ids.add('oxc.oxc-vscode')
+	if (config.testing.framework === 'vitest') ids.add('vitest.explorer')
+	if (config.testing.framework === 'playwright') ids.add('ms-playwright.playwright')
+	return [...ids]
+}
+
+/**
+ * Emit .vscode/extensions.json recommending the editor extensions that match the
+ * enabled tools. Merge-friendly: preserves any recommendations already present
+ * and never clobbers a hand-authored file it can't parse as JSON (e.g. JSONC
+ * with comments) — returns null in that case. Returns the written path otherwise.
+ */
+export async function generateVscodeExtensions(
+	config: ProjectConfig,
+	targetDir: string
+): Promise<string | null> {
+	const filepath = path.join(targetDir, '.vscode', 'extensions.json')
+	let existing: string[] = []
+	if (await fs.pathExists(filepath)) {
+		try {
+			const current = (await fs.readJson(filepath)) as { recommendations?: unknown }
+			if (Array.isArray(current.recommendations)) {
+				existing = current.recommendations.filter((r): r is string => typeof r === 'string')
+			}
+		} catch {
+			return null
+		}
+	}
+	const merged = [...new Set([...existing, ...recommendedExtensions(config)])]
+	await fs.ensureDir(path.dirname(filepath))
+	await fs.writeJson(filepath, { recommendations: merged }, { spaces: 2 })
+	return '.vscode/extensions.json'
 }
 
 const DEFAULT_NODE_MAJOR = 22

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -953,4 +953,27 @@ describe('doctor README badges check', () => {
 		const b = results.find((r) => r.check === 'README badges')
 		expect(b?.status).toBe('drift')
 	})
+
+	it('nudges when a tool config lacks its recommended VS Code extension', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'biome.json'), { $schema: 'x' })
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'VS Code extensions')
+		expect(r?.status).toBe('optional-missing')
+		expect(r?.detail).toMatch(/biomejs\.biome/)
+	})
+
+	it('passes when .vscode/extensions.json recommends the matching extension', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'biome.json'), { $schema: 'x' })
+		await fs.ensureDir(join(dir, '.vscode'))
+		await fs.writeJson(join(dir, '.vscode', 'extensions.json'), {
+			recommendations: ['biomejs.biome'],
+		})
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'VS Code extensions')
+		expect(r?.status).toBe('ok')
+	})
 })

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -41,6 +41,12 @@ describe('fix registry', () => {
 		}
 	})
 
+	it('registers the vscode-extensions fixer for the VS Code extensions check', () => {
+		const fixer = getFixers().find((f) => f.target === 'vscode-extensions')
+		expect(fixer).toBeTruthy()
+		expect(fixer?.appliesTo).toContain('VS Code extensions')
+	})
+
 	it('listFixers returns a flat summary of every registered target', () => {
 		const summary = listFixers()
 		expect(summary.length).toBe(getFixers().length)

--- a/tests/cli/generators/misc.test.ts
+++ b/tests/cli/generators/misc.test.ts
@@ -7,10 +7,29 @@ import {
 	generateKnipConfig,
 	generateMiscBaseline,
 	generateNvmrc,
+	generateVscodeExtensions,
+	recommendedExtensions,
 } from '../../../src/cli/generators/misc.js'
+import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
+
+function cfg(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+	return {
+		projectName: 'demo',
+		projectType: 'library',
+		typescript: { enabled: true, config: 'base' },
+		linting: { tool: 'biome' },
+		formatting: { tool: 'biome' },
+		testing: { framework: 'vitest' },
+		gitHooks: false,
+		commitLint: false,
+		semanticRelease: false,
+		bundler: 'none',
+		...overrides,
+	}
+}
 
 describe('generateEditorConfig', () => {
 	it('writes .editorconfig with utf-8 and lf', async () => {
@@ -29,6 +48,63 @@ describe('generateNvmrc', () => {
 		await generateNvmrc(dir)
 		const content = await fs.readFile(join(dir, '.nvmrc'), 'utf-8')
 		expect(content.trim()).toBe('22')
+	})
+})
+
+describe('recommendedExtensions', () => {
+	it('always recommends EditorConfig and derives the rest from enabled tools', () => {
+		const ids = recommendedExtensions(
+			cfg({
+				linting: { tool: 'eslint' },
+				formatting: { tool: 'prettier' },
+				testing: { framework: 'vitest' },
+				oxlint: true,
+			})
+		)
+		expect(ids).toContain('EditorConfig.EditorConfig')
+		expect(ids).toContain('dbaeumer.vscode-eslint')
+		expect(ids).toContain('esbenp.prettier-vscode')
+		expect(ids).toContain('vitest.explorer')
+		expect(ids).toContain('oxc.oxc-vscode')
+		expect(ids).not.toContain('biomejs.biome')
+	})
+
+	it('recommends Biome when it is the linter or formatter', () => {
+		expect(recommendedExtensions(cfg({ linting: { tool: 'biome' } }))).toContain('biomejs.biome')
+	})
+})
+
+describe('generateVscodeExtensions', () => {
+	it('writes .vscode/extensions.json with the matching recommendations', async () => {
+		const dir = newTmpDir()
+		const written = await generateVscodeExtensions(cfg(), dir)
+		expect(written).toBe('.vscode/extensions.json')
+		const json = await fs.readJson(join(dir, '.vscode', 'extensions.json'))
+		expect(json.recommendations).toContain('biomejs.biome')
+		expect(json.recommendations).toContain('vitest.explorer')
+		expect(json.recommendations).toContain('EditorConfig.EditorConfig')
+	})
+
+	it('preserves existing recommendations and dedupes', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.vscode'))
+		await fs.writeJson(join(dir, '.vscode', 'extensions.json'), {
+			recommendations: ['some.user-extension', 'biomejs.biome'],
+		})
+		await generateVscodeExtensions(cfg(), dir)
+		const json = await fs.readJson(join(dir, '.vscode', 'extensions.json'))
+		expect(json.recommendations).toContain('some.user-extension')
+		expect(json.recommendations.filter((r: string) => r === 'biomejs.biome')).toHaveLength(1)
+	})
+
+	it('does not clobber an unparseable (commented) extensions.json', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.vscode'))
+		const original = '{\n  // keep my comments\n  "recommendations": ["a.b"]\n}\n'
+		await fs.writeFile(join(dir, '.vscode', 'extensions.json'), original)
+		const written = await generateVscodeExtensions(cfg(), dir)
+		expect(written).toBeNull()
+		expect(await fs.readFile(join(dir, '.vscode', 'extensions.json'), 'utf-8')).toBe(original)
 	})
 })
 


### PR DESCRIPTION
Closes #146.

Scaffolds `.vscode/extensions.json` recommending the editor extensions that match the enabled tools — the "cheap win alongside .editorconfig" from the issue.

**Recommendation map** (derived from `ProjectConfig`; EditorConfig always included since the baseline always writes `.editorconfig`):

| Tool | Extension |
|---|---|
| Biome (lint or format) | `biomejs.biome` |
| ESLint | `dbaeumer.vscode-eslint` |
| Prettier | `esbenp.prettier-vscode` |
| Oxlint | `oxc.oxc-vscode` |
| Vitest | `vitest.explorer` |
| Playwright | `ms-playwright.playwright` |
| always | `EditorConfig.EditorConfig` |

**Merge-friendly:** preserves any existing recommendations, dedupes, and never clobbers a hand-authored file it can't parse as JSON (returns null instead).

**Completes the doctor → fix → generator loop** like every other baseline file:
- Generator wired into `generateConfigs` + `computeFileList`.
- `VS Code extensions` doctor check — info-level nudge (`optional-missing`, non-failing) when a tool config on disk lacks its recommended extension.
- `fix vscode-extensions` fixer (safe-merge) scaffolds/repairs it.
- Docs updated (getting-started, cli reference).

345 tests pass (+8 new: generator merge/no-clobber, doctor nudge/ok, fixer registration); typecheck + lint clean.