### PR TITLE
feat(size-limit): exports-driven budgets for multi-subpath libraries

### DIFF
--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -474,13 +474,13 @@ const FIXERS: Fixer[] = [
 	{
 		target: 'size-limit',
 		description:
-			'Scaffold .size-limit.json with a default 10 kB budget (customize per-subpath for libraries)',
+			'Scaffold a size-limit budget — exports-driven .size-limit.cjs for multi-subpath libraries, else a static .size-limit.json',
 		appliesTo: ['size-limit'],
-		outputs: ['.size-limit.json'],
+		outputs: ['.size-limit.cjs', '.size-limit.json'],
 		canFixDrift: true,
 		async run({ targetDir }) {
-			await generateSizeLimitConfig(targetDir)
-			return { filesWritten: ['.size-limit.json'] }
+			const written = await generateSizeLimitConfig(targetDir)
+			return { filesWritten: [written] }
 		},
 	},
 	{

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -29,6 +29,40 @@ const SIZE_LIMIT_CONFIG = [
 	},
 ]
 
+// Exports-driven size-limit config for multi-subpath libraries: one budget per
+// exported subpath, computed from package.json at run time so newly added
+// modules are covered automatically. The static-array form silently drifts as
+// modules ship without a budget (#165). The root '.' barrel is skipped — it
+// re-exports everything and grows legitimately. Tighten individual modules via
+// OVERRIDES.
+const SIZE_LIMIT_CJS = `const pkg = require('./package.json')
+
+// Per-subpath budget overrides, e.g. { './clipboard': '500 B' }.
+const OVERRIDES = {}
+const DEFAULT_LIMIT = '10 kB'
+
+// Resolve the ESM entry file for an exports condition (string, or an object
+// with a string \`import\`, or a nested \`import.default\`).
+function importPath(cond) {
+  if (typeof cond === 'string') return cond
+  if (cond && typeof cond === 'object') {
+    if (typeof cond.import === 'string') return cond.import
+    if (cond.import && typeof cond.import === 'object') return cond.import.default
+  }
+  return undefined
+}
+
+module.exports = Object.entries(pkg.exports || {})
+  .filter(([sub]) => sub !== '.' && sub !== './package.json')
+  .map(([sub, cond]) => [sub, importPath(cond)])
+  .filter(([, file]) => typeof file === 'string')
+  .map(([sub, file]) => ({
+    name: \`\${pkg.name}\${sub.slice(1)}\`,
+    path: file.replace(/^\\.\\//, ''),
+    limit: OVERRIDES[sub] || DEFAULT_LIMIT,
+  }))
+`
+
 const CODEOWNERS_CONTENT = `# .github/CODEOWNERS
 # Each line is a file pattern followed by one or more owners.
 # Owners can be GitHub usernames (@user) or team names (@org/team).
@@ -206,8 +240,31 @@ export async function generateKnipConfig(targetDir: string) {
 	await fs.writeJson(path.join(targetDir, 'knip.json'), config, { spaces: 2 })
 }
 
-export async function generateSizeLimitConfig(targetDir: string) {
+/**
+ * Scaffold a size-limit budget. Multi-subpath libraries (≥1 subpath export
+ * beyond the root barrel) get an exports-driven `.size-limit.cjs` that emits one
+ * budget per subpath from package.json at run time — so new modules are covered
+ * automatically. Everything else gets a static `.size-limit.json` for the root
+ * bundle. Returns the written filename.
+ */
+export async function generateSizeLimitConfig(targetDir: string): Promise<string> {
+	const pkgPath = path.join(targetDir, 'package.json')
+	let subpathCount = 0
+	if (await fs.pathExists(pkgPath)) {
+		const pkg = (await fs.readJson(pkgPath)) as { exports?: unknown }
+		if (pkg.exports && typeof pkg.exports === 'object') {
+			subpathCount = Object.keys(pkg.exports).filter(
+				(k) => k.startsWith('./') && k !== './package.json'
+			).length
+		}
+	}
+
+	if (subpathCount >= 1) {
+		await fs.writeFile(path.join(targetDir, '.size-limit.cjs'), SIZE_LIMIT_CJS)
+		return '.size-limit.cjs'
+	}
 	await fs.writeJson(path.join(targetDir, '.size-limit.json'), SIZE_LIMIT_CONFIG, { spaces: 2 })
+	return '.size-limit.json'
 }
 
 export async function generateCodeowners(targetDir: string): Promise<string> {

--- a/tests/cli/generators/misc.test.ts
+++ b/tests/cli/generators/misc.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module'
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
@@ -7,9 +8,11 @@ import {
 	generateKnipConfig,
 	generateMiscBaseline,
 	generateNvmrc,
+	generateSizeLimitConfig,
 } from '../../../src/cli/generators/misc.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
+const require = createRequire(import.meta.url)
 const newTmpDir = useTmpDir()
 
 describe('generateEditorConfig', () => {
@@ -29,6 +32,59 @@ describe('generateNvmrc', () => {
 		await generateNvmrc(dir)
 		const content = await fs.readFile(join(dir, '.nvmrc'), 'utf-8')
 		expect(content.trim()).toBe('22')
+	})
+})
+
+describe('generateSizeLimitConfig', () => {
+	it('emits an exports-driven .size-limit.cjs for multi-subpath libraries', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			exports: {
+				'.': { import: './dist/index.js' },
+				'./hooks': { import: './dist/hooks/index.js' },
+				'./providers': { import: { types: './x.d.ts', default: './dist/providers/index.js' } },
+				'./package.json': './package.json',
+			},
+		})
+
+		const written = await generateSizeLimitConfig(dir)
+		expect(written).toBe('.size-limit.cjs')
+
+		// The generated config computes one budget per subpath from package.json
+		// at run time — the root '.' barrel and ./package.json are skipped.
+		const config = require(join(dir, '.size-limit.cjs')) as Array<{
+			name: string
+			path: string
+			limit: string
+		}>
+		expect(config).toHaveLength(2)
+		expect(config).toContainEqual({ name: 'demo/hooks', path: 'dist/hooks/index.js', limit: '10 kB' })
+		expect(config).toContainEqual({
+			name: 'demo/providers',
+			path: 'dist/providers/index.js',
+			limit: '10 kB',
+		})
+	})
+
+	it('falls back to a static .size-limit.json for a single-export package', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			exports: { '.': { import: './dist/index.js' } },
+		})
+
+		const written = await generateSizeLimitConfig(dir)
+		expect(written).toBe('.size-limit.json')
+		const config = await fs.readJson(join(dir, '.size-limit.json'))
+		expect(config[0].path).toBe('dist/index.js')
+	})
+
+	it('falls back to the static form when there is no package.json', async () => {
+		const dir = newTmpDir()
+		const written = await generateSizeLimitConfig(dir)
+		expect(written).toBe('.size-limit.json')
+		expect(await fs.pathExists(join(dir, '.size-limit.json'))).toBe(true)
 	})
 })
 


### PR DESCRIPTION
Closes #165.

A static `size-limit` array lists only a handful of a multi-subpath library's exports and silently drifts — new modules ship with no budget, so size regressions in them go uncaught (`browser-common` had budgets for 5 of 50 modules).

`generateSizeLimitConfig` now inspects `package.json` exports:
- **≥1 subpath export beyond the root barrel** → emits an exports-driven `.size-limit.cjs` that computes one budget per subpath *at run time*, so newly added modules are covered automatically. The root `.` barrel is skipped (it re-exports everything and grows legitimately); per-module overrides via an `OVERRIDES` map.
- **single/root-only export (or no package.json)** → keeps the static `.size-limit.json`.

`fix size-limit` writes whichever form fits; doctor already recognises `.size-limit.cjs`.

The generated `.cjs` handles all three exports-condition shapes (string `import`, nested `import.default`, bare string).

340 tests pass (+3, including a runtime `require()` of the generated config asserting one budget per subpath); typecheck + lint clean.