### PR TITLE
feat(doctor): language field + detectLanguage() detector (#140)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import { BADGE_START, hasPublicOnlyBadges } from '../generators/badges.js'
+import { detectLanguage } from '../utils/detect-language.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
 
@@ -1296,6 +1297,23 @@ async function checkGitLabCI(dir: string): Promise<CheckResult> {
 
 export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	const targetDir = path.resolve(dir)
+
+	// Seam: gate the whole JS check suite by detected language. A Swift/Perl/
+	// Python repo gets a single informative result instead of ~26 JS "missing"
+	// findings. 'unknown' (bare dir) still runs the JS suite — that's a fresh
+	// repo mid-setup. ponytail: per-check language tagging is the umbrella (#139)
+	// follow-up; today the whole suite is JS, so a top-level guard is enough.
+	const language = await detectLanguage(targetDir)
+	if (language !== 'js' && language !== 'unknown') {
+		return [
+			{
+				check: 'language',
+				status: 'ok',
+				detail: `detected ${language} project — ${PACKAGE} checks are JavaScript-focused and were skipped`,
+			},
+		]
+	}
+
 	const pkg = await readPackageJson(targetDir)
 	const lock = await readLockfile(targetDir)
 	const results: CheckResult[] = []

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -11,6 +11,7 @@ export const PRESET_NAMES: readonly PresetName[] = [
 ] as const
 
 const BASE: Omit<ProjectConfig, 'projectName' | 'projectType' | 'typescript' | 'bundler'> = {
+	language: 'js',
 	linting: { tool: 'biome' },
 	formatting: { tool: 'biome' },
 	testing: { framework: 'vitest', environment: 'node' },
@@ -95,6 +96,7 @@ export const CONFIG_SCHEMA = {
 	],
 	properties: {
 		projectName: { type: 'string', minLength: 1 },
+		language: { type: 'string', enum: ['js', 'swift', 'perl', 'python'] },
 		projectType: {
 			type: 'string',
 			enum: ['library', 'web-app', 'node-api', 'nextjs-app', 'react-app'],

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -17,6 +17,12 @@ import {
 
 export interface ProjectConfig {
 	projectName: string
+	/**
+	 * Primary language of the repo. Optional for backward compat — lockfiles
+	 * written before v2 lack it and are migrated to 'js' on read. New setups
+	 * always record it. Part of the multi-language seam (#139/#140).
+	 */
+	language?: 'js' | 'swift' | 'perl' | 'python'
 	projectType: 'library' | 'web-app' | 'node-api' | 'nextjs-app' | 'react-app'
 	typescript: {
 		enabled: boolean
@@ -325,6 +331,9 @@ async function promptForConfig(): Promise<ProjectConfig> {
 
 	return {
 		projectName: answers.projectName,
+		// v1 of the setup wizard scaffolds JS/TS repos only; the field exists so
+		// doctor/fix can gate by language (#139). No prompt yet — always 'js'.
+		language: 'js',
 		projectType: answers.projectType,
 		typescript: {
 			enabled: answers.useTypeScript || false,

--- a/src/cli/utils/detect-language.ts
+++ b/src/cli/utils/detect-language.ts
@@ -1,0 +1,25 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+export type DetectedLanguage = 'js' | 'swift' | 'perl' | 'python' | 'unknown'
+
+/**
+ * Marker files that identify a repo's language, checked in order — first match
+ * wins. One language per repo root; multi-language monorepos are out of scope
+ * for v1 (see #139). A dir with no marker → 'unknown' (base checks only).
+ */
+const MARKERS: ReadonlyArray<[DetectedLanguage, readonly string[]]> = [
+	['js', ['package.json']],
+	['swift', ['Package.swift']],
+	['perl', ['cpanfile', 'Makefile.PL', 'dist.ini']],
+	['python', ['pyproject.toml', 'setup.py']],
+]
+
+export async function detectLanguage(dir: string): Promise<DetectedLanguage> {
+	for (const [language, candidates] of MARKERS) {
+		for (const candidate of candidates) {
+			if (await fs.pathExists(path.join(dir, candidate))) return language
+		}
+	}
+	return 'unknown'
+}

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -5,7 +5,9 @@ import { validateProjectConfig } from '../commands/setup-presets.js'
 import type { ProjectConfig } from '../commands/setup.js'
 
 export const LOCKFILE_NAME = '.js-tooling.json'
-export const LOCKFILE_VERSION = 1
+// v2 added ProjectConfig.language (multi-language seam, #140). v1 files are
+// migrated to v2 on read, defaulting language to 'js'.
+export const LOCKFILE_VERSION = 2
 const LOCKFILE_SCHEMA_URL = 'https://rtorcato.github.io/js-tooling/schemas/lockfile.json'
 
 export interface Lockfile {
@@ -14,6 +16,20 @@ export interface Lockfile {
 	config: ProjectConfig
 	writtenBy: string
 	writtenAt: string
+}
+
+/**
+ * Upgrade an older lockfile in-memory. Only touches files older than the
+ * current version, so a newer-than-supported file is left as-is for
+ * checkLockfile to flag. The file is rewritten to v2 next time it's saved.
+ */
+function migrate(lock: Lockfile): Lockfile {
+	if (lock.version >= LOCKFILE_VERSION) return lock
+	return {
+		...lock,
+		version: LOCKFILE_VERSION,
+		config: { language: 'js', ...lock.config },
+	}
 }
 
 export async function readLockfile(dir: string): Promise<Lockfile | null> {
@@ -25,7 +41,7 @@ export async function readLockfile(dir: string): Promise<Lockfile | null> {
 		const obj = raw as Record<string, unknown>
 		if (typeof obj.version !== 'number') return null
 		if (typeof obj.config !== 'object' || obj.config === null) return null
-		return obj as unknown as Lockfile
+		return migrate(obj as unknown as Lockfile)
 	} catch {
 		return null
 	}

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -732,7 +732,7 @@ describe('fix + lockfile', () => {
 		await seedPackageJson(dir)
 		await fixCommand('lockfile', { directory: dir, yes: true })
 		const lock = await fs.readJson(join(dir, '.js-tooling.json'))
-		expect(lock.version).toBe(1)
+		expect(lock.version).toBe(2)
 		expect(lock.config.projectName).toBe('demo')
 		expect(lock.config.linting.tool).toBe('biome')
 	})

--- a/tests/cli/utils/detect-language.test.ts
+++ b/tests/cli/utils/detect-language.test.ts
@@ -1,0 +1,34 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { detectLanguage } from '../../../src/cli/utils/detect-language.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('detectLanguage', () => {
+	it('returns unknown for a bare dir with no marker files', async () => {
+		expect(await detectLanguage(newTmpDir())).toBe('unknown')
+	})
+
+	it.each([
+		['package.json', 'js'],
+		['Package.swift', 'swift'],
+		['cpanfile', 'perl'],
+		['Makefile.PL', 'perl'],
+		['dist.ini', 'perl'],
+		['pyproject.toml', 'python'],
+		['setup.py', 'python'],
+	])('resolves %s to %s', async (marker, expected) => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, marker), '')
+		expect(await detectLanguage(dir)).toBe(expected)
+	})
+
+	it('prefers js when package.json coexists with another marker (first match wins)', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'package.json'), '{}')
+		await fs.writeFile(join(dir, 'pyproject.toml'), '')
+		expect(await detectLanguage(dir)).toBe('js')
+	})
+})

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -47,6 +47,22 @@ describe('readLockfile', () => {
 		await fs.writeJson(join(dir, LOCKFILE_NAME), { writtenBy: 'x' })
 		expect(await readLockfile(dir)).toBeNull()
 	})
+
+	it('migrates a v1 file to v2, defaulting language to js', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, LOCKFILE_NAME), {
+			version: 1,
+			config: baseConfig(), // baseConfig predates the language field
+			writtenBy: 'old',
+			writtenAt: '2024-01-01T00:00:00.000Z',
+		})
+
+		const lock = await readLockfile(dir)
+		expect(lock?.version).toBe(2)
+		expect(lock?.config.language).toBe('js')
+		// Existing fields survive the migration untouched.
+		expect(lock?.config.projectName).toBe('demo')
+	})
 })
 
 describe('writeLockfile', () => {


### PR DESCRIPTION
Closes #140. Seams 1-2 of the multi-language umbrella (#139) — the enabling groundwork so doctor/fix can gate by language.

## Seam 1 — `language` field
- Optional `ProjectConfig.language: 'js' | 'swift' | 'perl' | 'python'` (optional for backward compat; pre-existing lockfiles/`--config` files still validate). Presets + the interactive prompt now record `'js'`.
- `LOCKFILE_VERSION` bumped 1→2 with an on-read `migrate()` that defaults pre-v2 lockfiles to `language: 'js'`. Only older files are upgraded, so a newer-than-supported lockfile is still flagged by `checkLockfile`.

## Seam 2 — `detectLanguage(dir)`
- New `src/cli/utils/detect-language.ts`. First marker-file match wins: `package.json`→js · `Package.swift`→swift · `cpanfile`/`Makefile.PL`/`dist.ini`→perl · `pyproject.toml`/`setup.py`→python · else `unknown`.
- Wired at the top of `runDoctor` (which `fixCommand` flows through): a Swift/Perl/Python repo returns a single informative `language` result instead of ~26 JS "missing" findings. `unknown` (bare dir mid-setup) and `js` run the full suite unchanged.
- `readPackageJson` was already private to `doctor.ts`/`fix.ts` — no change needed.

## Scope
Per the issue title ("seams 1-2") and its Tests section, this is the enabling groundwork. **Per-check language tagging of all ~26 checks is intentionally deferred to the umbrella (#139)** — marked with a `ponytail:` comment at the guard. A top-level guard already delivers the "doctor skips a Perl repo" payoff today.

## Tests
- `detect-language.test.ts`: each marker resolves to the right language; bare dir → `unknown`; js wins when `package.json` coexists with another marker.
- `lockfile.test.ts`: a v1 file loads as v2 with `language: 'js'`, existing fields preserved.
- Updated one `fix.test.ts` assertion for the version bump (1→2).

Full suite: **359 passing**; typecheck + biome clean. Also drove `runDoctor` against real Perl and JS dirs — Perl → 1 result, JS → 36 checks.