### PR TITLE
feat(scaffold): ship are-the-types-wrong in library verify + release

### DIFF
--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -201,7 +201,7 @@ ${
 
       - name: 🏗️ Build project
         run: pnpm build
-${config.publint ? '\n      - name: 🔍 Validate package with publint\n        run: pnpm exec publint --strict\n' : ''}
+${isLibrary ? '\n      - name: 🔍 Validate type resolution (are-the-types-wrong)\n        run: pnpm attw\n' : ''}${config.publint ? '\n      - name: 🔍 Validate package with publint\n        run: pnpm exec publint --strict\n' : ''}
       - name: 📦 Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -131,6 +131,13 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 		scripts['publint'] = 'publint --strict'
 	}
 
+	// are-the-types-wrong validates that a consumer's `import` actually resolves
+	// the shipped `.d.ts`. Only meaningful for publishable libraries. The default
+	// profile fits the dual (cjs+esm) exports the library scaffold emits.
+	if (config.projectType === 'library') {
+		scripts['attw'] = 'attw --pack'
+	}
+
 	// Git hooks
 	if (config.gitHooks) {
 		scripts['prepare'] = 'husky'
@@ -174,7 +181,11 @@ export function composeVerifyScript(
 	}
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
 	if (config.publint) cmds.push('pnpm publint')
-	return cmds.length >= 2 ? cmds.join(' && ') : null
+	// attw is a publish-safety rider, not a core check — it never justifies a
+	// verify chain on its own, so append it only once we've decided to emit one.
+	if (cmds.length < 2) return null
+	if (config.projectType === 'library') cmds.push('pnpm attw')
+	return cmds.join(' && ')
 }
 
 /**
@@ -260,6 +271,11 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 	if (config.gitHooks) {
 		deps['husky'] = '^9.0.0'
 		deps['lint-staged'] = '^16.0.0'
+	}
+
+	// are-the-types-wrong — validate published type resolution for libraries.
+	if (config.projectType === 'library') {
+		deps['@arethetypeswrong/cli'] = '^0.18.2'
 	}
 
 	// Commit linting

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -175,6 +175,9 @@ jobs:
       - name: 🏗️ Build project
         run: pnpm build
 
+      - name: 🔍 Validate type resolution (are-the-types-wrong)
+        run: pnpm attw
+
       - name: 📦 Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -255,9 +258,10 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "build": "tsup",
     "build:watch": "tsup --watch",
     "knip": "knip",
+    "attw": "attw --pack",
     "prepare": "husky",
     "release": "semantic-release",
-    "verify": "pnpm typecheck && pnpm check && pnpm exec vitest run"
+    "verify": "pnpm typecheck && pnpm check && pnpm exec vitest run && pnpm attw"
   },
   "dependencies": {},
   "devDependencies": {
@@ -270,6 +274,7 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "tsup": "^8.0.0",
     "husky": "^9.0.0",
     "lint-staged": "^16.0.0",
+    "@arethetypeswrong/cli": "^0.18.2",
     "@commitlint/cli": "^20.0.0",
     "@commitlint/config-conventional": "^20.0.0",
     "semantic-release": "^25.0.0",

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -112,6 +112,23 @@ describe('generateGitHubActions', () => {
 		expect(content).toContain('upload-artifact')
 	})
 
+	it('adds an attw type-resolution step to the build job for libraries', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig({ projectType: 'library', bundler: 'tsup' }), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).toContain('are-the-types-wrong')
+		expect(content).toContain('pnpm attw')
+	})
+
+	it('omits the attw step for non-library projects', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig({ projectType: 'react-app', bundler: 'vite' }), dir)
+
+		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+		expect(content).not.toContain('pnpm attw')
+	})
+
 	it('omits build job when bundler is none', async () => {
 		const dir = newTmpDir()
 		await generateGitHubActions(baseConfig({ bundler: 'none' }), dir)

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -61,6 +61,24 @@ describe('generatePackageJson', () => {
 		expect(pkg.devDependencies['@rtorcato/js-tooling']).toBe('latest')
 	})
 
+	it('wires are-the-types-wrong (attw) for library projects', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(baseConfig({ projectType: 'library' }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.attw).toBe('attw --pack')
+		expect(pkg.devDependencies['@arethetypeswrong/cli']).toBeDefined()
+	})
+
+	it('omits attw for non-library projects', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(baseConfig({ projectType: 'react-app' }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.attw).toBeUndefined()
+		expect(pkg.devDependencies['@arethetypeswrong/cli']).toBeUndefined()
+	})
+
 	it('adds library fields for library project type', async () => {
 		const dir = newTmpDir()
 		await generatePackageJson(baseConfig({ projectType: 'library' }), dir)
@@ -185,7 +203,9 @@ describe('generatePackageJson', () => {
 		)
 
 		const pkg = await fs.readJson(join(dir, 'package.json'))
-		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm check && pnpm exec vitest run')
+		expect(pkg.scripts.verify).toBe(
+			'pnpm typecheck && pnpm check && pnpm exec vitest run && pnpm attw'
+		)
 	})
 
 	it('omits the verify script when only one tool is enabled', async () => {
@@ -217,7 +237,7 @@ describe('generatePackageJson', () => {
 		const pkg = await fs.readJson(join(dir, 'package.json'))
 		expect(pkg.devDependencies.publint).toBe('^0.3.0')
 		expect(pkg.scripts.publint).toBe('publint --strict')
-		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm check && pnpm publint')
+		expect(pkg.scripts.verify).toBe('pnpm typecheck && pnpm check && pnpm publint && pnpm attw')
 	})
 
 	it('omits publint when not enabled', async () => {
@@ -238,7 +258,7 @@ describe('composeVerifyScript', () => {
 				testing: { framework: 'vitest' },
 			})
 		)
-		expect(result).toBe('pnpm typecheck && pnpm lint && pnpm exec vitest run')
+		expect(result).toBe('pnpm typecheck && pnpm lint && pnpm exec vitest run && pnpm attw')
 	})
 
 	it('uses pnpm test --ci for jest projects', () => {
@@ -248,7 +268,7 @@ describe('composeVerifyScript', () => {
 				testing: { framework: 'jest' },
 			})
 		)
-		expect(result).toBe('pnpm typecheck && pnpm check && pnpm test --ci')
+		expect(result).toBe('pnpm typecheck && pnpm check && pnpm test --ci && pnpm attw')
 	})
 
 	it('returns null when fewer than two tools are enabled', () => {


### PR DESCRIPTION
Closes #164.

`doctor` *flagged* the absence of `are-the-types-wrong` (attw) but the scaffold never *provided* it — each sibling hand-added the dep, script, and CI wiring (`browser-common` #27 was the signal it belongs upstream). Without attw in CI, a broken `types` resolution in `exports` can ship to npm undetected.

Library projects now get it by default:
- **dep + script:** `@arethetypeswrong/cli` devDependency + `"attw": "attw --pack"` (the default profile fits the dual cjs+esm exports the library scaffold emits).
- **verify:** `attw` appended to the composed `verify` chain — but as a *publish-safety rider*: it's added only after the chain already has ≥2 core checks, so it never fabricates a verify chain for a single-tool project (that invariant is covered by a regression test).
- **CI:** an `attw` step in the build job, so a broken type resolution fails the build and blocks the release job (`release` `needs: build`).

Net effect: a fresh library scaffold passes its own `are-the-types-wrong` doctor check out of the box. The existing `fix attw` still handles retrofitting existing repos.

341 tests pass (+4: attw dep/script for library, omitted for non-library, CI step present/absent; plus the single-tool verify invariant preserved); snapshots + typecheck + lint clean.