### PR TITLE
feat(cli): add PostCSS preset (#65)

### DIFF
--- a/apps/docs/docs/reference/postcss.md
+++ b/apps/docs/docs/reference/postcss.md
@@ -1,0 +1,50 @@
+---
+title: PostCSS
+description: Minimal PostCSS config (autoprefixer) for non-Tailwind CSS pipelines.
+---
+
+[PostCSS](https://postcss.org) transforms CSS with JavaScript plugins. This
+preset scaffolds a minimal `postcss.config.mjs` with
+[autoprefixer](https://github.com/postcss/autoprefixer) — vendor prefixing
+driven by your [browserslist](https://github.com/browserslist/browserslist).
+
+:::note Tailwind users
+Tailwind CSS **v4** ships its own PostCSS plugin (`@tailwindcss/postcss`), which
+autoprefixes on its own — so if you use the [Tailwind preset](./tailwind) you
+already have a `postcss.config.mjs` and don't need this one. This preset is for
+CSS pipelines **without** Tailwind. It's **safe-add**, so running it never
+overwrites a Tailwind-generated config.
+:::
+
+## Usage
+
+```bash
+npx @rtorcato/js-tooling fix postcss
+```
+
+## Generated `postcss.config.mjs`
+
+```js
+export default {
+  plugins: {
+    autoprefixer: {},
+  },
+}
+```
+
+Add more PostCSS plugins (e.g. `postcss-nesting`, `postcss-preset-env`) to the
+`plugins` object as your pipeline needs them.
+
+## Peer dependencies
+
+```json
+{
+  "devDependencies": {
+    "postcss": "^8",
+    "autoprefixer": "^10"
+  }
+}
+```
+
+Autoprefixer targets the browsers in your `browserslist` (set in `package.json`
+or `.browserslistrc`); without one it falls back to its defaults.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
         'reference/github-actions',
         'reference/jest',
         'reference/oxlint',
+        'reference/postcss',
         'reference/prettier',
         'reference/publint',
         'reference/rollup',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -29,6 +29,7 @@ import {
 } from '../generators/misc.js'
 import { generateConfigs } from '../generators/index.js'
 import { composeVerifyScriptFromPkg } from '../generators/package-json.js'
+import { generatePostcss } from '../generators/postcss.js'
 import {
 	generateCodeQLWorkflow,
 	generateDependabotConfig,
@@ -476,6 +477,18 @@ const FIXERS: Fixer[] = [
 		riskLevel: 'safe-add',
 		async run({ targetDir }) {
 			const written = await generateTailwind(targetDir)
+			return { filesWritten: written }
+		},
+	},
+	{
+		target: 'postcss',
+		description: 'Scaffold postcss.config.mjs with autoprefixer (non-Tailwind CSS pipelines)',
+		appliesTo: ['PostCSS'],
+		outputs: ['postcss.config.mjs'],
+		// safe-add: never clobber an existing config (incl. one written by `fix tailwind`).
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const written = await generatePostcss(targetDir)
 			return { filesWritten: written }
 		},
 	},

--- a/src/cli/generators/postcss.ts
+++ b/src/cli/generators/postcss.ts
@@ -1,0 +1,25 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * Scaffold a minimal PostCSS config for non-Tailwind CSS pipelines (autoprefixer
+ * over your browserslist). Tailwind v4 users get their PostCSS wiring from the
+ * Tailwind preset instead (`@tailwindcss/postcss`, which autoprefixes on its
+ * own), so this stays out of their way — safe-add never clobbers an existing
+ * postcss.config.mjs.
+ */
+export async function generatePostcss(targetDir: string): Promise<string[]> {
+	const dest = path.join(targetDir, 'postcss.config.mjs')
+	if (await fs.pathExists(dest)) return []
+	await fs.writeFile(dest, POSTCSS_CONFIG)
+	return ['postcss.config.mjs']
+}
+
+const POSTCSS_CONFIG = `export default {
+	plugins: {
+		// Adds vendor prefixes based on your browserslist (package.json or
+		// .browserslistrc). Add more PostCSS plugins here as needed.
+		autoprefixer: {},
+	},
+}
+`

--- a/tests/cli/generators/postcss.test.ts
+++ b/tests/cli/generators/postcss.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { generatePostcss } from '../../../src/cli/generators/postcss.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('generatePostcss', () => {
+	it('writes a postcss.config.mjs with autoprefixer', async () => {
+		const dir = newTmpDir()
+		const written = await generatePostcss(dir)
+		expect(written).toEqual(['postcss.config.mjs'])
+
+		const config = await fs.readFile(join(dir, 'postcss.config.mjs'), 'utf8')
+		expect(config).toContain('autoprefixer')
+		expect(config).toContain('export default')
+	})
+
+	it('is safe-add — never clobbers an existing config (e.g. from fix tailwind)', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'postcss.config.mjs'), '// tailwind\n')
+		const written = await generatePostcss(dir)
+		expect(written).toEqual([])
+		expect(await fs.readFile(join(dir, 'postcss.config.mjs'), 'utf8')).toBe('// tailwind\n')
+	})
+})


### PR DESCRIPTION
Closes #65.

## What

A **fix-only** `postcss` target that scaffolds a minimal `postcss.config.mjs` with `autoprefixer`, for CSS pipelines **without** Tailwind.

```js
export default {
  plugins: {
    autoprefixer: {},
  },
}
```

## Scope note (v3 → v4)

The issue described a v3-style default (`tailwindcss` + `autoprefixer` in PostCSS). But the shipped Tailwind preset is **v4**, where `@tailwindcss/postcss` replaces both and autoprefixes on its own — the Tailwind preset already writes `postcss.config.mjs` for that case. So this preset serves the **standalone** (non-Tailwind) case instead.

Consequences of that:
- **safe-add** — never clobbers a config written by `fix tailwind` (verified: 2nd run skips).
- **No wizard prompt** — Tailwind already handles the "implicit when Tailwind selected" path; a separate prompt on every frontend setup would be noise. `fix postcss` *is* the manual opt-in.
- Generated **directly** (like Turborepo/Tailwind), not via a `tooling/` re-export — postcss configs are tiny and project-owned.

## Verification

- `pnpm test` — 399 pass (2 new).
- Typecheck + biome clean.
- End-to-end on the built CLI: `fix postcss` writes the config, re-run safe-skips, `fix --list` shows the target.

Docs: `reference/postcss.md` + sidebar, with a note pointing Tailwind users at the Tailwind preset.