### PR TITLE
feat(cli): add Turborepo preset for pnpm workspaces (#68)

### DIFF
--- a/apps/docs/docs/reference/turborepo.md
+++ b/apps/docs/docs/reference/turborepo.md
@@ -1,0 +1,70 @@
+---
+title: Turborepo
+description: Starter turbo.json task pipeline for pnpm-workspace monorepos.
+---
+
+[Turborepo](https://turborepo.com) caches and parallelizes tasks across a
+pnpm-workspace monorepo. js-tooling scaffolds a starter `turbo.json` with a
+sensible build/lint/typecheck/test/dev pipeline — you tune the `outputs` to
+match what each package emits.
+
+Because it only makes sense in a monorepo, the setup wizard offers it **only
+when the target directory already contains `pnpm-workspace.yaml`**, and
+`doctor` only reports on it inside a workspace.
+
+## Usage
+
+Scaffold it into an existing monorepo:
+
+```bash
+npx @rtorcato/js-tooling fix turborepo
+```
+
+`setup` also offers it interactively when it detects a `pnpm-workspace.yaml`.
+The fixer is **safe-add** — it never overwrites an existing `turbo.json`.
+
+## Generated `turbo.json`
+
+```json
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+    },
+    "lint": {},
+    "typecheck": { "dependsOn": ["^build"] },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "dev": { "cache": false, "persistent": true }
+  }
+}
+```
+
+- `dependsOn: ["^build"]` — a task waits for the same task in its workspace
+  dependencies to finish first (the `^` means "upstream packages").
+- `outputs` — the files Turborepo caches per task. Trim these to what your
+  packages actually produce (e.g. drop `.next/**` if you have no Next.js app).
+- `dev` is `cache: false` + `persistent: true` — long-running, never cached.
+
+## Peer dependency
+
+Add `turbo` to the workspace root `devDependencies` and wire the scripts:
+
+```json
+{
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "lint": "turbo run lint"
+  },
+  "devDependencies": {
+    "turbo": "^2"
+  }
+}
+```
+
+Then `doctor` reports `Turborepo — ok` once `turbo.json` is present.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -57,6 +57,7 @@ const sidebars: SidebarsConfig = {
         'reference/rollup',
         'reference/semantic-release',
         'reference/tsup',
+        'reference/turborepo',
         'reference/typescript',
         'reference/vitest',
       ],

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1319,6 +1319,20 @@ async function checkAiSetup(dir: string): Promise<CheckResult> {
 	}
 }
 
+// Only called for pnpm-workspace monorepos (see runDoctor) — a single-package
+// repo has no use for turbo.json, so the check would be noise there.
+async function checkTurborepo(dir: string): Promise<CheckResult> {
+	if (await fs.pathExists(path.join(dir, 'turbo.json'))) {
+		return { check: 'Turborepo', status: 'ok', detail: 'turbo.json found' }
+	}
+	return {
+		check: 'Turborepo',
+		status: 'optional-missing',
+		detail: 'pnpm workspace without turbo.json',
+		hint: 'Run `npx @rtorcato/js-tooling fix turborepo` to scaffold a task pipeline',
+	}
+}
+
 async function checkGitLabCI(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -1375,6 +1389,10 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkReadmeBadges(targetDir, pkg))
 	results.push(await checkCoverageUpload(targetDir))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
+	// Turborepo is monorepo-only — only surface the check when a workspace exists.
+	if (await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))) {
+		results.push(await checkTurborepo(targetDir))
+	}
 
 	// Lockfile-driven demotion: if the lock records an intentional opt-out for a
 	// check that's currently optional-missing, demote it to ok with a clear detail.

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -28,6 +28,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	CodeQL: 'codeql',
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
+	Turborepo: 'turborepo',
 	lockfile: 'lockfile',
 	'.js-tooling.json': 'lockfile',
 	'are-the-types-wrong': 'attw',
@@ -85,6 +86,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			return c.badges === false
 		case 'AI setup':
 			return c.aiSetup === false
+		case 'Turborepo':
+			return c.turborepo === false
 		default:
 			return false
 	}
@@ -143,6 +146,8 @@ export function lockfilePatchForTarget(
 			return c.badges ? null : { badges: true }
 		case 'ai':
 			return c.aiSetup ? null : { aiSetup: true }
+		case 'turborepo':
+			return c.turborepo ? null : { turborepo: true }
 		default:
 			return null
 	}

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -35,6 +35,7 @@ import {
 } from '../generators/security.js'
 import { generateVitestConfig } from '../generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../generators/treeshake.js'
+import { generateTurborepo } from '../generators/turborepo.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../generators/typedoc.js'
 import { copyPreset } from '../utils/copy-preset.js'
 import {
@@ -414,6 +415,18 @@ const FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			const written = await generateGitLabCI(inferProjectConfig(pkg), targetDir)
+			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'turborepo',
+		description: 'Scaffold turbo.json task pipeline (pnpm-workspace monorepos)',
+		appliesTo: ['Turborepo'],
+		outputs: ['turbo.json'],
+		// safe-add: never clobber a hand-tuned turbo.json.
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const written = await generateTurborepo(targetDir)
 			return { filesWritten: [written] }
 		},
 	},

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -143,6 +143,7 @@ export const CONFIG_SCHEMA = {
 		publint: { type: 'boolean' },
 		badges: { type: 'boolean' },
 		aiSetup: { type: 'boolean' },
+		turborepo: { type: 'boolean' },
 	},
 } as const
 
@@ -236,6 +237,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 			'.mcp.json.example'
 		)
 	}
+	if (config.turborepo) files.push('turbo.json')
 	files.push('README.md')
 	return files
 }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -47,6 +47,8 @@ export interface ProjectConfig {
 	badges?: boolean
 	/** Scaffold AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example). */
 	aiSetup?: boolean
+	/** Scaffold a turbo.json task pipeline (pnpm-workspace monorepos). */
+	turborepo?: boolean
 }
 
 export interface SetupOptions {
@@ -81,7 +83,7 @@ async function resolveConfig(options: SetupOptions): Promise<ProjectConfig> {
 		const projectName = path.basename(path.resolve(options.directory))
 		return buildPresetConfig(options.preset as PresetName, projectName)
 	}
-	return promptForConfig()
+	return promptForConfig(path.resolve(options.directory))
 }
 
 export async function setupProject(options: SetupOptions) {
@@ -134,7 +136,10 @@ export async function setupProject(options: SetupOptions) {
 	}
 }
 
-async function promptForConfig(): Promise<ProjectConfig> {
+async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
+	// Turborepo only makes sense in a pnpm-workspace monorepo, so the prompt is
+	// only offered when one is already present in the target dir.
+	const hasWorkspace = await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))
 	const answers = await inquirer.prompt([
 		{
 			type: 'input',
@@ -302,6 +307,13 @@ async function promptForConfig(): Promise<ProjectConfig> {
 			default: true,
 		},
 		{
+			type: 'confirm',
+			name: 'turborepo',
+			message: '🚀 Add a Turborepo task pipeline (turbo.json)?',
+			default: true,
+			when: () => hasWorkspace,
+		},
+		{
 			type: 'list',
 			name: 'bundler',
 			message: '📦 Which bundler/build tool?',
@@ -357,6 +369,7 @@ async function promptForConfig(): Promise<ProjectConfig> {
 		publint: answers.publint ?? false,
 		badges: answers.badges ?? false,
 		aiSetup: answers.aiSetup ?? false,
+		turborepo: answers.turborepo ?? false,
 	}
 }
 

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -14,6 +14,7 @@ import { generateSecurityConfigs } from './security.js'
 import { generateTestingConfigs } from './testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from './treeshake.js'
 import { generateTSConfig } from './tsconfig.js'
+import { generateTurborepo } from './turborepo.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -84,6 +85,11 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 	// after the treeshake-check path so its richer workspace file (if written)
 	// is never clobbered.
 	await ensureBuildApprovals(config, targetDir)
+
+	// Turborepo task pipeline (pnpm-workspace monorepos, when opted-in)
+	if (config.turborepo) {
+		await generateTurborepo(targetDir)
+	}
 
 	// AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example)
 	if (config.aiSetup) {

--- a/src/cli/generators/turborepo.ts
+++ b/src/cli/generators/turborepo.ts
@@ -1,0 +1,37 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * Scaffold a starter turbo.json for a pnpm-workspace monorepo. Turborepo 2.x
+ * (`tasks`, not the pre-2.0 `pipeline`). The defaults cover the common
+ * build/lint/typecheck/test/dev pipeline; teams tune outputs per repo.
+ */
+export async function generateTurborepo(targetDir: string): Promise<string> {
+	const filepath = path.join(targetDir, 'turbo.json')
+	await fs.writeJson(filepath, TURBO_CONFIG, { spaces: 2 })
+	return 'turbo.json'
+}
+
+const TURBO_CONFIG = {
+	$schema: 'https://turborepo.com/schema.json',
+	tasks: {
+		build: {
+			dependsOn: ['^build'],
+			// Covers both plain bundlers (dist) and Next.js apps; cache is invalidated
+			// on source changes. Drop what your packages don't emit.
+			outputs: ['dist/**', '.next/**', '!.next/cache/**'],
+		},
+		lint: {},
+		typecheck: {
+			dependsOn: ['^build'],
+		},
+		test: {
+			dependsOn: ['^build'],
+			outputs: ['coverage/**'],
+		},
+		dev: {
+			cache: false,
+			persistent: true,
+		},
+	},
+} as const

--- a/tests/cli/generators/turborepo.test.ts
+++ b/tests/cli/generators/turborepo.test.ts
@@ -1,0 +1,48 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { generateTurborepo } from '../../../src/cli/generators/turborepo.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('generateTurborepo', () => {
+	it('writes a valid turbo.json with a task pipeline', async () => {
+		const dir = newTmpDir()
+		const written = await generateTurborepo(dir)
+		expect(written).toBe('turbo.json')
+
+		const turbo = await fs.readJson(join(dir, 'turbo.json'))
+		expect(turbo.$schema).toContain('turborepo')
+		expect(turbo.tasks.build.dependsOn).toEqual(['^build'])
+		expect(turbo.tasks.build.outputs).toContain('dist/**')
+		expect(turbo.tasks.dev).toEqual({ cache: false, persistent: true })
+	})
+})
+
+describe('doctor Turborepo check', () => {
+	const findTurbo = (results: { check: string }[]) =>
+		results.find((r) => r.check === 'Turborepo')
+
+	it('does not surface the check in a single-package repo', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		expect(findTurbo(await runDoctor(dir))).toBeUndefined()
+	})
+
+	it('flags optional-missing in a workspace without turbo.json', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		expect(findTurbo(await runDoctor(dir))?.status).toBe('optional-missing')
+	})
+
+	it('reports ok in a workspace with turbo.json', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		await generateTurborepo(dir)
+		expect(findTurbo(await runDoctor(dir))?.status).toBe('ok')
+	})
+})


### PR DESCRIPTION
Closes #68. Adds a Turborepo preset so pnpm-workspace monorepos get a sensible `turbo.json` to start from — scaffolded via setup/fix and audited by doctor.

## What
- **Generator** (`src/cli/generators/turborepo.ts`): renders a Turborepo 2.x `turbo.json` (`tasks`, not the pre-2.0 `pipeline`) with a build/lint/typecheck/test/dev pipeline, `dependsOn: ["^build"]`, and per-task `outputs`.
- **Setup wizard**: offers "Add a Turborepo task pipeline?" **only when the target dir already contains `pnpm-workspace.yaml`** (turbo is monorepo-only). `promptForConfig` now takes the resolved target dir to make that check.
- **`fix turborepo`**: `safe-add` scaffolder — never clobbers a hand-tuned `turbo.json`. Wired into `FIXERS`, `FIX_TARGETS`, `lockfilePatchForTarget`, and `declinedInLock` for lockfile intent tracking.
- **Doctor check**: `Turborepo` — surfaced **only inside a workspace root** (`optional-missing` without `turbo.json`, `ok` with it). Kept out of single-package repos to avoid noise.
- **`ProjectConfig.turborepo`** flag + JSON schema + `computeFileList` entry.
- **Docs**: `apps/docs/docs/reference/turborepo.md` + sidebar entry.

## Design note
The `turbo.json` is rendered inline (like the GitLab CI / GitHub Actions generators) rather than copied from a `tooling/turborepo/` template — `tooling/` holds the *published* shared configs consumer repos extend, whereas `turbo.json` is a scaffolded, per-repo file. Same pattern every other CI/config generator here uses.

## Tests
- `turborepo.test.ts`: generator emits a valid task pipeline; doctor check is **absent** in a single-package repo, `optional-missing` in a workspace without `turbo.json`, `ok` with it.
- Also drove `fix turborepo --yes` end-to-end against a real workspace dir (all five tasks written).

Full suite: **363 passing**; typecheck + biome clean.