### PR TITLE
feat(cli): add optional deploy workflow templates via fix (#66)

### DIFF
--- a/apps/docs/docs/reference/github-actions.md
+++ b/apps/docs/docs/reference/github-actions.md
@@ -1,0 +1,35 @@
+---
+title: GitHub Actions
+description: The CI workflow scaffolded by setup, plus optional deploy workflows you can add with fix.
+---
+
+Every scaffold gets a `ci.yml` (lint / typecheck / test / build, and release for
+libraries) out of the box. Beyond that, js-tooling ships **optional deploy
+workflows** you add on demand — they're too deploy-target-specific to scaffold
+by default, so the setup wizard never prompts for them.
+
+## Optional deploy workflows
+
+Add any of these to an existing repo with `fix`:
+
+```bash
+npx @rtorcato/js-tooling fix docker-publish
+npx @rtorcato/js-tooling fix vercel-deploy
+npx @rtorcato/js-tooling fix cloudflare-pages
+npx @rtorcato/js-tooling fix preview-deployments
+```
+
+Each is **safe-add** — it writes `.github/workflows/<name>.yml` only if that
+file doesn't already exist, so it never clobbers a workflow you've customized.
+
+| Target | Workflow | Trigger | Secrets |
+|---|---|---|---|
+| `docker-publish` | Build + push a Docker image to GHCR | tag push (`v*`) | none (uses `GITHUB_TOKEN`) |
+| `vercel-deploy` | Production deploy to Vercel | push to `main` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` |
+| `cloudflare-pages` | Deploy a static build to Cloudflare Pages | push to `main` | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` |
+| `preview-deployments` | Per-PR preview deploy + URL comment | `pull_request` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` |
+
+Each workflow ships with least-privilege `permissions:` and references its
+secrets via `${{ secrets.* }}` — add them under **Settings → Secrets and
+variables → Actions** in your repo. A couple carry a placeholder to fill in
+(the Cloudflare Pages `--project-name`, for example).

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -50,6 +50,7 @@ const sidebars: SidebarsConfig = {
         'reference/commitlint',
         'reference/esbuild',
         'reference/eslint',
+        'reference/github-actions',
         'reference/jest',
         'reference/oxlint',
         'reference/prettier',

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"tooling/semantic-release/*.d.mts",
 		"tooling/claude/*.md",
 		"tooling/mcp/mcp.json.example",
+		"tooling/github-actions/workflows/*.yml",
 		"README.md"
 	],
 	"exports": {

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -15,6 +15,7 @@ import {
 } from '../generators/git.js'
 import { generateGitHubActions } from '../generators/github-actions.js'
 import { generateGitLabCI } from '../generators/gitlab-ci.js'
+import { GH_WORKFLOWS, generateGhWorkflow } from '../generators/github-workflows.js'
 import { generateESLintConfig, generatePrettierConfig } from '../generators/linting.js'
 import {
 	ensureEnginesNode,
@@ -156,6 +157,40 @@ function hasRequireCondition(exports: unknown): boolean {
 function isEsmOnly(pkg: Record<string, unknown>): boolean {
 	return pkg.type === 'module' && !hasRequireCondition(pkg.exports)
 }
+
+// Optional deploy workflows (issue #66). One flat fix target each, no doctor
+// check and no setup prompt — they're opt-in and too deploy-specific to nag.
+const GH_WORKFLOW_META: Record<(typeof GH_WORKFLOWS)[number], { check: string; desc: string }> = {
+	'docker-publish': {
+		check: 'Docker publish workflow',
+		desc: 'Scaffold .github/workflows/docker-publish.yml (build + push image to GHCR on tag)',
+	},
+	'vercel-deploy': {
+		check: 'Vercel deploy workflow',
+		desc: 'Scaffold .github/workflows/vercel-deploy.yml (production deploy to Vercel on main)',
+	},
+	'cloudflare-pages': {
+		check: 'Cloudflare Pages workflow',
+		desc: 'Scaffold .github/workflows/cloudflare-pages.yml (static-site deploy to Cloudflare Pages)',
+	},
+	'preview-deployments': {
+		check: 'Preview deployments workflow',
+		desc: 'Scaffold .github/workflows/preview-deployments.yml (per-PR preview deploy)',
+	},
+}
+
+const GH_WORKFLOW_FIXERS: Fixer[] = GH_WORKFLOWS.map((name) => ({
+	target: name,
+	description: GH_WORKFLOW_META[name].desc,
+	appliesTo: [GH_WORKFLOW_META[name].check],
+	outputs: [`.github/workflows/${name}.yml`],
+	// safe-add: never clobber an existing workflow of the same name.
+	riskLevel: 'safe-add',
+	async run({ targetDir }) {
+		const written = await generateGhWorkflow(name, targetDir)
+		return { filesWritten: [written] }
+	},
+}))
 
 const FIXERS: Fixer[] = [
 	{
@@ -417,6 +452,7 @@ const FIXERS: Fixer[] = [
 			return { filesWritten: [written] }
 		},
 	},
+	...GH_WORKFLOW_FIXERS,
 	{
 		target: 'editorconfig',
 		description: 'Scaffold .editorconfig (UTF-8, LF, tab indent)',

--- a/src/cli/generators/github-workflows.ts
+++ b/src/cli/generators/github-workflows.ts
@@ -1,0 +1,28 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+import { getPackageRoot } from '../utils/copy-preset.js'
+
+/**
+ * Optional GitHub Actions deploy workflows, scaffolded on demand via
+ * `fix <name>`. They're static templates (no config-driven branching) copied
+ * verbatim from tooling/, unlike the config-aware ci.yml generator. Setup does
+ * not scaffold these — they're too deploy-target-specific to assume.
+ */
+export const GH_WORKFLOWS = [
+	'docker-publish',
+	'vercel-deploy',
+	'cloudflare-pages',
+	'preview-deployments',
+] as const
+
+export type GhWorkflow = (typeof GH_WORKFLOWS)[number]
+
+export async function generateGhWorkflow(name: GhWorkflow, targetDir: string): Promise<string> {
+	const source = path.join(getPackageRoot(), 'tooling/github-actions/workflows', `${name}.yml`)
+	const relTarget = path.join('.github', 'workflows', `${name}.yml`)
+	// Self-enforced safe-add: these fixers have no doctor check, so the fix
+	// command's own safe-add guard (which keys off an `ok` check) can't kick in.
+	// overwrite:false keeps a user-customized workflow of the same name intact.
+	await fs.copy(source, path.join(targetDir, relTarget), { overwrite: false, errorOnExist: false })
+	return relTarget
+}

--- a/tests/cli/generators/github-workflows.test.ts
+++ b/tests/cli/generators/github-workflows.test.ts
@@ -1,0 +1,73 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import {
+	GH_WORKFLOWS,
+	generateGhWorkflow,
+} from '../../../src/cli/generators/github-workflows.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('generateGhWorkflow', () => {
+	it.each(GH_WORKFLOWS)('scaffolds %s into .github/workflows', async (name) => {
+		const dir = newTmpDir()
+		const written = await generateGhWorkflow(name, dir)
+		expect(written).toBe(`.github/workflows/${name}.yml`)
+
+		const yaml = await fs.readFile(join(dir, written), 'utf-8')
+		// Every workflow declares a name, a trigger, and least-privilege perms.
+		expect(yaml).toMatch(/^name:/m)
+		expect(yaml).toMatch(/^on:/m)
+		expect(yaml).toMatch(/^permissions:/m)
+		expect(yaml).toMatch(/^jobs:/m)
+	})
+
+	it('docker-publish uses GHCR + GITHUB_TOKEN and triggers on tags', async () => {
+		const dir = newTmpDir()
+		await generateGhWorkflow('docker-publish', dir)
+		const yaml = await fs.readFile(join(dir, '.github/workflows/docker-publish.yml'), 'utf-8')
+		expect(yaml).toContain('ghcr.io')
+		expect(yaml).toContain('secrets.GITHUB_TOKEN')
+		expect(yaml).toContain("tags: ['v*']")
+		expect(yaml).toContain('packages: write')
+	})
+
+	it('vercel-deploy references the Vercel secrets', async () => {
+		const dir = newTmpDir()
+		await generateGhWorkflow('vercel-deploy', dir)
+		const yaml = await fs.readFile(join(dir, '.github/workflows/vercel-deploy.yml'), 'utf-8')
+		for (const secret of ['VERCEL_TOKEN', 'VERCEL_ORG_ID', 'VERCEL_PROJECT_ID']) {
+			expect(yaml).toContain(secret)
+		}
+	})
+
+	it('cloudflare-pages references the Cloudflare secrets', async () => {
+		const dir = newTmpDir()
+		await generateGhWorkflow('cloudflare-pages', dir)
+		const yaml = await fs.readFile(join(dir, '.github/workflows/cloudflare-pages.yml'), 'utf-8')
+		expect(yaml).toContain('CLOUDFLARE_API_TOKEN')
+		expect(yaml).toContain('CLOUDFLARE_ACCOUNT_ID')
+	})
+
+	it('preview-deployments triggers on pull_request', async () => {
+		const dir = newTmpDir()
+		await generateGhWorkflow('preview-deployments', dir)
+		const yaml = await fs.readFile(join(dir, '.github/workflows/preview-deployments.yml'), 'utf-8')
+		expect(yaml).toContain('pull_request:')
+		expect(yaml).toContain('pull-requests: write')
+	})
+
+	it('is safe-add: does not clobber an existing workflow', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.github/workflows'))
+		// Simulate a user-customized workflow already in place, then run the fixer
+		// through the fix command path (which enforces safe-add).
+		const path = join(dir, '.github/workflows/docker-publish.yml')
+		await fs.writeFile(path, 'name: mine\n')
+		const { fixCommand } = await import('../../../src/cli/commands/fix.js')
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fixCommand('docker-publish', { directory: dir, yes: true, silent: true })
+		expect(await fs.readFile(path, 'utf-8')).toBe('name: mine\n')
+	})
+})

--- a/tooling/github-actions/workflows/cloudflare-pages.yml
+++ b/tooling/github-actions/workflows/cloudflare-pages.yml
@@ -1,0 +1,42 @@
+# Deploy a static build to Cloudflare Pages on push to main.
+# Secrets: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID
+# Set your Pages project name below (replace YOUR_PROJECT) and the build
+# output dir if it isn't `dist`.
+name: ☁️ Cloudflare Pages Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=YOUR_PROJECT

--- a/tooling/github-actions/workflows/docker-publish.yml
+++ b/tooling/github-actions/workflows/docker-publish.yml
@@ -1,0 +1,44 @@
+# Build and publish a Docker image to GHCR on tag push.
+# Requires a Dockerfile at the repo root. No extra secrets needed —
+# GITHUB_TOKEN authenticates to ghcr.io for the current repository.
+name: 🐳 Docker Publish
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/tooling/github-actions/workflows/preview-deployments.yml
+++ b/tooling/github-actions/workflows/preview-deployments.yml
@@ -1,0 +1,54 @@
+# Per-PR preview deploy to Vercel. Posts a preview URL for every pull request
+# so reviewers can click through the change before merge.
+# Secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+name: 🔍 Preview Deployment
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy preview
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on the PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🔍 Preview deployed: ${{ steps.deploy.outputs.url }}`,
+            })

--- a/tooling/github-actions/workflows/vercel-deploy.yml
+++ b/tooling/github-actions/workflows/vercel-deploy.yml
@@ -1,0 +1,40 @@
+# Production deploy to Vercel on push to main.
+# Secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+# (Project Settings → Tokens, and `vercel link` writes the org/project IDs.)
+name: ▲ Vercel Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Closes #66. Ships four opt-in GitHub Actions deploy workflows, scaffolded on demand via `fix`.

## Targets
```bash
npx @rtorcato/js-tooling fix docker-publish       # build + push image to GHCR on tag
npx @rtorcato/js-tooling fix vercel-deploy         # production deploy to Vercel on main
npx @rtorcato/js-tooling fix cloudflare-pages      # static-site deploy to Cloudflare Pages
npx @rtorcato/js-tooling fix preview-deployments   # per-PR preview deploy + URL comment
```

| Target | Trigger | Secrets | Permissions |
|---|---|---|---|
| `docker-publish` | tag `v*` | none (`GITHUB_TOKEN`) | `packages: write` |
| `vercel-deploy` | push `main` | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` | `contents: read` |
| `cloudflare-pages` | push `main` | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` | `deployments: write` |
| `preview-deployments` | `pull_request` | Vercel secrets | `pull-requests: write` |

## Design
- **Static templates** live under `tooling/github-actions/workflows/*.yml` (added to `package.json` `files` so they ship) and are copied verbatim by `generateGhWorkflow` — unlike the config-aware `ci.yml` generator, these have no config-driven branching, so static files beat inline rendering (and dodge `${{ }}` escaping).
- **Four flat `fix` targets** (`fix docker-publish`, …) rather than the issue's `fix gh-workflow <name>` — the `fix [target]` CLI takes a single positional, and flat targets match every existing fixer (`fix gitlab-ci`, `fix codeql`). Built by mapping over `GH_WORKFLOWS` so there's no 4× boilerplate.
- **Safe-add, self-enforced.** These fixers have no doctor check (deploy workflows shouldn't nag every repo), so the fix command's framework-level safe-add guard — which keys off an `ok` check — can't apply. The generator enforces no-clobber itself via `fs.copy(..., { overwrite: false })`, preserving a user-customized workflow of the same name.
- **No setup prompt, no doctor check** — per the issue, too deploy-target-specific to scaffold or audit by default.

## Tests
`github-workflows.test.ts`: every workflow scaffolds with `name`/`on`/`permissions`/`jobs`; per-target secret + trigger + permission assertions; and a **safe-add test** driving `fixCommand('docker-publish')` against an existing file to confirm it's not clobbered.

Full suite: **368 passing**; typecheck + biome clean.

Docs: `apps/docs/docs/reference/github-actions.md` + sidebar entry.