### PR TITLE
docs: add ROADMAP + public-API release checklist (#133)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,3 +22,12 @@
 - [ ] No `console.log` left in production code
 - [ ] No breaking changes (or BREAKING CHANGE footer added to commit)
 - [ ] `pnpm check` (Biome) passes
+
+## Public API / docs
+
+<!-- Only if this changes a public API — a ProjectConfig field, doctor check
+name, fix target, or export subpath. Delete this section otherwise. -->
+
+- [ ] Docs site updated (`apps/docs/`)
+- [ ] README updated (examples / reference)
+- [ ] Relevant [`ROADMAP.md`](../ROADMAP.md) / milestone item ticked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,16 @@ Releases are automated using semantic-release:
 3. **Changelog generation:** Automatic based on commits
 4. **npm publication:** Automated via GitHub Actions
 
+Version bumps are automated, but **public-API changes carry a manual checklist**.
+If a PR changes a public API — a `ProjectConfig` field, a `doctor` check name, a
+`fix` target, or an export subpath — it must also:
+
+- [ ] Update the docs site (`apps/docs/`)
+- [ ] Update the README (examples / reference)
+- [ ] Tick the relevant [`ROADMAP.md`](ROADMAP.md) / milestone item
+
+See [`ROADMAP.md`](ROADMAP.md) for the milestone phases (Shipped → Beta → v1.0).
+
 ## 📝 Pull Request Guidelines
 
 ### Before Submitting

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,45 @@
+# Roadmap
+
+The direction for `@rtorcato/js-tooling`. Tracked against GitHub
+[milestones](https://github.com/rtorcato/js-tooling/milestones); this file and
+the milestones should stay in sync. Version bumps are automated
+(semantic-release) — the roadmap tracks the **public surface**, not releases.
+
+## ✅ Shipped
+
+The pre-1.0 foundation, published on npm and dogfooded here:
+
+- `setup` wizard + non-interactive `--preset` / `--config` for JS/TS repos.
+- `doctor` drift checks (TypeScript, Biome/ESLint, Prettier, Vitest, Husky,
+  semantic-release, GitHub repo settings, and more) with a lockfile record.
+- `fix` scaffolders for every check, plus `copy` and `list`.
+- Published config bases: TypeScript, Biome, ESLint, Prettier, Vitest/Jest,
+  tsup/esbuild/rollup/vite, semantic-release, Changesets, Docusaurus.
+- Presets: Turborepo, Tailwind CSS v4.
+
+## 🧪 Beta — pre-1.0 preview line
+
+Hardening the surface before committing to a stable API. Breaking changes may
+still land on the `2.x` line.
+
+- Dogfood the bases internally and across the sibling fleet ([#148](https://github.com/rtorcato/js-tooling/issues/148)).
+- Multi-language base + per-language modules umbrella ([#139](https://github.com/rtorcato/js-tooling/issues/139)).
+- Dependabot strategy rollout ([#111](https://github.com/rtorcato/js-tooling/issues/111)).
+- npm Trusted Publishing / OIDC migration ([#201](https://github.com/rtorcato/js-tooling/issues/201)).
+- Docs-site scaffolding + shared Docusaurus helpers ([#100](https://github.com/rtorcato/js-tooling/issues/100), [#54](https://github.com/rtorcato/js-tooling/issues/54)).
+
+## 🎯 v1.0 — Stable API
+
+The commitments a `1.0` implies:
+
+- Frozen `ProjectConfig` schema + `.js-tooling.json` lockfile format (documented,
+  versioned, migrated).
+- Stable `doctor` check names and `fix` target names (they're a public contract —
+  scripts and CI depend on them).
+- Stable export subpaths (`@rtorcato/js-tooling/*`).
+- SemVer discipline: no breaking changes to the above without a major bump.
+
+---
+
+Have an idea? Open an [issue](https://github.com/rtorcato/js-tooling/issues) and,
+if it fits a phase above, tag it with the matching milestone.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,10 @@
 # Roadmap
 
-The direction for `@rtorcato/js-tooling`. Tracked against GitHub
-[milestones](https://github.com/rtorcato/js-tooling/milestones); this file and
-the milestones should stay in sync. Version bumps are automated
-(semantic-release) — the roadmap tracks the **public surface**, not releases.
+The direction for `@rtorcato/js-tooling`. Active work is organized by GitHub
+[milestones](https://github.com/rtorcato/js-tooling/milestones) — this file
+mirrors them so the roadmap and the tracker don't drift. Version bumps are
+automated (semantic-release); the roadmap tracks the **public surface**, not
+releases.
 
 ## ✅ Shipped
 
@@ -17,29 +18,38 @@ The pre-1.0 foundation, published on npm and dogfooded here:
   tsup/esbuild/rollup/vite, semantic-release, Changesets, Docusaurus.
 - Presets: Turborepo, Tailwind CSS v4.
 
-## 🧪 Beta — pre-1.0 preview line
+## 🚧 In progress — pre-1.0 milestones
 
-Hardening the surface before committing to a stable API. Breaking changes may
-still land on the `2.x` line.
+Tracked one-to-one with the GitHub milestones. Breaking changes may still land
+on the `2.x` line while these are open.
 
-- Dogfood the bases internally and across the sibling fleet ([#148](https://github.com/rtorcato/js-tooling/issues/148)).
-- Multi-language base + per-language modules umbrella ([#139](https://github.com/rtorcato/js-tooling/issues/139)).
-- Dependabot strategy rollout ([#111](https://github.com/rtorcato/js-tooling/issues/111)).
-- npm Trusted Publishing / OIDC migration ([#201](https://github.com/rtorcato/js-tooling/issues/201)).
-- Docs-site scaffolding + shared Docusaurus helpers ([#100](https://github.com/rtorcato/js-tooling/issues/100), [#54](https://github.com/rtorcato/js-tooling/issues/54)).
+- **[Hardening — trustworthy generated output](https://github.com/rtorcato/js-tooling/milestone/3)** —
+  fix every case where `setup`/`fix` emits broken or drifted output; lock it in
+  with snapshot + integration tests. The tool must be safe on a real repo.
+- **[GitHub settings sync](https://github.com/rtorcato/js-tooling/milestone/1)** —
+  machine-check and apply repo settings (branch protection, merge, workflow
+  perms) via `doctor`/`fix`, closing the prose-only gap.
+- **[Repo & release hygiene](https://github.com/rtorcato/js-tooling/milestone/4)** —
+  release-pipeline quality (OIDC, Dependabot, branch protection) for this repo.
+- **[Multi-language support](https://github.com/rtorcato/js-tooling/milestone/2)** —
+  a language-agnostic base + per-language modules (Swift, Perl, Python).
+- **[Docs & docs-site](https://github.com/rtorcato/js-tooling/milestone/5)** —
+  README, docs-site scaffolding, Docusaurus helpers, shared theme.
+- **[Preset backlog](https://github.com/rtorcato/js-tooling/milestone/6)** —
+  new tool presets (Bun, Nx, PostCSS, Renovate, more GHA workflows, …).
 
 ## 🎯 v1.0 — Stable API
 
-The commitments a `1.0` implies:
+The commitments a `1.0` implies, once the milestones above land:
 
 - Frozen `ProjectConfig` schema + `.js-tooling.json` lockfile format (documented,
   versioned, migrated).
-- Stable `doctor` check names and `fix` target names (they're a public contract —
-  scripts and CI depend on them).
+- Stable `doctor` check names and `fix` target names — they're a public contract
+  that scripts and CI depend on.
 - Stable export subpaths (`@rtorcato/js-tooling/*`).
 - SemVer discipline: no breaking changes to the above without a major bump.
 
 ---
 
 Have an idea? Open an [issue](https://github.com/rtorcato/js-tooling/issues) and,
-if it fits a phase above, tag it with the matching milestone.
+if it fits an open milestone, tag it there.


### PR DESCRIPTION
Closes #133 (docs portion).

## What

- **`ROADMAP.md`** (new) — mirrors the repo's **existing GitHub milestones** (Hardening, GitHub settings sync, Repo & release hygiene, Multi-language, Docs & docs-site, Preset backlog) under a Shipped → in-progress → **v1.0 — Stable API** framing. Each in-progress phase links its milestone so the roadmap and tracker can't drift.
- **PR template** + **CONTRIBUTING "Release Process"** — a public-API change checklist: any PR changing a `ProjectConfig` field, doctor check name, fix target, or export subpath must update the docs site, README, and tick the roadmap/milestone.

## Milestones — reconciled, not recreated

#133 asked to create Shipped/Beta/v1.0 milestones, but the repo **already has 6 thematic milestones**. Stacking a parallel taxonomy would re-introduce the ROADMAP↔tracker drift #133 wants to kill, so ROADMAP points at the existing milestones instead. No `gh` writes. The v1.0 freeze goals live in ROADMAP as a phase, not a milestone.

Markdown only — no code, tests, or lint surface touched.