### PR TITLE
feat(cli): add Release Please preset (#64)

### DIFF
--- a/apps/docs/docs/reference/release-please.md
+++ b/apps/docs/docs/reference/release-please.md
@@ -1,0 +1,64 @@
+---
+title: Release Please
+description: Google's changelog/PR-driven release tool — a third option alongside semantic-release and Changesets.
+---
+
+[Release Please](https://github.com/googleapis/release-please) automates
+releases by opening a "release PR" that collects Conventional Commits into a
+changelog and version bump; merging that PR tags the release. It runs entirely
+as a **GitHub Action** — there are no npm devDependencies to install — which
+makes it popular in OSS.
+
+It's the third release-tool option alongside the
+[semantic-release](./semantic-release) and [Changesets](./changesets) presets.
+Pick **one**; `doctor` flags a repo that configures more than one.
+
+## Usage
+
+```bash
+npx @rtorcato/js-tooling fix release-please
+```
+
+`setup` also offers it in the release-tool list for library projects. The fixer
+is **safe-add** — it never overwrites an existing config, manifest, or workflow.
+
+## Generated files
+
+`release-please-config.json` — single package at the repo root, Node release
+type:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}
+```
+
+`.release-please-manifest.json` — the last released version per package (Release
+Please updates it on each release PR):
+
+```json
+{
+  ".": "0.0.0"
+}
+```
+
+`.github/workflows/release-please.yml` — runs the action on every push to
+`main`.
+
+## Protected branches
+
+The workflow uses the default `GITHUB_TOKEN`, which opens the release PR. If
+`main` is protected against the default token, supply an admin PAT via a
+`RELEASE_TOKEN` secret and set the action's `token:` input to it — the scaffolded
+workflow has a commented line showing where.
+
+## Monorepos
+
+Add more entries under `packages` (and matching keys in the manifest), one per
+workspace you release.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -56,6 +56,7 @@ const sidebars: SidebarsConfig = {
         'reference/postcss',
         'reference/prettier',
         'reference/publint',
+        'reference/release-please',
         'reference/rollup',
         'reference/semantic-release',
         'reference/tailwind',

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -751,24 +751,38 @@ async function checkSemanticRelease(dir: string, pkg: Pkg | null): Promise<Check
 	}
 
 	const hasChangesets = await fs.pathExists(path.join(dir, '.changeset', 'config.json'))
+	const hasReleasePlease = await fs.pathExists(path.join(dir, 'release-please-config.json'))
+	const hasSemanticRelease = inPkg || configFile !== null
 
-	// Conflict: both semantic-release and Changesets configured.
-	if ((inPkg || configFile) && hasChangesets) {
+	// Conflict: more than one of {semantic-release, Changesets, Release Please}.
+	const configured = [
+		hasSemanticRelease && 'semantic-release',
+		hasChangesets && 'Changesets',
+		hasReleasePlease && 'Release Please',
+	].filter(Boolean) as string[]
+	if (configured.length > 1) {
 		return {
 			check: 'semantic-release',
 			status: 'drift',
-			detail: 'both semantic-release and Changesets are configured',
-			hint: 'Pick one release tool — remove either the semantic-release config or the .changeset/ directory',
+			detail: `multiple release tools configured (${configured.join(', ')})`,
+			hint: 'Pick one release tool — keep a single release config and remove the others',
 		}
 	}
 
-	if (!inPkg && !configFile) {
-		// Changesets present — treat semantic-release as intentionally not used.
+	if (!hasSemanticRelease) {
+		// An alternative tool present — treat semantic-release as intentionally not used.
 		if (hasChangesets) {
 			return {
 				check: 'semantic-release',
 				status: 'ok',
 				detail: 'using Changesets (.changeset/config.json) instead',
+			}
+		}
+		if (hasReleasePlease) {
+			return {
+				check: 'semantic-release',
+				status: 'ok',
+				detail: 'using Release Please (release-please-config.json) instead',
 			}
 		}
 		return {

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -19,6 +19,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'Husky pre-push': 'husky',
 	'verify script': 'verify',
 	'semantic-release': 'semantic-release',
+	'Release Please': 'release-please',
 	knip: 'knip',
 	'size-limit': 'size-limit',
 	'Tree-shake check': 'treeshake-check',
@@ -78,6 +79,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			)
 		case 'semantic-release':
 			return c.semanticRelease === false
+		case 'Release Please':
+			return c.releasePlease === false
 		case 'Dependabot':
 		case 'CodeQL':
 		// GitHub repo-settings checks (#137) share the securityAutomation opt-out.
@@ -139,6 +142,8 @@ export function lockfilePatchForTarget(
 			return c.gitHooks ? null : { gitHooks: true }
 		case 'semantic-release':
 			return c.semanticRelease ? null : { semanticRelease: true }
+		case 'release-please':
+			return c.releasePlease ? null : { releasePlease: true }
 		case 'dependabot':
 		case 'renovate':
 		case 'codeql':

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -30,6 +30,7 @@ import {
 import { generateConfigs } from '../generators/index.js'
 import { composeVerifyScriptFromPkg } from '../generators/package-json.js'
 import { generatePostcss } from '../generators/postcss.js'
+import { generateReleasePlease } from '../generators/release-please.js'
 import {
 	generateCodeQLWorkflow,
 	generateDependabotConfig,
@@ -356,6 +357,23 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const result = await copyPreset('changesets', targetDir)
 			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'release-please',
+		description:
+			'Scaffold Release Please config + manifest + GitHub Action (alternative to semantic-release)',
+		appliesTo: ['Release Please'],
+		outputs: [
+			'release-please-config.json',
+			'.release-please-manifest.json',
+			'.github/workflows/release-please.yml',
+		],
+		// safe-add: never clobber a hand-tuned config, manifest, or workflow.
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const written = await generateReleasePlease(targetDir)
+			return { filesWritten: written }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -138,6 +138,7 @@ export const CONFIG_SCHEMA = {
 		commitLint: { type: 'boolean' },
 		semanticRelease: { type: 'boolean' },
 		changesets: { type: 'boolean' },
+		releasePlease: { type: 'boolean' },
 		oxlint: { type: 'boolean' },
 		securityAutomation: { type: 'boolean' },
 		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'rollup', 'vite', 'none'] },
@@ -215,6 +216,13 @@ export function computeFileList(config: ProjectConfig): string[] {
 	else if (config.bundler === 'vite') files.push('vite.config.ts')
 	if (config.semanticRelease) files.push('release.config.mjs')
 	if (config.changesets) files.push('.changeset/config.json')
+	if (config.releasePlease) {
+		files.push(
+			'release-please-config.json',
+			'.release-please-manifest.json',
+			'.github/workflows/release-please.yml'
+		)
+	}
 	if (config.oxlint) files.push('.oxlintrc.json')
 	if (config.treeshakeCheck && config.projectType === 'library') {
 		files.push(

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -43,6 +43,8 @@ export interface ProjectConfig {
 	commitLint: boolean
 	semanticRelease: boolean
 	changesets?: boolean
+	/** Scaffold Release Please (Google's changelog/PR-driven release tool, runs as a GitHub Action). */
+	releasePlease?: boolean
 	oxlint?: boolean
 	securityAutomation: boolean
 	bundler: 'tsup' | 'esbuild' | 'rollup' | 'vite' | 'none'
@@ -277,6 +279,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 			choices: [
 				{ name: '📦 semantic-release (commit-message-driven)', value: 'semantic-release' },
 				{ name: '📝 Changesets (changeset-file-driven, monorepo-friendly)', value: 'changesets' },
+				{ name: '🙏 Release Please (changelog/PR-driven, GitHub Action)', value: 'release-please' },
 				{ name: '❌ None', value: 'none' },
 			],
 			default: 'semantic-release',
@@ -384,6 +387,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 		commitLint: answers.commitLint || false,
 		semanticRelease: answers.releaseTool === 'semantic-release',
 		changesets: answers.releaseTool === 'changesets',
+		releasePlease: answers.releaseTool === 'release-please',
 		oxlint: answers.oxlint || false,
 		securityAutomation: answers.securityAutomation ?? false,
 		bundler: answers.bundler || 'none',
@@ -452,7 +456,12 @@ function collectSkippedFixSuggestions(config: ProjectConfig): string[] {
 			'Run `npx @rtorcato/js-tooling fix commitlint` to add conventional-commit linting'
 		)
 	}
-	if (!config.semanticRelease && config.projectType === 'library') {
+	if (
+		!config.semanticRelease &&
+		!config.changesets &&
+		!config.releasePlease &&
+		config.projectType === 'library'
+	) {
 		suggestions.push(
 			'Run `npx @rtorcato/js-tooling fix semantic-release` to add automated releases'
 		)

--- a/src/cli/generators/build.ts
+++ b/src/cli/generators/build.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
+import { generateReleasePlease } from './release-please.js'
 
 // tsup, esbuild, and vite all pull in esbuild, whose install-time build script
 // pnpm 11 refuses to run until it's approved — otherwise `pnpm install` fails
@@ -55,6 +56,11 @@ export async function generateBuildConfigs(config: ProjectConfig, targetDir: str
 	// Generate Changesets config (alternative to semantic-release)
 	if (config.changesets) {
 		await generateChangesetsConfig(targetDir)
+	}
+
+	// Generate Release Please config + workflow (alternative to semantic-release)
+	if (config.releasePlease) {
+		await generateReleasePlease(targetDir)
 	}
 }
 

--- a/src/cli/generators/release-please.ts
+++ b/src/cli/generators/release-please.ts
@@ -1,0 +1,75 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * Scaffold Release Please — Google's changelog/PR-driven release tool, an
+ * alternative to semantic-release and Changesets. It runs entirely as a GitHub
+ * Action, so the setup is two manifest files (config + version manifest) plus a
+ * workflow; there are no npm devDependencies to install.
+ *
+ * Every file is safe-add — an existing one is never clobbered — so this can also
+ * repair a partial setup.
+ */
+export async function generateReleasePlease(targetDir: string): Promise<string[]> {
+	const written: string[] = []
+
+	const files: Array<[string, string]> = [
+		['release-please-config.json', RELEASE_PLEASE_CONFIG],
+		['.release-please-manifest.json', RELEASE_PLEASE_MANIFEST],
+		[path.join('.github', 'workflows', 'release-please.yml'), RELEASE_PLEASE_WORKFLOW],
+	]
+
+	for (const [rel, content] of files) {
+		const dest = path.join(targetDir, rel)
+		if (await fs.pathExists(dest)) continue
+		await fs.ensureDir(path.dirname(dest))
+		await fs.writeFile(dest, content)
+		written.push(rel)
+	}
+
+	return written
+}
+
+// Single package at the repo root, Node release type. Consumers add more
+// entries under `packages` for a monorepo.
+const RELEASE_PLEASE_CONFIG = `{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md"
+    }
+  }
+}
+`
+
+// Tracks the last released version per package. Release Please updates this on
+// every release PR; start at 0.0.0 (or your current version).
+const RELEASE_PLEASE_MANIFEST = `{
+  ".": "0.0.0"
+}
+`
+
+const RELEASE_PLEASE_WORKFLOW = `name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # GITHUB_TOKEN works for opening the release PR. If main is protected
+          # against the default token, swap in an admin PAT:
+          #   token: \${{ secrets.RELEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -162,6 +162,13 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: 'changesets',
 	},
 	{
+		name: 'Release Please',
+		description:
+			'Changelog/PR-driven release tool via GitHub Action (alternative to semantic-release)',
+		exports: [],
+		fixTarget: 'release-please',
+	},
+	{
 		name: 'Oxlint',
 		description: 'Rust-based linter (additive to Biome/ESLint)',
 		exports: ['@rtorcato/js-tooling/oxlint'],

--- a/tests/cli/generators/release-please.test.ts
+++ b/tests/cli/generators/release-please.test.ts
@@ -1,0 +1,64 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { generateReleasePlease } from '../../../src/cli/generators/release-please.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('generateReleasePlease', () => {
+	it('writes config, manifest, and the workflow', async () => {
+		const dir = newTmpDir()
+		const written = await generateReleasePlease(dir)
+		expect(written).toEqual([
+			'release-please-config.json',
+			'.release-please-manifest.json',
+			join('.github', 'workflows', 'release-please.yml'),
+		])
+
+		const config = await fs.readJson(join(dir, 'release-please-config.json'))
+		expect(config.packages['.']['release-type']).toBe('node')
+		const manifest = await fs.readJson(join(dir, '.release-please-manifest.json'))
+		expect(manifest['.']).toBe('0.0.0')
+		const workflow = await fs.readFile(join(dir, '.github/workflows/release-please.yml'), 'utf8')
+		expect(workflow).toContain('googleapis/release-please-action@v4')
+	})
+
+	it('is safe-add — never clobbers existing files', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'release-please-config.json'), '{ "mine": true }\n')
+		const written = await generateReleasePlease(dir)
+		expect(written).not.toContain('release-please-config.json')
+		expect(await fs.readFile(join(dir, 'release-please-config.json'), 'utf8')).toBe(
+			'{ "mine": true }\n'
+		)
+	})
+})
+
+describe('doctor release-tool conflict', () => {
+	const findRelease = (results: { check: string }[]) =>
+		results.find((r) => r.check === 'semantic-release')
+
+	it('reports ok "using Release Please" when only release-please is configured', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', private: false })
+		await generateReleasePlease(dir)
+		const r = findRelease(await runDoctor(dir))
+		expect(r?.status).toBe('ok')
+		expect(r?.detail).toMatch(/Release Please/)
+	})
+
+	it('flags drift when both semantic-release and release-please are configured', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			private: false,
+			release: { extends: '@rtorcato/js-tooling/semantic-release/github' },
+		})
+		await generateReleasePlease(dir)
+		const r = findRelease(await runDoctor(dir))
+		expect(r?.status).toBe('drift')
+		expect(r?.detail).toMatch(/multiple release tools/)
+	})
+})


### PR DESCRIPTION
Closes #64.

## What

Adds **Release Please** (Google's changelog/PR-driven release tool) as a third option alongside semantic-release and Changesets. It runs entirely as a **GitHub Action**, so the scaffold is two manifest files plus a workflow — **no npm devDependencies**.

`fix release-please` (and the setup wizard's release-tool list) scaffolds:
- `release-please-config.json` — single package at root, `release-type: node`
- `.release-please-manifest.json` — `{ ".": "0.0.0" }`
- `.github/workflows/release-please.yml` — `googleapis/release-please-action@v4` on push to `main`

## Wiring

`ProjectConfig.releasePlease` (mirrors the `changesets?` boolean), setup wizard option + mapping, `setup-presets` schema + file list, `build.ts` generator dispatch, a **safe-add** `fix release-please` target, lockfile opt-in/out, `list` entry, docs + sidebar.

**Doctor:** extended the release-tool check to a **3-way** mutual exclusion — flags a repo that configures more than one of {semantic-release, Changesets, Release Please}, and reports `ok — using Release Please instead` when it's the sole tool.

## ⚠️ Please review before merging

I left **auto-merge off** on this one — it touches release automation. Two things worth your eyes:
1. **The workflow** (`release-please.yml`) uses the default `GITHUB_TOKEN` with a commented `RELEASE_TOKEN` PAT fallback for protected `main`. Confirm that matches how you want releases to run here.
2. **Scope reduction:** the issue asked for `tooling/release-please/*.json` templates + a `@rtorcato/js-tooling/release-please` export. I generated the files inline instead (like Turborepo/Tailwind) and **skipped the export** — a release-please config isn't `extends`-able, so an export path isn't consumable. Say the word if you want the tooling/ templates + export for consistency anyway.

## Verification

- `pnpm test` — 403 pass (4 new: generator, safe-add, doctor "using Release Please", 3-way conflict).
- Typecheck + biome clean.
- End-to-end on the built CLI: `fix release-please` writes all 3 files; `doctor` reports `using Release Please instead`; `fix --list` shows the target.