### PR TITLE
feat(cli): add Tailwind CSS v4 preset (#63)

### DIFF
--- a/apps/docs/docs/reference/tailwind.md
+++ b/apps/docs/docs/reference/tailwind.md
@@ -1,0 +1,63 @@
+---
+title: Tailwind CSS
+description: Tailwind CSS v4 scaffold (PostCSS plugin + CSS entry) for frontend projects.
+---
+
+[Tailwind CSS](https://tailwindcss.com) v4 is **CSS-first** — there is no
+`tailwind.config.js` and content is auto-detected. js-tooling scaffolds the two
+files a v4 setup needs: a PostCSS config that loads the Tailwind plugin, and a
+CSS entry that imports Tailwind.
+
+The setup wizard offers it **only for frontend project types** (`web-app`,
+`react-app`, `nextjs-app`), and `doctor` only reports on it when `tailwindcss`
+is already a dependency.
+
+## Usage
+
+Scaffold it into an existing project:
+
+```bash
+npx @rtorcato/js-tooling fix tailwind
+```
+
+`setup` also offers it interactively for frontend projects. The fixer is
+**safe-add** — it never overwrites an existing `postcss.config.mjs` or CSS
+entry, so it can also repair a half-wired setup.
+
+## Generated files
+
+`postcss.config.mjs`:
+
+```js
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}
+```
+
+`src/styles/globals.css`:
+
+```css
+@import "tailwindcss";
+```
+
+Import `src/styles/globals.css` from your app entry point. Customize theme
+tokens directly in that CSS file with `@theme` — no JavaScript config needed.
+
+## Peer dependencies
+
+`setup` adds these to `devDependencies`; add them manually when running only the
+fixer:
+
+```json
+{
+  "devDependencies": {
+    "tailwindcss": "^4",
+    "@tailwindcss/postcss": "^4"
+  }
+}
+```
+
+Vite projects can use `@tailwindcss/vite` instead of the PostCSS plugin —
+`doctor` recognizes either. Then `doctor` reports `Tailwind — ok`.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -57,6 +57,7 @@ const sidebars: SidebarsConfig = {
         'reference/publint',
         'reference/rollup',
         'reference/semantic-release',
+        'reference/tailwind',
         'reference/tsup',
         'reference/turborepo',
         'reference/typescript',

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -174,6 +174,15 @@ async function checkFile(dir: string, spec: FileCheck): Promise<CheckResult> {
 
 type Pkg = Record<string, unknown>
 
+/** Merged dependencies + devDependencies of a package.json, for presence checks. */
+function allDeps(pkg: Pkg | null): Record<string, string> {
+	if (!pkg) return {}
+	return {
+		...((pkg.dependencies as Record<string, string> | undefined) ?? {}),
+		...((pkg.devDependencies as Record<string, string> | undefined) ?? {}),
+	}
+}
+
 async function readPackageJson(dir: string): Promise<Pkg | null> {
 	const filepath = path.join(dir, 'package.json')
 	if (!(await fs.pathExists(filepath))) return null
@@ -1335,6 +1344,39 @@ async function checkTurborepo(dir: string): Promise<CheckResult> {
 	}
 }
 
+// Only called when `tailwindcss` is a dependency (see runDoctor) — Tailwind is
+// opt-in per project, so nudging repos that don't use it would be noise. v4 is
+// CSS-first: the wiring is a PostCSS plugin (or the Vite plugin), not a config
+// file, so that's what we look for.
+async function checkTailwind(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const hasVitePlugin = '@tailwindcss/vite' in allDeps(pkg)
+	let postcssWired = false
+	for (const candidate of ['postcss.config.mjs', 'postcss.config.js', 'postcss.config.cjs']) {
+		const p = path.join(dir, candidate)
+		if (
+			(await fs.pathExists(p)) &&
+			(await fs.readFile(p, 'utf8')).includes('@tailwindcss/postcss')
+		) {
+			postcssWired = true
+			break
+		}
+	}
+
+	if (hasVitePlugin || postcssWired) {
+		return {
+			check: 'Tailwind',
+			status: 'ok',
+			detail: hasVitePlugin ? '@tailwindcss/vite configured' : '@tailwindcss/postcss configured',
+		}
+	}
+	return {
+		check: 'Tailwind',
+		status: 'optional-missing',
+		detail: 'tailwindcss installed without a PostCSS (or Vite) plugin',
+		hint: 'Run `npx @rtorcato/js-tooling fix tailwind` to scaffold the v4 PostCSS wiring',
+	}
+}
+
 async function checkGitLabCI(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -1414,6 +1456,10 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	// Turborepo is monorepo-only — only surface the check when a workspace exists.
 	if (await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))) {
 		results.push(await checkTurborepo(targetDir))
+	}
+	// Tailwind is opt-in — only surface the check when the repo actually depends on it.
+	if ('tailwindcss' in allDeps(pkg)) {
+		results.push(await checkTailwind(targetDir, pkg))
 	}
 
 	// Lockfile-driven demotion: if the lock records an intentional opt-out for a

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -29,6 +29,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
 	Turborepo: 'turborepo',
+	Tailwind: 'tailwind',
 	lockfile: 'lockfile',
 	'.js-tooling.json': 'lockfile',
 	'are-the-types-wrong': 'attw',
@@ -92,6 +93,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			return c.aiSetup === false
 		case 'Turborepo':
 			return c.turborepo === false
+		case 'Tailwind':
+			return c.tailwind === false
 		default:
 			return false
 	}
@@ -152,6 +155,8 @@ export function lockfilePatchForTarget(
 			return c.aiSetup ? null : { aiSetup: true }
 		case 'turborepo':
 			return c.turborepo ? null : { turborepo: true }
+		case 'tailwind':
+			return c.tailwind ? null : { tailwind: true }
 		default:
 			return null
 	}

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -36,6 +36,7 @@ import {
 } from '../generators/security.js'
 import { generateVitestConfig } from '../generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../generators/treeshake.js'
+import { generateTailwind } from '../generators/tailwind.js'
 import { generateTurborepo } from '../generators/turborepo.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../generators/typedoc.js'
 import { copyPreset } from '../utils/copy-preset.js'
@@ -464,6 +465,18 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const written = await generateTurborepo(targetDir)
 			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'tailwind',
+		description: 'Scaffold Tailwind CSS v4 (postcss.config.mjs + src/styles/globals.css)',
+		appliesTo: ['Tailwind'],
+		outputs: ['postcss.config.mjs', 'src/styles/globals.css'],
+		// safe-add: never clobber an existing PostCSS config or CSS entry.
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const written = await generateTailwind(targetDir)
+			return { filesWritten: written }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -146,6 +146,7 @@ export const CONFIG_SCHEMA = {
 		badges: { type: 'boolean' },
 		aiSetup: { type: 'boolean' },
 		turborepo: { type: 'boolean' },
+		tailwind: { type: 'boolean' },
 	},
 } as const
 
@@ -240,6 +241,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 		)
 	}
 	if (config.turborepo) files.push('turbo.json')
+	if (config.tailwind) files.push('postcss.config.mjs', 'src/styles/globals.css')
 	files.push('README.md')
 	return files
 }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -55,6 +55,8 @@ export interface ProjectConfig {
 	aiSetup?: boolean
 	/** Scaffold a turbo.json task pipeline (pnpm-workspace monorepos). */
 	turborepo?: boolean
+	/** Scaffold Tailwind CSS v4 (PostCSS plugin + CSS entry) for frontend projects. */
+	tailwind?: boolean
 }
 
 export interface SetupOptions {
@@ -320,6 +322,17 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 			when: () => hasWorkspace,
 		},
 		{
+			type: 'confirm',
+			name: 'tailwind',
+			message: '🎨 Add Tailwind CSS v4 (PostCSS plugin + globals.css)?',
+			default: true,
+			// Only meaningful for frontend project types.
+			when: (answers: any) =>
+				answers.projectType === 'web-app' ||
+				answers.projectType === 'react-app' ||
+				answers.projectType === 'nextjs-app',
+		},
+		{
 			type: 'list',
 			name: 'bundler',
 			message: '📦 Which bundler/build tool?',
@@ -379,6 +392,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 		badges: answers.badges ?? false,
 		aiSetup: answers.aiSetup ?? false,
 		turborepo: answers.turborepo ?? false,
+		tailwind: answers.tailwind ?? false,
 	}
 }
 

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -14,6 +14,7 @@ import { generateSecurityConfigs } from './security.js'
 import { generateTestingConfigs } from './testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from './treeshake.js'
 import { generateTSConfig } from './tsconfig.js'
+import { generateTailwind } from './tailwind.js'
 import { generateTurborepo } from './turborepo.js'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -89,6 +90,11 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 	// Turborepo task pipeline (pnpm-workspace monorepos, when opted-in)
 	if (config.turborepo) {
 		await generateTurborepo(targetDir)
+	}
+
+	// Tailwind CSS v4 (frontend projects, when opted-in)
+	if (config.tailwind) {
+		await generateTailwind(targetDir)
 	}
 
 	// AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example)

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -279,6 +279,12 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['vite'] = '^6.0.0'
 	}
 
+	// Tailwind CSS v4 — CSS-first, wired via the PostCSS plugin.
+	if (config.tailwind) {
+		deps['tailwindcss'] = '^4.0.0'
+		deps['@tailwindcss/postcss'] = '^4.0.0'
+	}
+
 	// Publishing hygiene
 	if (config.publint) {
 		deps['publint'] = '^0.3.0'

--- a/src/cli/generators/tailwind.ts
+++ b/src/cli/generators/tailwind.ts
@@ -1,0 +1,40 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * Scaffold Tailwind CSS v4. v4 is CSS-first — there is no `tailwind.config.js`
+ * and content is auto-detected, so the whole setup is a PostCSS plugin plus a
+ * CSS entry that imports Tailwind. Works uniformly for Vite, Next.js, and any
+ * PostCSS-based pipeline. Both files are safe-add — an existing file is never
+ * clobbered — so this can also repair a half-wired setup.
+ */
+export async function generateTailwind(targetDir: string): Promise<string[]> {
+	const written: string[] = []
+
+	const postcss = path.join(targetDir, 'postcss.config.mjs')
+	if (!(await fs.pathExists(postcss))) {
+		await fs.writeFile(postcss, POSTCSS_CONFIG)
+		written.push('postcss.config.mjs')
+	}
+
+	const cssRel = path.join('src', 'styles', 'globals.css')
+	const css = path.join(targetDir, cssRel)
+	if (!(await fs.pathExists(css))) {
+		await fs.ensureDir(path.dirname(css))
+		await fs.writeFile(css, GLOBALS_CSS)
+		written.push(cssRel)
+	}
+
+	return written
+}
+
+const POSTCSS_CONFIG = `export default {
+	plugins: {
+		'@tailwindcss/postcss': {},
+	},
+}
+`
+
+// v4 config lives in CSS. Import `src/styles/globals.css` from your app entry.
+const GLOBALS_CSS = `@import "tailwindcss";
+`

--- a/tests/cli/generators/tailwind.test.ts
+++ b/tests/cli/generators/tailwind.test.ts
@@ -1,0 +1,67 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { generateTailwind } from '../../../src/cli/generators/tailwind.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('generateTailwind', () => {
+	it('writes a v4 PostCSS config and CSS entry', async () => {
+		const dir = newTmpDir()
+		const written = await generateTailwind(dir)
+		expect(written).toEqual(['postcss.config.mjs', join('src', 'styles', 'globals.css')])
+
+		const postcss = await fs.readFile(join(dir, 'postcss.config.mjs'), 'utf8')
+		expect(postcss).toContain('@tailwindcss/postcss')
+		const css = await fs.readFile(join(dir, 'src/styles/globals.css'), 'utf8')
+		expect(css).toContain('@import "tailwindcss"')
+	})
+
+	it('is safe-add — never clobbers existing files', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'postcss.config.mjs'), '// hand-tuned\n')
+		const written = await generateTailwind(dir)
+		expect(written).toEqual([join('src', 'styles', 'globals.css')])
+		expect(await fs.readFile(join(dir, 'postcss.config.mjs'), 'utf8')).toBe('// hand-tuned\n')
+	})
+})
+
+describe('doctor Tailwind check', () => {
+	const findTailwind = (results: { check: string }[]) => results.find((r) => r.check === 'Tailwind')
+
+	it('does not surface the check when tailwindcss is not a dependency', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		expect(findTailwind(await runDoctor(dir))).toBeUndefined()
+	})
+
+	it('flags optional-missing when tailwindcss is installed without a plugin', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			devDependencies: { tailwindcss: '^4.0.0' },
+		})
+		expect(findTailwind(await runDoctor(dir))?.status).toBe('optional-missing')
+	})
+
+	it('reports ok once the PostCSS plugin is wired', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			devDependencies: { tailwindcss: '^4.0.0', '@tailwindcss/postcss': '^4.0.0' },
+		})
+		await generateTailwind(dir)
+		expect(findTailwind(await runDoctor(dir))?.status).toBe('ok')
+	})
+
+	it('reports ok when the Vite plugin is used instead', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			devDependencies: { tailwindcss: '^4.0.0', '@tailwindcss/vite': '^4.0.0' },
+		})
+		expect(findTailwind(await runDoctor(dir))?.status).toBe('ok')
+	})
+})


### PR DESCRIPTION
Closes #63.

## What

Adds a Tailwind CSS **v4** preset. v4 is CSS-first — no `tailwind.config.js`, content auto-detected — so the scaffold is just two files:

- `postcss.config.mjs` loading `@tailwindcss/postcss`
- `src/styles/globals.css` with `@import "tailwindcss";`

## Wiring (mirrors the Turborepo preset #68)

- **setup wizard** — `🎨 Add Tailwind CSS v4?` confirm, shown only for `web-app` / `react-app` / `nextjs-app`.
- **generator** — drops both files when `config.tailwind`.
- **package.json deps** — adds `tailwindcss` + `@tailwindcss/postcss` (`^4`).
- **`fix tailwind`** — safe-add scaffolder (never clobbers existing files; repairs half-wired setups).
- **doctor** — `Tailwind` check, gated on `tailwindcss` being a dependency so it stays silent on backend repos. Recognizes either the PostCSS plugin or `@tailwindcss/vite`.
- **lockfile** — records the `tailwind` opt-in/out.
- **docs** — `reference/tailwind.md` + sidebar entry.

## Notes

The issue text predated Tailwind v4 (it described a v3 `tailwind.config.mjs` + content globs). Built to v4 instead — less code, current best practice. Confirmed with the repo owner before implementing.

## Verification

- `pnpm test` — 397 pass (6 new for the generator + doctor check).
- Typecheck + biome clean.
- End-to-end: `fix tailwind` writes both files → `doctor` reports `Tailwind — ok`; `fix --list` shows the target.