### PR TITLE
feat(scaffold): add commitizen alongside commitlint

### DIFF
--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -62,6 +62,15 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 		}
 	}
 
+	// Commitizen adapter path — makes `pnpm commit` launch the conventional
+	// changelog prompt. Merged so an existing `config` block is preserved.
+	if (config.commitLint) {
+		packageJson.config = {
+			...(packageJson.config ?? {}),
+			commitizen: { path: './node_modules/cz-conventional-changelog' },
+		}
+	}
+
 	// Build-script approvals (esbuild etc.) are NOT written here: pnpm 11 ignores
 	// package.json's `pnpm` field and reads them from pnpm-workspace.yaml instead
 	// (see ensureBuildApprovals in build.ts).
@@ -121,6 +130,12 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 		scripts['build'] = 'vite build'
 		scripts['dev'] = 'vite'
 		scripts['preview'] = 'vite preview'
+	}
+
+	// Commitizen assistant — `pnpm commit` guides a conventional commit that
+	// then passes the commitlint enforcement layer.
+	if (config.commitLint) {
+		scripts['commit'] = 'cz'
 	}
 
 	// knip is part of the universal baseline (knip.json is always generated).
@@ -262,10 +277,12 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['lint-staged'] = '^16.0.0'
 	}
 
-	// Commit linting
+	// Commit linting (enforcement) + commitizen (assistance)
 	if (config.commitLint) {
 		deps['@commitlint/cli'] = '^20.0.0'
 		deps['@commitlint/config-conventional'] = '^20.0.0'
+		deps['commitizen'] = '^4.3.1'
+		deps['cz-conventional-changelog'] = '^3.3.0'
 	}
 
 	// Semantic release. The shipped github preset activates the changelog and

--- a/src/cli/generators/readme.ts
+++ b/src/cli/generators/readme.ts
@@ -96,6 +96,9 @@ This project follows [Conventional Commits](https://conventionalcommits.org/):
 - \`refactor:\` code refactoring
 - \`test:\` adding or updating tests
 - \`chore:\` maintenance tasks
+
+Run \`pnpm commit\` for a guided prompt (commitizen) that builds a compliant
+message; commitlint enforces the same rules on every commit.
 `
 		: ''
 }
@@ -222,6 +225,10 @@ function generateScriptsSection(config: ProjectConfig): string {
 
 	if (config.bundler !== 'none') {
 		scripts.push('- `pnpm build` - Build for production')
+	}
+
+	if (config.commitLint) {
+		scripts.push('- `pnpm commit` - Write a conventional commit via a guided prompt')
 	}
 
 	return scripts.join('\n')

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -254,6 +254,7 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "coverage": "vitest run --coverage",
     "build": "tsup",
     "build:watch": "tsup --watch",
+    "commit": "cz",
     "knip": "knip",
     "prepare": "husky",
     "release": "semantic-release",
@@ -272,6 +273,8 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "lint-staged": "^16.0.0",
     "@commitlint/cli": "^20.0.0",
     "@commitlint/config-conventional": "^20.0.0",
+    "commitizen": "^4.3.1",
+    "cz-conventional-changelog": "^3.3.0",
     "semantic-release": "^25.0.0",
     "@semantic-release/github": "^12.0.0",
     "@semantic-release/changelog": "^6.0.0",
@@ -295,6 +298,11 @@ exports[`generator output snapshots > package.json (library) 1`] = `
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }
 "

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -61,6 +61,27 @@ describe('generatePackageJson', () => {
 		expect(pkg.devDependencies['@rtorcato/js-tooling']).toBe('latest')
 	})
 
+	it('wires commitizen alongside commitlint when commitLint is on', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(baseConfig({ commitLint: true }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.commit).toBe('cz')
+		expect(pkg.config.commitizen.path).toBe('./node_modules/cz-conventional-changelog')
+		expect(pkg.devDependencies.commitizen).toBeDefined()
+		expect(pkg.devDependencies['cz-conventional-changelog']).toBeDefined()
+	})
+
+	it('omits commitizen wiring when commitLint is off', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(baseConfig({ commitLint: false }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.commit).toBeUndefined()
+		expect(pkg.config?.commitizen).toBeUndefined()
+		expect(pkg.devDependencies.commitizen).toBeUndefined()
+	})
+
 	it('adds library fields for library project type', async () => {
 		const dir = newTmpDir()
 		await generatePackageJson(baseConfig({ projectType: 'library' }), dir)


### PR DESCRIPTION
Closes #81.

The scaffold set up commitlint (enforcement) but not commitizen (assistance) — so users got the rules without the guided prompt. Sister project `js-common` uses commitizen + `pnpm commit`.

When commit linting is enabled, the scaffold now also emits:
- **devDependencies:** `commitizen` + `cz-conventional-changelog`
- **script:** `"commit": "cz"`
- **config:** `config.commitizen.path = ./node_modules/cz-conventional-changelog` (merged, preserving any existing `config` block)
- **README:** a `pnpm commit` note under Commit Convention + a Scripts entry

All gated on `config.commitLint`, so nothing changes when commit linting is off.

Scope note: this is the setup-time generator (matches the issue's framing). Existing repos running `fix commitlint` still only get `commitlint.config.mjs` — a follow-up could extend that fixer to add commitizen too.

339 tests pass (+2: commitizen on/off); typecheck + lint clean.