### PR TITLE
feat: self-hosted Claude plugin + skills for AI tools (#162)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "js-tooling",
+  "owner": {
+    "name": "Richard Torcato",
+    "email": "rtorcato@me.com"
+  },
+  "description": "Claude Code plugin for @rtorcato/js-tooling — the JavaScript/TypeScript tooling distribution (setup/doctor/fix CLI + shared config bases). Ships two skills: js-tooling and npm-publish.",
+  "plugins": [
+    {
+      "name": "js-tooling",
+      "source": "./",
+      "description": "Two skills in one plugin: how to adopt the shared presets + CLI, and how releases work (semantic-release owns the version — never publish by hand)."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "js-tooling",
+  "version": "1.0.0",
+  "description": "Teaches Claude to use @rtorcato/js-tooling correctly: the setup/doctor/fix CLI, extending the shared config bases, and the release automation (never publish by hand).",
+  "author": {
+    "name": "Richard Torcato",
+    "email": "rtorcato@me.com",
+    "url": "https://github.com/rtorcato"
+  },
+  "homepage": "https://rtorcato.github.io/js-tooling/",
+  "repository": "https://github.com/rtorcato/js-tooling",
+  "license": "MIT",
+  "keywords": ["tooling", "typescript", "biome", "vitest", "semantic-release", "monorepo"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,29 @@ npx @rtorcato/js-tooling fix engines --yes --json
 - Tests live alongside source in `tests/`; vitest with no separate config
 - semantic-release runs on push to `main`; `fix:` → patch, `feat:` → minor, `chore:` / `docs:` → no release
 
+## Releasing — never publish by hand
+
+Releases are fully automated by semantic-release on merge to `main`. **You don't
+publish, commits do** — the version is derived from Conventional Commit messages:
+
+- `fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE:` → major
+- `chore:` / `docs:` / `refactor:` / `test:` / `ci:` → no release
+
+Never run `npm publish`, `npm version`, or `git tag`, and never hand-edit the
+`version` field — semantic-release owns it, and editing it causes drift and
+merge conflicts. Run `pnpm verify` before pushing; a red CI blocks the release.
+(This mirrors the `npm-publish` Claude skill in `skills/npm-publish/`.)
+
+## Claude Code plugin
+
+This repo self-hosts a Claude Code plugin with two skills (`js-tooling`,
+`npm-publish`). Install it:
+
+```
+/plugin marketplace add rtorcato/js-tooling
+/plugin install js-tooling@js-tooling
+```
+
 ## Pointers
 
 - Site index for LLMs: https://rtorcato.github.io/js-tooling/llms.txt

--- a/README.md
+++ b/README.md
@@ -110,7 +110,21 @@ drift warnings.
 
 ## AI agent rules
 
-The package ships rules that teach AI coding agents to drive the CLI
+**Use with Claude Code.** This repo self-hosts a Claude plugin with two skills —
+`js-tooling` (drive the CLI + adopt the config bases) and `npm-publish` (how
+releases work):
+
+```
+/plugin marketplace add rtorcato/js-tooling
+/plugin install js-tooling@js-tooling
+```
+
+**Use with other AI tools.** The same guidance lives in [`AGENTS.md`](AGENTS.md)
+(shipped in the npm tarball) — Cursor, Copilot, and Codex read it directly.
+
+### Generate rules for *your* project
+
+The package also ships rules that teach AI coding agents to drive the CLI
 (`doctor` / `fix` / `setup`) non-interactively. Install for your agent — all
 generated from one source, so guidance never drifts between them:
 

--- a/apps/docs/docs/index.md
+++ b/apps/docs/docs/index.md
@@ -36,6 +36,23 @@ npx @rtorcato/js-tooling setup
 - **Supply-chain security** — Dependabot for weekly dep updates and CodeQL for security scanning, scaffolded as opt-in workflows.
 - **CLI** — `setup` wizard for new projects, `doctor` drift checker, `fix` for incremental upgrades, and `copy` for individual files.
 
+## Use with AI
+
+**Claude Code.** This repo self-hosts a Claude plugin with two skills —
+`js-tooling` (drive the CLI + adopt the config bases) and `npm-publish` (how
+releases work):
+
+```
+/plugin marketplace add rtorcato/js-tooling
+/plugin install js-tooling@js-tooling
+```
+
+**Other AI tools (Cursor / Copilot / Codex).** The same guidance ships in
+[`AGENTS.md`](https://github.com/rtorcato/js-tooling/blob/main/AGENTS.md) inside
+the npm tarball — most agents read it directly. See the
+[For AI agents](./guides/for-ai-agents.md) guide for the non-interactive CLI
+contract.
+
 ## Next steps
 
 - [Get started](./guides/getting-started.mdx) — install and scaffold a project.

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
 		"tooling/claude/*.md",
 		"tooling/mcp/mcp.json.example",
 		"tooling/github-actions/workflows/*.yml",
-		"README.md"
+		"README.md",
+		"AGENTS.md"
 	],
 	"exports": {
 		"./commitlint/config": {

--- a/skills/js-tooling/SKILL.md
+++ b/skills/js-tooling/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: js-tooling
+description: Use when setting up, auditing, or standardizing a JavaScript/TypeScript project that uses @rtorcato/js-tooling — scaffolding via the setup wizard, auditing with doctor, applying fixers, or extending the shared TypeScript/Biome/Vitest/semantic-release config bases. Covers the agent-friendly `--json` / `--yes` CLI surface.
+---
+
+# Using @rtorcato/js-tooling
+
+`@rtorcato/js-tooling` is a one-package JavaScript/TypeScript tooling
+distribution: a `setup` / `doctor` / `fix` CLI plus shared config **bases**
+(TypeScript, Biome, ESLint, Prettier, Vitest, Jest, tsup/esbuild/rollup/vite,
+semantic-release, Changesets). Adopt the presets and drive the CLI — this is not
+a runtime import surface.
+
+## The CLI is agent-friendly
+
+Every command supports `--json` and a non-interactive mode. `fix --json` implies
+`--yes` (a prompt would corrupt JSON).
+
+```bash
+# Scaffold a new project (no prompts, no install)
+npx @rtorcato/js-tooling setup --preset library -d ./my-lib --skip-install
+
+# Audit an existing repo → structured findings
+npx @rtorcato/js-tooling doctor --json -d ./repo
+
+# Apply every fixable finding, then re-audit
+npx @rtorcato/js-tooling fix --yes --json -d ./repo
+npx @rtorcato/js-tooling doctor --json -d ./repo
+
+# One targeted fixer (targets come from `list --json`)
+npx @rtorcato/js-tooling fix dependabot --yes --json
+```
+
+Presets for `--preset`: `library`, `web-app`, `node-api`, `nextjs-app`,
+`react-app`. For full control, `setup --config-schema` prints the JSON Schema for
+`ProjectConfig`; write a config against it and pass `--config <path>`
+(`--dry-run` previews the resolved config + file list without writing).
+
+## Rules
+
+1. **Extend the shared bases; don't copy them.** In a consumer repo, reference
+   the published config rather than duplicating it, so a base upgrade flows
+   through:
+   ```jsonc
+   // tsconfig.json
+   { "extends": "@rtorcato/js-tooling/typescript/base" }
+   // biome.json
+   { "extends": ["@rtorcato/js-tooling/biome"] }
+   ```
+   Config subpaths mirror the `exports` map 1:1 — run `list --json` to enumerate
+   them.
+
+2. **Let `doctor` decide, `fix` repair.** Don't hand-edit generated config to
+   match the standard — run `doctor` to find drift and `fix <target>` to apply
+   it. Check names and fix targets are a stable contract (`list --json`).
+
+3. **Respect the drift policy.** `fix` defaults the confirm to **No** for drift
+   (an existing file that doesn't extend the preset); `--yes` is required to
+   overwrite. Safe-merge fixers (`engines`, `husky`, `package-json`) only
+   add/merge, never clobber.
+
+4. **Toolchain is fixed.** pnpm, Node ≥22, ESM-only (`"type": "module"`), Biome
+   for lint+format (not ESLint/Prettier by default). Run the gate with
+   `pnpm verify` (typecheck + biome + vitest) before pushing.
+
+5. **Releases are automated — see the `npm-publish` skill.** Never run
+   `npm publish`, `npm version`, or `git tag`, and never hand-edit the `version`
+   field. semantic-release owns it.
+
+## More
+
+- Human docs: https://rtorcato.github.io/js-tooling/
+- LLM index: https://rtorcato.github.io/js-tooling/llms.txt
+- Repo `AGENTS.md` carries the same guidance for non-Claude tools.

--- a/skills/npm-publish/SKILL.md
+++ b/skills/npm-publish/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: npm-publish
+description: >-
+  Use when releasing or publishing any @rtorcato/* package, cutting a version,
+  or writing commit messages intended to trigger a release. Releases are fully
+  automated via semantic-release + Conventional Commits — never run
+  `npm publish` or bump the version in package.json by hand.
+---
+
+# Publishing an @rtorcato/* package
+
+Every package in the family releases the same way: **you don't publish, commits
+do.** `semantic-release` runs in CI on merge to `main`, derives the next version
+from commit messages, updates the changelog, tags, creates a GitHub release, and
+publishes to npm (`publishConfig.access: "public"`).
+
+## The version comes from the commit message
+
+Conventional Commits are enforced by husky + commitlint, and they drive the
+version bump:
+
+- `fix: …` → patch (`1.2.0` → `1.2.1`)
+- `feat: …` → minor (`1.2.0` → `1.3.0`)
+- `feat!: …` or a `BREAKING CHANGE:` footer → major (`1.2.0` → `2.0.0`)
+- `chore:`, `docs:`, `refactor:`, `test:`, `ci:` → no release
+
+So the way to ship a change is to phrase the commit correctly, not to touch the
+version field. semantic-release owns `version` in package.json — editing it by
+hand causes drift and merge conflicts.
+
+## Before you push
+
+Run the family's gate locally; CI runs the same thing and a red build blocks the
+release:
+
+```bash
+pnpm verify   # typecheck + biome check + vitest run  (some repos also add treeshake)
+```
+
+Then commit with a conventional message and open the PR:
+
+```bash
+git commit -m "feat: add createKvStore batch get"
+```
+
+On merge to `main`, semantic-release does the rest. Don't run `npm version`,
+`npm publish`, or `git tag` manually — they fight the automation.
+
+## House conventions (consistent across the family)
+
+- Package manager: **pnpm**, Node **≥22**, ESM-only (`"type": "module"`).
+- Lint/format: **Biome** (`pnpm check` / `pnpm check:fix`), not ESLint/Prettier.
+- Build: **tsup** (or a `build.mjs` esbuild script) emitting `dist/` with `.d.ts`.
+- Public API is the `exports` map only — never add deep-import paths into `dist`.
+- New public surface ships with strict types + JSDoc and a matching update to the
+  co-located SKILL.md in the **same PR**.


### PR DESCRIPTION
Closes #162.

## What

A **self-hosted, in-repo AI skill** so AI tools use `@rtorcato/js-tooling` correctly — mirrors the browser-common pattern (`.claude-plugin/` + `skills/` at the repo root), no central marketplace repo to drift.

### Claude Code plugin (one plugin, two skills)
- `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json`
- `skills/js-tooling/SKILL.md` — drive the setup/doctor/fix CLI (`--json`/`--yes`), extend the shared config bases, drift policy, fixed toolchain
- `skills/npm-publish/SKILL.md` — releases are automated (semantic-release owns the version; never `npm publish`/`npm version`/`git tag`/hand-edit `version`)
- ✅ **`claude plugin validate .` passes**

Install:
```
/plugin marketplace add rtorcato/js-tooling
/plugin install js-tooling@js-tooling
```

### Other AI tools
- `AGENTS.md` added to package.json `files` so it ships in the npm tarball (tools scanning `node_modules` find it)
- Added a **Releasing** section to `AGENTS.md` mirroring the npm-publish skill, so the two stay in sync

### Docs
- README "AI agent rules" now leads with the plugin install + AGENTS.md (distinct from the existing consumer rule-generation)
- Docs homepage gets a "Use with AI" block (Claude + other tools)

## Verification

- `claude plugin validate .` → passes (added `version` to plugin.json to clear the one warning).
- `pnpm test` — 399 pass (content/manifest change, no code paths touched); typecheck + biome clean.

## Note
Kept `AGENTS.md` ↔ `SKILL.md` sync as a documented rule (in both AGENTS.md and the js-tooling skill): public-API changes update both in the same PR.