### PR TITLE
feat(cli): add Cypress preset (#67)

### DIFF
--- a/apps/docs/docs/reference/cypress.md
+++ b/apps/docs/docs/reference/cypress.md
@@ -1,0 +1,68 @@
+---
+title: Cypress
+description: Cypress E2E preset — a peer to Playwright, sharing the tests/e2e folder.
+---
+
+[Cypress](https://www.cypress.io) is an end-to-end testing framework and a peer
+to the Playwright preset — pick whichever your team prefers; js-tooling has no
+preference. Both keep their specs under `tests/e2e/` so switching runners
+doesn't move the folder.
+
+The setup wizard offers Cypress as a `testing.framework` choice alongside
+Vitest, Jest, and Playwright.
+
+## Usage
+
+Scaffold it into an existing project:
+
+```bash
+npx @rtorcato/js-tooling fix cypress
+```
+
+`setup` also offers it interactively. The fixer is **safe-add** — it re-writes
+only the deterministic config re-export and never clobbers your custom commands
+or specs.
+
+## Generated files
+
+`cypress.config.ts` re-exports the shared base:
+
+```ts
+export { default } from '@rtorcato/js-tooling/cypress'
+```
+
+The base (`@rtorcato/js-tooling/cypress`) sets:
+
+- `baseUrl` — `CYPRESS_BASE_URL` env var, defaulting to `http://localhost:3000`
+- `specPattern` — `tests/e2e/**/*.cy.{js,jsx,ts,tsx}`
+- `supportFile` — `cypress/support/e2e.ts`
+
+Also scaffolded:
+
+- `cypress/support/e2e.ts` — loaded before each spec; imports custom commands
+- `cypress/support/commands.ts` — where you register `Cypress.Commands.add(...)`
+- `tests/e2e/example.cy.ts` — a starter spec
+
+## Scripts
+
+```json
+{
+  "scripts": {
+    "test:e2e": "cypress run",
+    "test:e2e:ui": "cypress open"
+  }
+}
+```
+
+## Peer dependency
+
+`setup` adds `cypress` to `devDependencies`; add it manually when running only
+the fixer:
+
+```json
+{
+  "devDependencies": {
+    "cypress": "^14"
+  }
+}
+```

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
         'reference/biome',
         'reference/changesets',
         'reference/commitlint',
+        'reference/cypress',
         'reference/esbuild',
         'reference/eslint',
         'reference/github-actions',

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
 		"tooling/eslint/*.d.mts",
 		"tooling/eslint/types.d.ts",
 		"tooling/jest-presets/**",
+		"tooling/cypress/cypress.config.mjs",
+		"tooling/cypress/cypress.config.d.mts",
 		"tooling/playwright/playwright.config.mjs",
 		"tooling/playwright/playwright.config.d.mts",
 		"tooling/prettier/index.mjs",
@@ -113,6 +115,10 @@
 		"./jest-presets/node/jest-preset": {
 			"types": "./tooling/jest-presets/node/jest-preset.d.mts",
 			"import": "./tooling/jest-presets/node/jest-preset.mjs"
+		},
+		"./cypress": {
+			"types": "./tooling/cypress/cypress.config.d.mts",
+			"import": "./tooling/cypress/cypress.config.mjs"
 		},
 		"./playwright": {
 			"types": "./tooling/playwright/playwright.config.d.mts",

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -34,7 +34,7 @@ import {
 	generateDependabotConfig,
 	generateRenovateConfig,
 } from '../generators/security.js'
-import { generateVitestConfig } from '../generators/testing.js'
+import { generateCypressConfig, generateVitestConfig } from '../generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../generators/treeshake.js'
 import { generateTurborepo } from '../generators/turborepo.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../generators/typedoc.js'
@@ -253,6 +253,23 @@ const FIXERS: Fixer[] = [
 				await fs.writeFile(setupPath, savedSetup)
 			}
 			return { filesWritten: ['vitest.config.ts'] }
+		},
+	},
+	{
+		target: 'cypress',
+		description: 'Scaffold Cypress E2E config + support/ boilerplate + a starter spec',
+		appliesTo: ['Cypress'],
+		outputs: [
+			'cypress.config.ts',
+			'cypress/support/e2e.ts',
+			'cypress/support/commands.ts',
+			'tests/e2e/example.cy.ts',
+		],
+		// safe-add: re-writes only the deterministic config; never clobbers specs.
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const written = await generateCypressConfig(targetDir)
+			return { filesWritten: written }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -130,7 +130,7 @@ export const CONFIG_SCHEMA = {
 			additionalProperties: false,
 			required: ['framework'],
 			properties: {
-				framework: { type: 'string', enum: ['vitest', 'jest', 'playwright', 'none'] },
+				framework: { type: 'string', enum: ['vitest', 'jest', 'playwright', 'cypress', 'none'] },
 				environment: { type: 'string', enum: ['node', 'browser', 'both'] },
 			},
 		},
@@ -197,6 +197,14 @@ export function computeFileList(config: ProjectConfig): string[] {
 	}
 	if (config.testing.framework === 'playwright') {
 		files.push('playwright.config.ts')
+	}
+	if (config.testing.framework === 'cypress') {
+		files.push(
+			'cypress.config.ts',
+			'cypress/support/e2e.ts',
+			'cypress/support/commands.ts',
+			'tests/e2e/example.cy.ts'
+		)
 	}
 	if (config.gitHooks) {
 		files.push('.husky/pre-commit', '.gitignore')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -36,7 +36,7 @@ export interface ProjectConfig {
 		tool: 'biome' | 'prettier' | 'none'
 	}
 	testing: {
-		framework: 'vitest' | 'jest' | 'playwright' | 'none'
+		framework: 'vitest' | 'jest' | 'playwright' | 'cypress' | 'none'
 		environment?: 'node' | 'browser' | 'both'
 	}
 	gitHooks: boolean
@@ -239,6 +239,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 				{ name: '⚡ Vitest (Fast, Vite-powered)', value: 'vitest' },
 				{ name: '🃏 Jest (Traditional)', value: 'jest' },
 				{ name: '🎭 Playwright (E2E)', value: 'playwright' },
+				{ name: '🌲 Cypress (E2E)', value: 'cypress' },
 				{ name: '❌ None', value: 'none' },
 			],
 			default: 'vitest',

--- a/src/cli/generators/git.ts
+++ b/src/cli/generators/git.ts
@@ -174,5 +174,14 @@ coverage/
 `
 	}
 
+	if (config.testing.framework === 'cypress') {
+		gitignoreContent += `
+# Cypress
+/cypress/screenshots/
+/cypress/videos/
+/cypress/downloads/
+`
+	}
+
 	await fs.writeFile(gitignorePath, gitignoreContent)
 }

--- a/src/cli/generators/gitlab-ci.ts
+++ b/src/cli/generators/gitlab-ci.ts
@@ -44,7 +44,7 @@ function renderGitLabCI(config: ProjectConfig): string {
 		const testCmd =
 			config.testing.framework === 'vitest'
 				? 'pnpm exec vitest run'
-				: config.testing.framework === 'playwright'
+				: config.testing.framework === 'playwright' || config.testing.framework === 'cypress'
 					? 'pnpm test:e2e'
 					: 'pnpm test'
 		jobs.push(`test:

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -115,6 +115,9 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 	} else if (config.testing.framework === 'playwright') {
 		scripts['test:e2e'] = 'playwright test'
 		scripts['test:e2e:ui'] = 'playwright test --ui'
+	} else if (config.testing.framework === 'cypress') {
+		scripts['test:e2e'] = 'cypress run'
+		scripts['test:e2e:ui'] = 'cypress open'
 	}
 
 	// Build scripts
@@ -191,7 +194,7 @@ export function composeVerifyScript(
 		cmds.push('pnpm exec vitest run')
 	} else if (config.testing.framework === 'jest') {
 		cmds.push('pnpm test --ci')
-	} else if (config.testing.framework === 'playwright') {
+	} else if (config.testing.framework === 'playwright' || config.testing.framework === 'cypress') {
 		cmds.push('pnpm test:e2e')
 	}
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
@@ -223,7 +226,7 @@ export function composeVerifyScriptFromPkg(
 	else if (scripts.lint && !scripts.check) cmds.push('pnpm lint')
 	if (deps.vitest) cmds.push('pnpm exec vitest run')
 	else if (deps.jest) cmds.push('pnpm test --ci')
-	else if (deps['@playwright/test']) cmds.push('pnpm test:e2e')
+	else if (deps['@playwright/test'] || deps.cypress) cmds.push('pnpm test:e2e')
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
 	if (deps.publint || scripts.publint) cmds.push('pnpm publint')
 	return cmds.length >= 2 ? cmds.join(' && ') : null
@@ -264,6 +267,8 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		}
 	} else if (config.testing.framework === 'playwright') {
 		deps['@playwright/test'] = '^1.60.0'
+	} else if (config.testing.framework === 'cypress') {
+		deps['cypress'] = '^14.0.0'
 	}
 
 	// Build tools

--- a/src/cli/generators/readme.ts
+++ b/src/cli/generators/readme.ts
@@ -60,6 +60,7 @@ ${config.linting.tool === 'eslint' ? '├── prettier.config.mjs  # Prettier 
 ${config.testing.framework === 'vitest' ? '├── vitest.config.ts     # Vitest configuration' : ''}
 ${config.testing.framework === 'jest' ? '├── jest.config.mjs     # Jest configuration' : ''}
 ${config.testing.framework === 'playwright' ? '├── playwright.config.ts # Playwright configuration' : ''}
+${config.testing.framework === 'cypress' ? '├── cypress.config.ts   # Cypress configuration' : ''}
 ${config.bundler === 'tsup' ? '├── tsup.config.ts       # tsup configuration' : ''}
 ${config.bundler === 'esbuild' ? '├── build.mjs           # esbuild configuration' : ''}
 ${config.bundler === 'vite' ? '├── vite.config.ts       # Vite configuration' : ''}
@@ -180,6 +181,9 @@ function generateTestingSection(config: ProjectConfig): string {
 	} else if (config.testing.framework === 'playwright') {
 		commands.push('pnpm test:e2e      # Run E2E tests')
 		commands.push('pnpm test:e2e:ui   # Run E2E tests with UI')
+	} else if (config.testing.framework === 'cypress') {
+		commands.push('pnpm test:e2e      # Run E2E tests headless')
+		commands.push('pnpm test:e2e:ui   # Open the Cypress runner')
 	}
 
 	return `\`\`\`bash\n${commands.join('\n')}\n\`\`\``
@@ -257,6 +261,8 @@ function generateToolingList(config: ProjectConfig): string {
 		tools.push('- **Jest** - Testing framework')
 	} else if (config.testing.framework === 'playwright') {
 		tools.push('- **Playwright** - End-to-end testing')
+	} else if (config.testing.framework === 'cypress') {
+		tools.push('- **Cypress** - End-to-end testing')
 	}
 
 	if (config.bundler === 'tsup') {

--- a/src/cli/generators/testing.ts
+++ b/src/cli/generators/testing.ts
@@ -9,6 +9,8 @@ export async function generateTestingConfigs(config: ProjectConfig, targetDir: s
 		await generateJestConfig(config, targetDir)
 	} else if (config.testing.framework === 'playwright') {
 		await generatePlaywrightConfig(targetDir)
+	} else if (config.testing.framework === 'cypress') {
+		await generateCypressConfig(targetDir)
 	}
 }
 
@@ -57,4 +59,53 @@ export async function generatePlaywrightConfig(targetDir: string) {
 	const playwrightConfig = `export { default } from '@rtorcato/js-tooling/playwright'
 `
 	await fs.writeFile(playwrightConfigPath, playwrightConfig)
+}
+
+// The re-export config is deterministic and always (re)written; the support
+// boilerplate and starter spec are safe-add so re-running never clobbers a
+// user's custom commands or tests. Returns the files that were written.
+export async function generateCypressConfig(targetDir: string): Promise<string[]> {
+	const written = ['cypress.config.ts']
+	await fs.writeFile(
+		path.join(targetDir, 'cypress.config.ts'),
+		`export { default } from '@rtorcato/js-tooling/cypress'
+`
+	)
+
+	// Support boilerplate: e2e.ts is loaded before every spec and pulls in custom
+	// commands (Cypress convention).
+	await fs.ensureDir(path.join(targetDir, 'cypress', 'support'))
+	const boilerplate: Array<[string, string]> = [
+		[
+			'cypress/support/e2e.ts',
+			`// Loaded automatically before each E2E spec. Add global hooks here.
+import './commands'
+`,
+		],
+		[
+			'cypress/support/commands.ts',
+			`// Register custom Cypress commands here, e.g.:
+// Cypress.Commands.add('login', (email, password) => { /* ... */ })
+export {}
+`,
+		],
+		[
+			// Starter spec under the shared tests/e2e folder.
+			'tests/e2e/example.cy.ts',
+			`describe('example', () => {
+	it('loads the home page', () => {
+		cy.visit('/')
+	})
+})
+`,
+		],
+	]
+	for (const [rel, content] of boilerplate) {
+		const dest = path.join(targetDir, rel)
+		if (await fs.pathExists(dest)) continue
+		await fs.ensureDir(path.dirname(dest))
+		await fs.writeFile(dest, content)
+		written.push(rel)
+	}
+	return written
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -128,6 +128,12 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: null,
 	},
 	{
+		name: 'Cypress',
+		description: 'End-to-end testing configuration (peer to Playwright)',
+		exports: ['@rtorcato/js-tooling/cypress'],
+		fixTarget: 'cypress',
+	},
+	{
 		name: 'Commitlint',
 		description: 'Conventional commit linting',
 		exports: ['@rtorcato/js-tooling/commitlint/config'],

--- a/tests/cli/generators/testing.test.ts
+++ b/tests/cli/generators/testing.test.ts
@@ -64,14 +64,40 @@ describe('generateTestingConfigs', () => {
 	})
 
 	it('the shipped playwright preset references defineConfig and devices', async () => {
-		const presetPath = join(
-			process.cwd(),
-			'tooling/playwright/playwright.config.mjs'
-		)
+		const presetPath = join(process.cwd(), 'tooling/playwright/playwright.config.mjs')
 		const preset = await fs.readFile(presetPath, 'utf-8')
 		expect(preset).toMatch(/from '@playwright\/test'/)
 		expect(preset).toMatch(/\bdefineConfig\b/)
 		expect(preset).toMatch(/\bdevices\b/)
+	})
+
+	it('writes a cypress config + support/spec boilerplate', async () => {
+		const dir = newTmpDir()
+		await generateTestingConfigs(baseConfig({ testing: { framework: 'cypress' } }), dir)
+
+		const cypressConfig = await fs.readFile(join(dir, 'cypress.config.ts'), 'utf-8')
+		expect(cypressConfig).toContain("from '@rtorcato/js-tooling/cypress'")
+		expect(await fs.pathExists(join(dir, 'cypress/support/e2e.ts'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'cypress/support/commands.ts'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'tests/e2e/example.cy.ts'))).toBe(true)
+	})
+
+	it('cypress fixer is safe-add — never clobbers an existing spec', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, 'tests/e2e'))
+		await fs.writeFile(join(dir, 'tests/e2e/example.cy.ts'), '// mine\n')
+		await generateTestingConfigs(baseConfig({ testing: { framework: 'cypress' } }), dir)
+		expect(await fs.readFile(join(dir, 'tests/e2e/example.cy.ts'), 'utf-8')).toBe('// mine\n')
+	})
+
+	it('the shipped cypress preset references defineConfig and the e2e block', async () => {
+		const preset = await fs.readFile(
+			join(process.cwd(), 'tooling/cypress/cypress.config.mjs'),
+			'utf-8'
+		)
+		expect(preset).toMatch(/from 'cypress'/)
+		expect(preset).toMatch(/\bdefineConfig\b/)
+		expect(preset).toMatch(/tests\/e2e/)
 	})
 
 	it('writes nothing when framework is none', async () => {

--- a/tooling/cypress/cypress.config.d.mts
+++ b/tooling/cypress/cypress.config.d.mts
@@ -1,0 +1,4 @@
+import type { defineConfig } from 'cypress'
+
+declare const config: Parameters<typeof defineConfig>[0]
+export default config

--- a/tooling/cypress/cypress.config.mjs
+++ b/tooling/cypress/cypress.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+	e2e: {
+		baseUrl: process.env.CYPRESS_BASE_URL ?? 'http://localhost:3000',
+		// Specs live alongside Playwright's `tests/e2e` convention so switching
+		// E2E runners doesn't move the test folder.
+		specPattern: 'tests/e2e/**/*.cy.{js,jsx,ts,tsx}',
+		supportFile: 'cypress/support/e2e.ts',
+		video: false,
+	},
+})


### PR DESCRIPTION
Closes #67.

## What

Adds a **Cypress** E2E preset as a peer to the existing Playwright preset — no preference between them. Both keep specs under `tests/e2e/`, so switching runners doesn't move the folder.

- `tooling/cypress/cypress.config.mjs` factory (`+ .d.mts`), exported as `@rtorcato/js-tooling/cypress`. Sets `baseUrl` (env-overridable), `specPattern: tests/e2e/**/*.cy.{js,jsx,ts,tsx}`, `supportFile: cypress/support/e2e.ts`.
- Generated `cypress.config.ts` re-exports the factory; scaffolds `cypress/support/{e2e,commands}.ts` + a starter `tests/e2e/example.cy.ts`.

## Wiring (threads the `testing.framework` enum)

`setup.ts` (union + wizard choice), `setup-presets.ts` (schema enum + file list), generator (`testing.ts`), `package-json.ts` (scripts `test:e2e`/`test:e2e:ui` → `cypress run`/`open`, `cypress` dep, both verify chains), `.gitignore` (`git.ts`), GitLab CI, README (structure/commands/tools), `list` command entry, and a **safe-add** `fix cypress` target.

## Notes

- `fix cypress` re-writes only the deterministic config re-export; support files and specs are never clobbered (verified on re-run).
- Did **not** add `cypress` to this repo's own devDependencies — nothing in the test/typecheck/build pipeline imports the config module (the `.d.mts` derives its type from `defineConfig`, tooling/ isn't typechecked here), so pulling the Cypress binary in would be dead weight. Consumers install it themselves.
- Added `reference/cypress.md` + sidebar. Playwright has no doc page; referenced it as plain text to avoid a broken Docusaurus link.

## Verification

- `pnpm test` — 394 pass (3 new for the generator + safe-add + shipped-preset shape).
- Typecheck + biome clean.
- End-to-end on the built CLI: `fix cypress` writes all 4 files; re-run only rewrites the config; `list` shows Cypress.