### PR TITLE
feat(doctor): GitHub repo-settings drift checks via gh (#137)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import fs from 'fs-extra'
 import { BADGE_START, hasPublicOnlyBadges } from '../generators/badges.js'
 import { detectLanguage } from '../utils/detect-language.js'
+import { checkGitHubSettings } from '../utils/github-settings.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
 
@@ -1397,6 +1398,9 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkReleaseToken(targetDir))
 	results.push(await checkDependabot(targetDir))
 	results.push(await checkCodeQL(targetDir))
+	// GitHub repo-settings drift (branch protection, merge settings, workflow
+	// permissions). Read-only; self-skips as `ok` outside a live GitHub repo.
+	results.push(...(await checkGitHubSettings(targetDir)))
 	results.push(await checkGitLabCI(targetDir))
 	results.push(await checkCodeowners(targetDir))
 	results.push(await checkCommunityHealth(targetDir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -79,6 +79,10 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			return c.semanticRelease === false
 		case 'Dependabot':
 		case 'CodeQL':
+		// GitHub repo-settings checks (#137) share the securityAutomation opt-out.
+		case 'Branch protection':
+		case 'Merge settings':
+		case 'Workflow permissions':
 			return c.securityAutomation === false
 		case 'publint':
 			return c.publint === false

--- a/src/cli/utils/github-settings.ts
+++ b/src/cli/utils/github-settings.ts
@@ -1,0 +1,214 @@
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import fs from 'fs-extra'
+import type { CheckResult } from '../commands/doctor.js'
+
+/**
+ * Machine-checks the GitHub side of the js-tooling standard — branch
+ * protection, merge settings, workflow permissions — which doctor's
+ * file-on-disk checks can't see (#137). Read-only. Shells out to `gh` via an
+ * injectable seam (no octokit, zero deps, auth for free), modeled on
+ * install.ts's resolve-never-reject style. The applying fixer is a follow-up
+ * (#138); these checks only report.
+ */
+
+export interface GhResult {
+	ok: boolean
+	stdout: string
+	stderr: string
+	/** Process exit code, or null when gh never ran / timed out. */
+	code: number | null
+}
+
+export type GhExec = (args: string[]) => Promise<GhResult>
+
+const GH_TIMEOUT_MS = 10_000
+
+/** Real `gh` runner — never rejects; a missing/failing gh resolves ok:false. */
+export const realGhExec: GhExec = (args) =>
+	new Promise((resolve) => {
+		let settled = false
+		const done = (r: GhResult) => {
+			if (settled) return
+			settled = true
+			clearTimeout(timer)
+			resolve(r)
+		}
+		// gh args are internal/derived from gh itself (never user free-text), so
+		// shell:false + an args array keeps this injection-safe.
+		const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+		let stdout = ''
+		let stderr = ''
+		const timer = setTimeout(() => {
+			child.kill()
+			done({ ok: false, stdout: '', stderr: 'gh timed out', code: null })
+		}, GH_TIMEOUT_MS)
+		child.stdout.on('data', (d) => {
+			stdout += d
+		})
+		child.stderr.on('data', (d) => {
+			stderr += d
+		})
+		child.on('close', (code) => done({ ok: code === 0, stdout, stderr, code }))
+		child.on('error', (err) => done({ ok: false, stdout: '', stderr: String(err), code: null }))
+	})
+
+/** The standard doctor checks these settings against. */
+export const GITHUB_STANDARD = {
+	// Required status contexts on the default branch (strict off — see below).
+	requiredContexts: ['lint', 'typecheck', 'build', 'test'],
+} as const
+
+const CHECK_NAMES = ['Branch protection', 'Merge settings', 'Workflow permissions'] as const
+
+/** All three checks as an `ok` skip — keeps them out of next-steps and exit code. */
+function skipAll(reason: string): CheckResult[] {
+	return CHECK_NAMES.map((check) => ({ check, status: 'ok', detail: `skipped — ${reason}` }))
+}
+
+function skip(check: string, reason: string): CheckResult {
+	return { check, status: 'ok', detail: `skipped — ${reason}` }
+}
+
+interface RepoProbe {
+	nameWithOwner?: string
+	defaultBranchRef?: { name?: string } | null
+	autoMergeAllowed?: boolean
+	squashMergeAllowed?: boolean
+	deleteBranchOnMerge?: boolean
+}
+
+export async function checkGitHubSettings(
+	dir: string,
+	exec: GhExec = realGhExec
+): Promise<CheckResult[]> {
+	// Cheap gate first: no .git → never spawn (keeps tmp-dir doctor runs offline).
+	if (!(await fs.pathExists(path.join(dir, '.git')))) return skipAll('not a git repository')
+
+	// One combined probe: proves gh is installed + authed + has a GitHub remote
+	// + online, and carries the merge settings in the same call.
+	const probe = await exec([
+		'repo',
+		'view',
+		'--json',
+		'nameWithOwner,defaultBranchRef,autoMergeAllowed,squashMergeAllowed,deleteBranchOnMerge',
+	])
+	if (!probe.ok) return skipAll(probeFailureReason(probe))
+
+	let meta: RepoProbe
+	try {
+		meta = JSON.parse(probe.stdout) as RepoProbe
+	} catch {
+		return skipAll('could not parse gh output')
+	}
+	const nwo = meta.nameWithOwner
+	if (!nwo) return skipAll('no GitHub remote')
+	const branch = meta.defaultBranchRef?.name ?? 'main'
+
+	return [
+		await checkBranchProtection(exec, nwo, branch),
+		checkMergeSettings(meta),
+		await checkWorkflowPermissions(exec, nwo),
+	]
+}
+
+function probeFailureReason(probe: GhResult): string {
+	if (probe.code === null) return 'gh not installed'
+	if (/not logged|gh auth login|authentication/i.test(probe.stderr)) return 'gh not authenticated'
+	return 'not a GitHub repo or gh unavailable'
+}
+
+async function checkBranchProtection(
+	exec: GhExec,
+	nwo: string,
+	branch: string
+): Promise<CheckResult> {
+	const check = 'Branch protection'
+	const r = await exec(['api', `repos/${nwo}/branches/${branch}/protection`])
+	if (!r.ok) {
+		if (/404|not found/i.test(r.stderr)) {
+			return {
+				check,
+				status: 'optional-missing',
+				detail: `${branch} is unprotected`,
+				hint: `Protect ${branch}: require checks ${GITHUB_STANDARD.requiredContexts.join(', ')}, no force-push/deletions`,
+			}
+		}
+		if (/403|forbidden/i.test(r.stderr)) return skip(check, 'token lacks admin access')
+		return skip(check, 'could not read branch protection')
+	}
+
+	let p: Record<string, any>
+	try {
+		p = JSON.parse(r.stdout)
+	} catch {
+		return skip(check, 'could not parse protection response')
+	}
+
+	const deltas: string[] = []
+	const contexts: string[] = p.required_status_checks?.contexts ?? []
+	const missing = GITHUB_STANDARD.requiredContexts.filter((c) => !contexts.includes(c))
+	if (missing.length) deltas.push(`missing required checks: ${missing.join(', ')}`)
+	if (p.required_status_checks?.strict === true)
+		deltas.push('strict status checks on (should be off)')
+	// enforce_admins must stay off so the App/RELEASE_TOKEN can bypass protection
+	// to push semantic-release's version commit (see Release-token doctor check).
+	if (p.enforce_admins?.enabled === true) deltas.push('enforce_admins on (blocks release bypass)')
+	if (p.allow_force_pushes?.enabled === true) deltas.push('force pushes allowed')
+	if (p.allow_deletions?.enabled === true) deltas.push('branch deletions allowed')
+	// Required human review deadlocks solo Dependabot auto-merge.
+	if (p.required_pull_request_reviews) deltas.push('required PR reviews on (deadlocks auto-merge)')
+
+	if (deltas.length)
+		return {
+			check,
+			status: 'drift',
+			detail: deltas.join('; '),
+			hint: `Align ${branch} protection with the standard`,
+		}
+	return { check, status: 'ok', detail: `${branch} protected per standard` }
+}
+
+function checkMergeSettings(meta: RepoProbe): CheckResult {
+	const check = 'Merge settings'
+	const deltas: string[] = []
+	if (!meta.autoMergeAllowed) deltas.push('auto-merge disabled')
+	if (!meta.squashMergeAllowed) deltas.push('squash-merge disabled')
+	if (!meta.deleteBranchOnMerge) deltas.push('delete-branch-on-merge disabled')
+	if (deltas.length)
+		return {
+			check,
+			status: 'drift',
+			detail: deltas.join('; '),
+			hint: 'Enable auto-merge, squash-merge, and delete-branch-on-merge in repo settings',
+		}
+	return { check, status: 'ok', detail: 'auto-merge, squash-merge, delete-on-merge all on' }
+}
+
+async function checkWorkflowPermissions(exec: GhExec, nwo: string): Promise<CheckResult> {
+	const check = 'Workflow permissions'
+	const r = await exec(['api', `repos/${nwo}/actions/permissions/workflow`])
+	if (!r.ok) {
+		if (/403|forbidden/i.test(r.stderr)) return skip(check, 'token lacks admin access')
+		return skip(check, 'could not read workflow permissions')
+	}
+	let p: Record<string, any>
+	try {
+		p = JSON.parse(r.stdout)
+	} catch {
+		return skip(check, 'could not parse permissions response')
+	}
+	const deltas: string[] = []
+	if (p.default_workflow_permissions !== 'read')
+		deltas.push(`default permissions '${p.default_workflow_permissions}' (should be read)`)
+	if (p.can_approve_pull_request_reviews === true)
+		deltas.push('workflows can approve PRs (should be off)')
+	if (deltas.length)
+		return {
+			check,
+			status: 'drift',
+			detail: deltas.join('; '),
+			hint: 'Set default workflow permissions to read-only and disable workflow PR approvals',
+		}
+	return { check, status: 'ok', detail: 'read-only default, no workflow PR approvals' }
+}

--- a/tests/cli/utils/github-settings.test.ts
+++ b/tests/cli/utils/github-settings.test.ts
@@ -1,0 +1,145 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it, vi } from 'vitest'
+import { checkGitHubSettings, type GhExec, type GhResult } from '../../../src/cli/utils/github-settings.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+/** A git repo (doctor's cheap .git gate must pass before gh runs). */
+function gitRepo(): string {
+	const dir = newTmpDir()
+	fs.ensureDirSync(join(dir, '.git'))
+	return dir
+}
+
+const ok = (stdout: string): GhResult => ({ ok: true, stdout, stderr: '', code: 0 })
+const fail = (stderr: string, code: number | null = 1): GhResult => ({
+	ok: false,
+	stdout: '',
+	stderr,
+	code,
+})
+
+const COMPLIANT_PROBE = JSON.stringify({
+	nameWithOwner: 'owner/repo',
+	defaultBranchRef: { name: 'main' },
+	autoMergeAllowed: true,
+	squashMergeAllowed: true,
+	deleteBranchOnMerge: true,
+})
+const COMPLIANT_PROTECTION = JSON.stringify({
+	required_status_checks: { strict: false, contexts: ['lint', 'typecheck', 'build', 'test'] },
+	enforce_admins: { enabled: false },
+	allow_force_pushes: { enabled: false },
+	allow_deletions: { enabled: false },
+	required_pull_request_reviews: null,
+})
+const COMPLIANT_WORKFLOW = JSON.stringify({
+	default_workflow_permissions: 'read',
+	can_approve_pull_request_reviews: false,
+})
+
+/** Route canned responses by which gh subcommand is invoked. */
+function fakeGh(overrides: { probe?: GhResult; protection?: GhResult; workflow?: GhResult } = {}): GhExec {
+	return vi.fn(async (args: string[]) => {
+		if (args[0] === 'repo') return overrides.probe ?? ok(COMPLIANT_PROBE)
+		if (args[1]?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
+		if (args[1]?.includes('/actions/permissions/workflow'))
+			return overrides.workflow ?? ok(COMPLIANT_WORKFLOW)
+		return fail('unexpected call')
+	})
+}
+
+const byName = (results: { check: string }[], name: string) =>
+	results.find((r) => r.check === name)
+
+describe('checkGitHubSettings — skip paths', () => {
+	it('never spawns gh outside a git repo', async () => {
+		const exec = fakeGh()
+		const results = await checkGitHubSettings(newTmpDir(), exec)
+		expect(exec).not.toHaveBeenCalled()
+		expect(results).toHaveLength(3)
+		expect(results.every((r) => r.status === 'ok' && r.detail.includes('skipped'))).toBe(true)
+	})
+
+	it('skips all three when gh is not installed', async () => {
+		const exec = fakeGh({ probe: fail('spawn gh ENOENT', null) })
+		const results = await checkGitHubSettings(gitRepo(), exec)
+		expect(results.every((r) => r.status === 'ok')).toBe(true)
+		expect(byName(results, 'Branch protection')?.detail).toContain('gh not installed')
+	})
+
+	it('skips when the probe fails (no GitHub remote / not authed)', async () => {
+		const exec = fakeGh({ probe: fail('gh auth login required') })
+		const results = await checkGitHubSettings(gitRepo(), exec)
+		expect(results.every((r) => r.status === 'ok' && r.detail.includes('skipped'))).toBe(true)
+	})
+})
+
+describe('checkGitHubSettings — compliant repo', () => {
+	it('reports all three ok when settings match the standard', async () => {
+		const results = await checkGitHubSettings(gitRepo(), fakeGh())
+		expect(results).toHaveLength(3)
+		expect(results.every((r) => r.status === 'ok')).toBe(true)
+		expect(byName(results, 'Branch protection')?.detail).toContain('protected per standard')
+	})
+})
+
+describe('checkGitHubSettings — drift', () => {
+	it('flags an unprotected default branch as optional-missing on 404', async () => {
+		const exec = fakeGh({ protection: fail('gh: Not Found (HTTP 404)') })
+		const results = await checkGitHubSettings(gitRepo(), exec)
+		const bp = byName(results, 'Branch protection')
+		expect(bp?.status).toBe('optional-missing')
+		expect(bp?.detail).toContain('unprotected')
+	})
+
+	it('skips branch protection (not drift) when the token lacks admin (403)', async () => {
+		const exec = fakeGh({ protection: fail('gh: Must have admin rights (HTTP 403)') })
+		const bp = byName(await checkGitHubSettings(gitRepo(), exec), 'Branch protection')
+		expect(bp?.status).toBe('ok')
+		expect(bp?.detail).toContain('skipped')
+	})
+
+	it('drifts when a required status check is missing', async () => {
+		const protection = ok(
+			JSON.stringify({
+				required_status_checks: { strict: false, contexts: ['lint', 'build', 'test'] },
+				enforce_admins: { enabled: false },
+				allow_force_pushes: { enabled: false },
+				allow_deletions: { enabled: false },
+			})
+		)
+		const bp = byName(await checkGitHubSettings(gitRepo(), fakeGh({ protection })), 'Branch protection')
+		expect(bp?.status).toBe('drift')
+		expect(bp?.detail).toContain('typecheck')
+	})
+
+	it('drifts when merge settings are off (from the probe)', async () => {
+		const probe = ok(
+			JSON.stringify({
+				nameWithOwner: 'owner/repo',
+				defaultBranchRef: { name: 'main' },
+				autoMergeAllowed: false,
+				squashMergeAllowed: true,
+				deleteBranchOnMerge: true,
+			})
+		)
+		const ms = byName(await checkGitHubSettings(gitRepo(), fakeGh({ probe })), 'Merge settings')
+		expect(ms?.status).toBe('drift')
+		expect(ms?.detail).toContain('auto-merge disabled')
+	})
+
+	it('drifts when default workflow permissions are write', async () => {
+		const workflow = ok(
+			JSON.stringify({
+				default_workflow_permissions: 'write',
+				can_approve_pull_request_reviews: false,
+			})
+		)
+		const wp = byName(await checkGitHubSettings(gitRepo(), fakeGh({ workflow })), 'Workflow permissions')
+		expect(wp?.status).toBe('drift')
+		expect(wp?.detail).toContain('write')
+	})
+})


### PR DESCRIPTION
Closes #137. Teaches `doctor` to check the **GitHub side** of the js-tooling standard — branch protection, merge settings, workflow permissions — which its file-on-disk checks never saw. Read-only (the applying fixer is the #138 follow-up).

## How
New `src/cli/utils/github-settings.ts` with an injectable `GhExec` seam — spawns `gh`, resolve-never-reject in the style of `install.ts`. No octokit, zero new deps, `gh`'s auth for free.

Three `CheckResult` rows, pushed from `runDoctor` right after `checkCodeQL`:

| Check | Source | Standard |
|---|---|---|
| **Branch protection** | `gh api repos/{nwo}/branches/{default}/protection` | required contexts `lint, typecheck, build, test` (strict off), `enforce_admins:false` (App-token release bypass), no force-push/deletions, no required PR reviews (would deadlock solo auto-merge) |
| **Merge settings** | the `gh repo view` probe | auto-merge + squash-merge + delete-branch-on-merge all on |
| **Workflow permissions** | `gh api repos/{nwo}/actions/permissions/workflow` | `default_workflow_permissions:read`, no workflow PR approvals |

## Graceful degradation (never fails doctor, never spawns needlessly)
1. Cheap `.git` gate first — no repo → three `ok` skips, **zero subprocesses** (keeps the existing tmp-dir doctor tests offline).
2. One combined `gh repo view --json …` probe proves gh is installed + authed + has a GitHub remote + online, and carries the merge settings.
3. Any failure → three `ok` results (`skipped — <reason>`), keeping them out of next-steps and the exit code (precedent: `checkTypedoc`, `checkTreeshakeSetup`).

Status mapping: protection **404 → `optional-missing`** ("main is unprotected", the #109 case), **403 → `ok` skip** (token lacks admin), wrong settings → **`drift`** naming the delta. Live path: 3 subprocesses, 10s timeout each.

The three checks join the `securityAutomation` opt-out group in `declinedInLock`.

## Deviation from the issue (called out)
The issue also lists `FIX_TARGETS` + `lockfilePatchForTarget` wiring. I **deferred those to #138** (the applying fixer): wiring `FIX_TARGETS` now would make `doctor`'s next-steps suggest `fix github-settings`, a command that doesn't exist until #138 — a broken suggestion. `declinedInLock` (which has real effect today) is wired. Easy to add the rest alongside the fixer.

## Tests
`tests/cli/utils/github-settings.test.ts` — fake `GhExec` with canned JSON, `useTmpDir`, no network: no-`.git` (asserts **zero** exec calls), gh-missing, probe-failure, compliant (3 ok), and drift paths (404 unprotected, 403 skip, missing `typecheck` context, auto-merge off, `write` workflow perms).

Full suite **391 passing**; typecheck + biome clean.