### PR TITLE
feat(dependabot): canonical strategy — groups + auto-merge (#111)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,25 +7,27 @@ updates:
       day: 1
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     commit-message:
       prefix: chore
       include: scope
     groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@typescript-eslint/*"
-          - "typescript-eslint"
-      semantic-release:
-        patterns:
-          - "semantic-release"
-          - "@semantic-release/*"
-      types:
-        patterns:
-          - "@types/*"
+      # minor + patch, split prod/dev — the auto-merge tier (green-gated).
+      production-minor:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # one PR per ecosystem for all majors — triaged monthly, never auto-merged.
+      major-updates:
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -891,22 +891,33 @@ async function checkDependabot(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
 		const candidatePath = path.join(dir, candidate)
 		if (await fs.pathExists(candidatePath)) {
-			// A config with no `groups:` predates the grouping/ignore defaults — a lone
-			// react-dom or TypeScript-major bump can never pass CI. Flag as drift so
-			// `fix dependabot` can bring it up to standard.
+			// The canonical strategy (#111) groups into production-minor / dev-minor
+			// (auto-merged) + major-updates (never), backed by a dependabot-automerge
+			// workflow. A config missing those groups or the workflow predates the
+			// standard — flag as drift so `fix dependabot` can bring it up to date.
 			const content = await fs.readFile(candidatePath, 'utf8')
-			if (!/^\s*groups:/m.test(content)) {
+			const hasCanonicalGroups = /production-minor/.test(content) && /major-updates/.test(content)
+			const hasAutomerge = await fs.pathExists(
+				path.join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+			)
+			if (!hasCanonicalGroups || !hasAutomerge) {
+				const missing = [
+					hasCanonicalGroups
+						? null
+						: 'canonical grouping (production-minor/dev-minor/major-updates)',
+					hasAutomerge ? null : 'dependabot-automerge.yml workflow',
+				].filter(Boolean)
 				return {
 					check: 'Dependabot',
 					status: 'drift',
-					detail: `${candidate} missing recommended dependency grouping`,
-					hint: 'Run `npx @rtorcato/js-tooling fix dependabot` to add grouping + ignore rules',
+					detail: `${candidate} missing ${missing.join(' + ')}`,
+					hint: 'Run `npx @rtorcato/js-tooling fix dependabot` to apply the canonical config + auto-merge workflow',
 				}
 			}
 			return {
 				check: 'Dependabot',
 				status: 'ok',
-				detail: `${candidate} found`,
+				detail: `${candidate} + auto-merge workflow found`,
 			}
 		}
 	}

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -32,6 +32,7 @@ import { composeVerifyScriptFromPkg } from '../generators/package-json.js'
 import { generatePostcss } from '../generators/postcss.js'
 import {
 	generateCodeQLWorkflow,
+	generateDependabotAutomerge,
 	generateDependabotConfig,
 	generateRenovateConfig,
 } from '../generators/security.js'
@@ -384,13 +385,17 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'dependabot',
-		description: 'Scaffold .github/dependabot.yml (weekly npm + actions updates, grouped)',
+		description:
+			'Scaffold the canonical .github/dependabot.yml + dependabot-automerge.yml (monthly, grouped, safe-tier auto-merge)',
 		appliesTo: ['Dependabot'],
-		outputs: ['.github/dependabot.yml'],
+		outputs: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
 		canFixDrift: true,
 		async run({ targetDir }) {
 			await generateDependabotConfig(targetDir)
-			return { filesWritten: ['.github/dependabot.yml'] }
+			await generateDependabotAutomerge(targetDir)
+			return {
+				filesWritten: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
+			}
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -207,7 +207,11 @@ export function computeFileList(config: ProjectConfig): string[] {
 	}
 	files.push('.github/workflows/ci.yml')
 	if (config.securityAutomation) {
-		files.push('.github/dependabot.yml', '.github/workflows/codeql.yml')
+		files.push(
+			'.github/dependabot.yml',
+			'.github/workflows/dependabot-automerge.yml',
+			'.github/workflows/codeql.yml'
+		)
 	}
 	if (config.bundler === 'tsup') files.push('tsup.config.ts')
 	else if (config.bundler === 'esbuild') files.push('build.mjs')

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -1,53 +1,95 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 
-export async function generateDependabotConfig(targetDir: string) {
-	await fs.ensureDir(path.join(targetDir, '.github'))
-	const filepath = path.join(targetDir, '.github', 'dependabot.yml')
-
-	const content = `version: 2
+// The canonical Dependabot strategy (#111): monthly, grouped into
+// production-minor / dev-minor (auto-mergeable on green) and major-updates (one
+// PR/ecosystem, never auto-merged), plus github-actions. See the guide:
+// apps/docs/docs/guides/dependabot-strategy.md
+const DEPENDABOT_CONFIG = `version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    versioning-strategy: "increase"
+      interval: monthly
+      day: 1
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
     commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    # TypeScript majors remove config options (7.0 dropped baseUrl) — a deliberate
-    # migration, not a dependabot bump. Take minor/patch only.
-    ignore:
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
+      prefix: chore
+      include: scope
     groups:
-      # react + react-dom must move in lockstep (React errors on mismatched versions),
-      # so group them; a lone react-dom bump can never pass CI. Inert in non-React repos.
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      # Fold every other minor/patch bump into one weekly PR to cut noise.
-      # Majors stay as individual PRs so breaking changes are reviewed on their own.
-      minor-and-patch:
-        patterns:
-          - "*"
+      # minor + patch, split prod/dev — the auto-merge tier (green-gated).
+      production-minor:
+        dependency-type: production
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # one PR per ecosystem for all majors — triaged monthly, never auto-merged.
+      major-updates:
+        update-types:
+          - major
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
+      day: 1
     commit-message:
-      prefix: "chore(ci)"
+      prefix: ci
+      include: scope
 `
 
-	await fs.writeFile(filepath, content)
+// Auto-merges the safe tier (patch + minor, prod + dev) once CI is green.
+// Requires branch protection with required checks on the default branch (#109),
+// otherwise \`gh pr merge --auto\` never fires. Majors are excluded by the guard.
+const DEPENDABOT_AUTOMERGE = `name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: \${{ github.event.pull_request.html_url }}
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`
+
+export async function generateDependabotConfig(targetDir: string) {
+	await fs.ensureDir(path.join(targetDir, '.github'))
+	await fs.writeFile(path.join(targetDir, '.github', 'dependabot.yml'), DEPENDABOT_CONFIG)
+}
+
+/** Scaffold the auto-merge workflow that backs the Dependabot strategy (#111). */
+export async function generateDependabotAutomerge(targetDir: string) {
+	await fs.ensureDir(path.join(targetDir, '.github', 'workflows'))
+	await fs.writeFile(
+		path.join(targetDir, '.github', 'workflows', 'dependabot-automerge.yml'),
+		DEPENDABOT_AUTOMERGE
+	)
 }
 
 export async function generateRenovateConfig(targetDir: string) {
@@ -127,5 +169,6 @@ jobs:
 
 export async function generateSecurityConfigs(targetDir: string) {
 	await generateDependabotConfig(targetDir)
+	await generateDependabotAutomerge(targetDir)
 	await generateCodeQLWorkflow(targetDir)
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -211,7 +211,7 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 	},
 	{
 		name: 'Dependabot',
-		description: 'Weekly automated dependency updates',
+		description: 'Monthly grouped dependency updates + safe-tier auto-merge',
 		exports: [],
 		fixTarget: 'dependabot',
 	},

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -555,13 +555,29 @@ describe('doctor security checks', () => {
 		expect(dep?.hint).toMatch(/fix dependabot/)
 	})
 
-	it('reports Dependabot ok when dependabot.yml has a groups block', async () => {
+	it('reports Dependabot drift when the config has non-canonical grouping', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.github'))
 		await fs.writeFile(
 			join(dir, '.github', 'dependabot.yml'),
-			'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    groups:\n      all:\n        patterns: ["*"]\n'
+			'version: 2\nupdates:\n  - package-ecosystem: npm\n    groups:\n      all:\n        patterns: ["*"]\n'
+		)
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('drift')
+	})
+
+	it('reports Dependabot ok with canonical groups + the auto-merge workflow', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'dependabot.yml'),
+			'version: 2\nupdates:\n  - package-ecosystem: npm\n    groups:\n      production-minor:\n        dependency-type: production\n      dev-minor:\n        dependency-type: development\n      major-updates:\n        update-types: [major]\n'
+		)
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+			'name: Dependabot auto-merge\n'
 		)
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('ok')

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -12,10 +12,20 @@ vi.mock('inquirer', () => ({
 const promptMock = vi.mocked(inquirer.prompt)
 const newTmpDir = useTmpDir()
 
-// A dependabot.yml with a `groups:` block reads as up-to-date (no drift), so the
-// fixer treats it as already-ok and leaves it alone.
+// The canonical dependabot.yml — with the canonical groups AND the auto-merge
+// workflow present (see seedDependabotStandard), doctor reads it as up-to-date,
+// so the fixer treats it as already-ok and leaves it alone.
 const GROUPED_DEPENDABOT =
-	'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    groups:\n      all:\n        patterns: ["*"]\n'
+	'version: 2\nupdates:\n  - package-ecosystem: npm\n    groups:\n      production-minor:\n        dependency-type: production\n      dev-minor:\n        dependency-type: development\n      major-updates:\n        update-types: [major]\n'
+
+/** Write the canonical config + auto-merge workflow so doctor reports Dependabot ok. */
+async function seedDependabotStandard(dir: string): Promise<void> {
+	await fs.outputFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+	await fs.outputFile(
+		join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+		'name: Dependabot auto-merge\n'
+	)
+}
 
 async function seedPackageJson(dir: string, extra: Record<string, unknown> = {}) {
 	await fs.writeJson(join(dir, 'package.json'), {
@@ -132,21 +142,24 @@ describe('fix targeted', () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.writeJson(join(dir, 'renovate.json'), { extends: ['config:recommended'] })
-		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+		await seedDependabotStandard(dir)
 		await fixCommand('dependabot', { directory: dir, yes: true })
 		// dependabot.yml should remain untouched (no overwrite) and no error thrown.
 		const yaml = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
 		expect(yaml).toBe(GROUPED_DEPENDABOT)
 	})
 
-	it('fix dependabot upgrades an existing config that lacks grouping', async () => {
+	it('fix dependabot upgrades a non-canonical config to the standard + workflow', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
 		await fixCommand('dependabot', { directory: dir, yes: true })
 		const yaml = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
-		expect(yaml).toMatch(/^\s*groups:/m)
-		expect(yaml).toMatch(/dependency-name: "typescript"/)
+		expect(yaml).toMatch(/production-minor/)
+		expect(yaml).toMatch(/major-updates/)
+		expect(await fs.pathExists(join(dir, '.github', 'workflows', 'dependabot-automerge.yml'))).toBe(
+			true
+		)
 	})
 
 	it('fix unknown-target exits non-zero', async () => {
@@ -601,8 +614,7 @@ describe('fix targeted', () => {
 	it('returns early when check is already ok', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.ensureDir(join(dir, '.github'))
-		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+		await seedDependabotStandard(dir)
 		// Should not call inquirer at all.
 		await fixCommand('dependabot', { directory: dir })
 		expect(promptMock).not.toHaveBeenCalled()
@@ -627,7 +639,7 @@ describe('fix --json', () => {
 				target: 'dependabot',
 				check: 'Dependabot',
 				status: 'applied',
-				filesWritten: ['.github/dependabot.yml'],
+				filesWritten: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
 			})
 		} finally {
 			logSpy.mockRestore()
@@ -690,8 +702,7 @@ describe('fix --json', () => {
 	it('reports already-ok for a check that passes', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.ensureDir(join(dir, '.github'))
-		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+		await seedDependabotStandard(dir)
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await fixCommand('dependabot', { directory: dir, json: true })

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import {
 	generateCodeQLWorkflow,
+	generateDependabotAutomerge,
 	generateDependabotConfig,
 	generateSecurityConfigs,
 } from '../../../src/cli/generators/security.js'
@@ -17,20 +18,39 @@ describe('generateDependabotConfig', () => {
 		const filepath = join(dir, '.github', 'dependabot.yml')
 		expect(await fs.pathExists(filepath)).toBe(true)
 		const content = await fs.readFile(filepath, 'utf-8')
-		expect(content).toMatch(/package-ecosystem: "npm"/)
-		expect(content).toMatch(/package-ecosystem: "github-actions"/)
-		expect(content).toMatch(/interval: "weekly"/)
+		expect(content).toMatch(/package-ecosystem: npm/)
+		expect(content).toMatch(/package-ecosystem: github-actions/)
+		expect(content).toMatch(/interval: monthly/)
 	})
 
-	it('groups react + react-dom and minor/patch bumps, and ignores typescript majors', async () => {
+	it('uses the canonical groups and monthly cadence with a 5-PR ceiling', async () => {
 		const dir = newTmpDir()
 		await generateDependabotConfig(dir)
 		const content = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
-		expect(content).toMatch(/^\s*groups:/m)
-		expect(content).toMatch(/react-dom/)
-		expect(content).toMatch(/minor-and-patch/)
-		expect(content).toMatch(/dependency-name: "typescript"/)
-		expect(content).toMatch(/version-update:semver-major/)
+		expect(content).toMatch(/production-minor/)
+		expect(content).toMatch(/dev-minor/)
+		expect(content).toMatch(/major-updates/)
+		expect(content).toMatch(/open-pull-requests-limit: 5/)
+		// dependency-type split (prod vs dev) is what makes the auto-merge tier safe.
+		expect(content).toMatch(/dependency-type: production/)
+		expect(content).toMatch(/dependency-type: development/)
+	})
+})
+
+describe('generateDependabotAutomerge', () => {
+	it('writes the auto-merge workflow gated to patch + minor', async () => {
+		const dir = newTmpDir()
+		await generateDependabotAutomerge(dir)
+		const content = await fs.readFile(
+			join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+			'utf-8'
+		)
+		expect(content).toMatch(/dependabot\/fetch-metadata/)
+		expect(content).toMatch(/version-update:semver-patch/)
+		expect(content).toMatch(/version-update:semver-minor/)
+		expect(content).toMatch(/gh pr merge --auto --squash/)
+		// majors must NOT be auto-merged.
+		expect(content).not.toMatch(/semver-major/)
 	})
 })
 
@@ -48,10 +68,13 @@ describe('generateCodeQLWorkflow', () => {
 })
 
 describe('generateSecurityConfigs', () => {
-	it('writes both dependabot and codeql configs', async () => {
+	it('writes dependabot config, auto-merge workflow, and codeql config', async () => {
 		const dir = newTmpDir()
 		await generateSecurityConfigs(dir)
 		expect(await fs.pathExists(join(dir, '.github', 'dependabot.yml'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.github', 'workflows', 'dependabot-automerge.yml'))).toBe(
+			true
+		)
 		expect(await fs.pathExists(join(dir, '.github', 'workflows', 'codeql.yml'))).toBe(true)
 	})
 })


### PR DESCRIPTION
Implements the code portion of #111 (the Dependabot standard from #110).

## What

Converges three divergent Dependabot configs (the generator's, this repo's, and the guide's) onto the **canonical strategy**:

- **`dependabot.yml`** — monthly, `open-pull-requests-limit: 5`, grouped into `production-minor` / `dev-minor` (minor+patch, split by dependency-type — the green-gated auto-merge tier) and `major-updates` (one PR/ecosystem, never auto-merged), plus `github-actions`.
- **`dependabot-automerge.yml`** (new generator output) — `dependabot/fetch-metadata` + `gh pr merge --auto --squash`, gated to `version-update:semver-patch` / `semver-minor`. Majors are excluded by the guard.
- **doctor** — `Dependabot` now drifts when the config lacks the canonical groups **or** the auto-merge workflow is missing; `fix dependabot` applies both.
- Dogfooded: this repo's own `.github/dependabot.yml` updated to canonical (its auto-merge workflow already matched).

## Scope / dependency

This is the **generator + doctor/fix + dogfood** slice. The runtime behavior (auto-merge actually firing) needs branch protection with required checks — **#109** — which is a live-repo setting, not code. The workflow comment and PR/guide call that out.

## Verification

- `pnpm test` — 401 pass (rewrote the dependabot/security/doctor/fix tests for the canonical config + workflow; added auto-merge generator coverage).
- Typecheck + biome clean.
- End-to-end on the built CLI: `fix dependabot` writes both files; `doctor` then reports `Dependabot — ok (config + auto-merge workflow found)`.

Spec: `apps/docs/docs/guides/dependabot-strategy.md`.