### PR TITLE
feat(ci): upload coverage to Codecov so the coverage badge works

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -59,7 +59,7 @@ Each row reports one of:
 | Repo baseline | `package.json`, `.editorconfig`, `.nvmrc` / `.node-version` |
 | Tooling presets | TypeScript, Biome, ESLint, Prettier, Vitest, Commitlint |
 | Automation | Husky, `lint-staged`, semantic-release, knip |
-| CI / supply chain | GitHub Actions, Dependabot, CodeQL, GitLab CI |
+| CI / supply chain | GitHub Actions, coverage upload, Dependabot, CodeQL, GitLab CI |
 
 After the per-row results, doctor prints a **Next steps:** footer listing the exact `fix` command to run for each non-ok item:
 
@@ -150,7 +150,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `husky` | `Husky` + `lint-staged` | `.husky/pre-commit`, package.json `lint-staged` field (deep-merges) |
 | `semantic-release` | `semantic-release` | `release.config.mjs` (skipped on private packages) |
 | `knip` | `knip` | `knip.json` |
-| `github-actions` | `GitHub Actions` | `.github/workflows/ci.yml` |
+| `github-actions` | `GitHub Actions` + `Coverage upload` | `.github/workflows/ci.yml` (+ `codecov.yml`; Vitest jobs run `pnpm coverage` and upload to Codecov) |
 | `dependabot` | `Dependabot` | `.github/dependabot.yml` |
 | `codeql` | `CodeQL` | `.github/workflows/codeql.yml` |
 | `attw` | `are-the-types-wrong` | adds `@arethetypeswrong/cli` + an `attw` script (esm-only profile when applicable), wires it into `verify` |

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -108,6 +108,7 @@ npx @rtorcato/js-tooling setup --config project.json -d ./my-lib --skip-install
 - `tsconfig.json` — extends the matching preset
 - `biome.json` / `eslint.config.js` + `prettier.config.js` — based on linting choice
 - `vitest.config.js` / `jest.config.js` — testing config
+- `codecov.yml` — if Vitest chosen; CI runs `pnpm coverage` and uploads to Codecov
 - `.husky/pre-commit`, `commitlint.config.js` — if git hooks chosen
 - `release.config.js` — if semantic release chosen
 - `.github/workflows/ci.yml` — CI workflow

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1094,6 +1094,49 @@ async function checkReadmeBadges(dir: string, pkg: Pkg | null): Promise<CheckRes
 	}
 }
 
+// A README that advertises a Codecov badge but a CI that never uploads coverage
+// leaves the badge permanently red. Only flags when the badge is actually present
+// (no badge → nothing to back, so it's not applicable).
+async function checkCoverageUpload(dir: string): Promise<CheckResult> {
+	const readmePath = path.join(dir, 'README.md')
+	const readme = (await fs.pathExists(readmePath)) ? await fs.readFile(readmePath, 'utf8') : ''
+	if (!/codecov\.io/.test(readme)) {
+		return {
+			check: 'Coverage upload',
+			status: 'ok',
+			detail: 'no coverage badge in README (nothing to back)',
+		}
+	}
+
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (await fs.pathExists(workflowsDir)) {
+		try {
+			const files = (await fs.readdir(workflowsDir)).filter(
+				(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+			)
+			for (const f of files) {
+				const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+				if (/codecov\/codecov-action/.test(content)) {
+					return {
+						check: 'Coverage upload',
+						status: 'ok',
+						detail: `coverage badge backed by codecov-action in .github/workflows/${f}`,
+					}
+				}
+			}
+		} catch {
+			// fall through to drift
+		}
+	}
+
+	return {
+		check: 'Coverage upload',
+		status: 'drift',
+		detail: 'README has a Codecov badge but no CI step uploads coverage (badge stays red)',
+		hint: 'Run `npx @rtorcato/js-tooling fix github-actions` to regenerate ci.yml with a Codecov upload step',
+	}
+}
+
 async function checkTreeshakeSetup(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const appCheckPath = path.join(dir, 'apps', 'treeshake-check', 'check.mjs')
 	if (await fs.pathExists(appCheckPath)) {
@@ -1260,6 +1303,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkPublint(targetDir, pkg))
 	results.push(await checkReadmeBadges(targetDir, pkg))
+	results.push(await checkCoverageUpload(targetDir))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 
 	// Lockfile-driven demotion: if the lock records an intentional opt-out for a

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -22,6 +22,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'size-limit': 'size-limit',
 	'Tree-shake check': 'treeshake-check',
 	'GitHub Actions': 'github-actions',
+	'Coverage upload': 'github-actions',
 	Dependabot: 'dependabot',
 	CodeQL: 'codeql',
 	CODEOWNERS: 'codeowners',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -332,13 +332,15 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'github-actions',
-		description: 'Scaffold .github/workflows/ci.yml',
-		appliesTo: ['GitHub Actions'],
-		outputs: ['.github/workflows/ci.yml'],
+		description: 'Scaffold .github/workflows/ci.yml (+ codecov.yml when tests run)',
+		appliesTo: ['GitHub Actions', 'Coverage upload'],
+		outputs: ['.github/workflows/ci.yml', 'codecov.yml'],
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			await generateGitHubActions(inferProjectConfig(pkg), targetDir)
-			return { filesWritten: ['.github/workflows/ci.yml'] }
+			const filesWritten = ['.github/workflows/ci.yml']
+			if (await fs.pathExists(path.join(targetDir, 'codecov.yml'))) filesWritten.push('codecov.yml')
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -187,7 +187,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 		files.push('prettier.config.mjs')
 	}
 	if (config.testing.framework === 'vitest') {
-		files.push('vitest.config.ts', 'vitest.setup.ts')
+		files.push('vitest.config.ts', 'vitest.setup.ts', 'codecov.yml')
 	}
 	if (config.testing.framework === 'jest') {
 		files.push('jest.config.mjs')

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -2,6 +2,26 @@ import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
 
+// Minimal Codecov config — auto targets keep it from failing a fresh repo that
+// has no baseline yet, while the 1% threshold tolerates rounding noise.
+// https://docs.codecov.com/docs/codecov-yaml
+const CODECOV_YML = `coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+`
+
+/** Coverage is uploaded when Vitest is the test runner (it emits an lcov report). */
+function usesCoverage(config: ProjectConfig): boolean {
+	return config.testing.framework === 'vitest'
+}
+
 export async function generateGitHubActions(config: ProjectConfig, targetDir: string) {
 	const workflowsDir = path.join(targetDir, '.github', 'workflows')
 	await fs.ensureDir(workflowsDir)
@@ -10,6 +30,12 @@ export async function generateGitHubActions(config: ProjectConfig, targetDir: st
 
 	const workflow = generateWorkflowYAML(config)
 	await fs.writeFile(workflowPath, workflow)
+
+	// codecov.yml is the CI's coverage-upload companion — emit it alongside ci.yml
+	// whenever the workflow uploads coverage, so the codecov badge isn't red.
+	if (usesCoverage(config)) {
+		await fs.writeFile(path.join(targetDir, 'codecov.yml'), CODECOV_YML)
+	}
 }
 
 function generateWorkflowYAML(config: ProjectConfig): string {
@@ -17,6 +43,7 @@ function generateWorkflowYAML(config: ProjectConfig): string {
 	const hasTypeScript = config.typescript.enabled
 	const hasBuild = config.bundler !== 'none'
 	const isLibrary = config.projectType === 'library'
+	const hasCoverage = usesCoverage(config)
 
 	return `name: 🚀 CI/CD Pipeline
 
@@ -169,7 +196,17 @@ ${
           key: \${{ needs.dependencies.outputs.cache-key }}
 
       - name: 🧪 Run tests
-        run: pnpm test`
+        run: ${hasCoverage ? 'pnpm coverage' : 'pnpm test'}
+${
+	hasCoverage
+		? `
+      - name: 📊 Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false`
+		: ''
+}`
 		: ''
 }
 ${

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -225,6 +225,8 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 	// Testing frameworks
 	if (config.testing.framework === 'vitest') {
 		deps['vitest'] = '^4.1.9'
+		// Coverage provider so `pnpm coverage` (and the CI Codecov upload) works.
+		deps['@vitest/coverage-v8'] = '^4.1.9'
 		if (config.testing.environment === 'browser' || config.testing.environment === 'both') {
 			deps['@vitest/ui'] = '^4.1.9'
 			deps['jsdom'] = '^25.0.0'

--- a/src/cli/generators/testing.ts
+++ b/src/cli/generators/testing.ts
@@ -21,7 +21,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: '${config.testing.environment === 'browser' ? 'jsdom' : 'node'}',
-    setupFiles: ['./vitest.setup.ts']
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      // lcov feeds Codecov; text is the local console summary.
+      reporter: ['text', 'lcov']
+    }
   }
 })
 `

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -953,4 +953,44 @@ describe('doctor README badges check', () => {
 		const b = results.find((r) => r.check === 'README badges')
 		expect(b?.status).toBe('drift')
 	})
+
+	it('flags a Codecov badge with no CI coverage upload', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(
+			join(dir, 'README.md'),
+			'# demo\n\n![Coverage](https://codecov.io/gh/o/r/branch/main/graph/badge.svg)\n'
+		)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(join(dir, '.github', 'workflows', 'ci.yml'), 'name: CI\n')
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'Coverage upload')
+		expect(r?.status).toBe('drift')
+	})
+
+	it('passes coverage upload when ci.yml uses codecov-action', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(
+			join(dir, 'README.md'),
+			'# demo\n\n![Coverage](https://codecov.io/gh/o/r/branch/main/graph/badge.svg)\n'
+		)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'name: CI\njobs:\n  test:\n    steps:\n      - uses: codecov/codecov-action@v5\n'
+		)
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'Coverage upload')
+		expect(r?.status).toBe('ok')
+	})
+
+	it('coverage upload not applicable without a Codecov badge', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(join(dir, 'README.md'), '# demo\n')
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'Coverage upload')
+		expect(r?.status).toBe('ok')
+	})
 })

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -146,7 +146,13 @@ jobs:
           key: \${{ needs.dependencies.outputs.cache-key }}
 
       - name: 🧪 Run tests
-        run: pnpm test
+        run: pnpm coverage
+
+      - name: 📊 Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: \${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   build:
     runs-on: ubuntu-latest
@@ -267,6 +273,7 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "@types/node": "^26.0.1",
     "@biomejs/biome": "^2.5.1",
     "vitest": "^4.1.9",
+    "@vitest/coverage-v8": "^4.1.9",
     "tsup": "^8.0.0",
     "husky": "^9.0.0",
     "lint-staged": "^16.0.0",
@@ -307,7 +314,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    setupFiles: ['./vitest.setup.ts']
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      provider: 'v8',
+      // lcov feeds Codecov; text is the local console summary.
+      reporter: ['text', 'lcov']
+    }
   }
 })
 "

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -87,7 +87,7 @@ describe('generateGitHubActions', () => {
 
 	it('includes test job when a testing framework is configured', async () => {
 		const dir = newTmpDir()
-		await generateGitHubActions(baseConfig({ testing: { framework: 'vitest' } }), dir)
+		await generateGitHubActions(baseConfig({ testing: { framework: 'jest' } }), dir)
 
 		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
 		expect(content).toContain('test:')
@@ -100,6 +100,26 @@ describe('generateGitHubActions', () => {
 
 		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
 		expect(content).not.toContain('Run tests')
+	})
+
+	it('uploads coverage and emits codecov.yml for Vitest', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig({ testing: { framework: 'vitest' } }), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).toContain('pnpm coverage')
+		expect(content).toContain('codecov/codecov-action@v5')
+		expect(content).toContain('CODECOV_TOKEN')
+		expect(await fs.pathExists(join(dir, 'codecov.yml'))).toBe(true)
+	})
+
+	it('does not upload coverage or emit codecov.yml when tests are absent', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig({ testing: { framework: 'none' } }), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).not.toContain('codecov')
+		expect(await fs.pathExists(join(dir, 'codecov.yml'))).toBe(false)
 	})
 
 	it('includes build job when bundler is configured', async () => {


### PR DESCRIPTION
Closes #144.

The scaffolded README carries a Codecov badge but nothing uploaded coverage — so the badge was permanently red. This wires up the full path (Vitest projects only):

- **CI:** the test job runs `pnpm coverage` and uploads via `codecov/codecov-action@v5` (token from `CODECOV_TOKEN`, `fail_ci_if_error: false`).
- **codecov.yml:** minimal config (auto targets + 1% threshold) emitted next to `ci.yml` — owned by the CI generator, so `fix github-actions` regenerates both.
- **vitest.config.ts:** adds a v8 coverage provider + `['text', 'lcov']` reporter; `@vitest/coverage-v8` added to devDependencies so `pnpm coverage` actually produces the lcov report.
- **Doctor:** new `Coverage upload` check — a README Codecov badge with no CI upload step is drift (badge stays red); not-applicable when there's no badge. Maps to the `github-actions` fix target.
- Docs + snapshots updated.

342 tests pass (+5 new: coverage upload generator/no-op, doctor drift/ok/n-a); typecheck + lint clean.