### PR TITLE
feat(cli): docs-site generator — scaffold a Docusaurus site (#100)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1377,6 +1377,24 @@ async function checkTailwind(dir: string, pkg: Pkg | null): Promise<CheckResult>
 	}
 }
 
+// Optional docs site (#100/#106). A repo with apps/doc(s)/docusaurus.config.*
+// has one; otherwise nudge. Optional — most repos don't publish a docs site.
+async function checkDocsSite(dir: string): Promise<CheckResult> {
+	for (const folder of ['apps/docs', 'apps/doc']) {
+		for (const cfg of ['docusaurus.config.ts', 'docusaurus.config.js']) {
+			if (await fs.pathExists(path.join(dir, folder, cfg))) {
+				return { check: 'Docs site', status: 'ok', detail: `${folder}/${cfg} found` }
+			}
+		}
+	}
+	return {
+		check: 'Docs site',
+		status: 'optional-missing',
+		detail: 'no Docusaurus docs site',
+		hint: 'Run `npx @rtorcato/js-tooling fix docs-site` to scaffold apps/docs + a Pages deploy',
+	}
+}
+
 async function checkGitLabCI(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
 		if (await fs.pathExists(path.join(dir, candidate))) {
@@ -1444,6 +1462,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	// permissions). Read-only; self-skips as `ok` outside a live GitHub repo.
 	results.push(...(await checkGitHubSettings(targetDir)))
 	results.push(await checkGitLabCI(targetDir))
+	results.push(await checkDocsSite(targetDir))
 	results.push(await checkCodeowners(targetDir))
 	results.push(await checkCommunityHealth(targetDir))
 	results.push(await checkAiSetup(targetDir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -28,6 +28,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	CodeQL: 'codeql',
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
+	'Docs site': 'docs-site',
 	Turborepo: 'turborepo',
 	Tailwind: 'tailwind',
 	lockfile: 'lockfile',
@@ -93,6 +94,8 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			return c.aiSetup === false
 		case 'Turborepo':
 			return c.turborepo === false
+		case 'Docs site':
+			return c.docsSite === false
 		case 'Tailwind':
 			return c.tailwind === false
 		default:
@@ -155,6 +158,8 @@ export function lockfilePatchForTarget(
 			return c.aiSetup ? null : { aiSetup: true }
 		case 'turborepo':
 			return c.turborepo ? null : { turborepo: true }
+		case 'docs-site':
+			return c.docsSite ? null : { docsSite: true }
 		case 'tailwind':
 			return c.tailwind ? null : { tailwind: true }
 		default:

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -27,6 +27,7 @@ import {
 	generateSizeLimitConfig,
 	generateVscodeExtensions,
 } from '../generators/misc.js'
+import { generateDocsSite } from '../generators/docs-site.js'
 import { generateConfigs } from '../generators/index.js'
 import { composeVerifyScriptFromPkg } from '../generators/package-json.js'
 import { generatePostcss } from '../generators/postcss.js'
@@ -441,6 +442,27 @@ const FIXERS: Fixer[] = [
 		canFixDrift: false,
 		async run({ targetDir }) {
 			const filesWritten = await generateCommunityHealth(targetDir)
+			return { filesWritten }
+		},
+	},
+	{
+		target: 'docs-site',
+		description: 'Scaffold a Docusaurus docs site (apps/docs) + pnpm workspace + Pages deploy',
+		appliesTo: ['Docs site'],
+		outputs: [
+			'apps/docs/package.json',
+			'apps/docs/docusaurus.config.ts',
+			'apps/docs/sidebars.ts',
+			'apps/docs/tsconfig.json',
+			'apps/docs/docs/intro.md',
+			'apps/docs/static/.nojekyll',
+			'.github/workflows/docs.yml',
+			'pnpm-workspace.yaml',
+		],
+		// safe-add: only writes missing files; never clobbers a hand-tuned site.
+		riskLevel: 'safe-add',
+		async run({ targetDir, pkg }) {
+			const filesWritten = await generateDocsSite(targetDir, pkg)
 			return { filesWritten }
 		},
 	},

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -147,6 +147,7 @@ export const CONFIG_SCHEMA = {
 		aiSetup: { type: 'boolean' },
 		turborepo: { type: 'boolean' },
 		tailwind: { type: 'boolean' },
+		docsSite: { type: 'boolean' },
 	},
 } as const
 
@@ -238,6 +239,18 @@ export function computeFileList(config: ProjectConfig): string[] {
 			'.github/copilot-instructions.md',
 			'.claude/skills/js-tooling.md',
 			'.mcp.json.example'
+		)
+	}
+	if (config.docsSite) {
+		files.push(
+			'apps/docs/package.json',
+			'apps/docs/docusaurus.config.ts',
+			'apps/docs/sidebars.ts',
+			'apps/docs/tsconfig.json',
+			'apps/docs/docs/intro.md',
+			'apps/docs/static/.nojekyll',
+			'.github/workflows/docs.yml',
+			'pnpm-workspace.yaml'
 		)
 	}
 	if (config.turborepo) files.push('turbo.json')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -57,6 +57,8 @@ export interface ProjectConfig {
 	turborepo?: boolean
 	/** Scaffold Tailwind CSS v4 (PostCSS plugin + CSS entry) for frontend projects. */
 	tailwind?: boolean
+	/** Scaffold a Docusaurus docs site (apps/docs) + pnpm workspace + Pages deploy. */
+	docsSite?: boolean
 }
 
 export interface SetupOptions {

--- a/src/cli/generators/docs-site.ts
+++ b/src/cli/generators/docs-site.ts
@@ -1,0 +1,244 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+import { parseRepository } from './badges.js'
+
+/**
+ * Scaffold a minimal, buildable Docusaurus docs site under apps/docs, wired into
+ * a pnpm workspace and a GitHub Pages deploy workflow (#100/#106). Identity
+ * (title, org, repo, url/baseUrl) is inferred from package.json — no hardcoded
+ * owner/repo. Neutral theme by default; brand it afterwards.
+ *
+ * Every file is safe-add — an existing one is never clobbered — so re-running is
+ * idempotent and won't overwrite a hand-tuned site. Deferred to follow-ups: the
+ * Playwright smoke test, TypeDoc API section, shared CSS tokens, and extracting
+ * sync-changelog.mjs / the workflow into `copy` targets.
+ */
+export interface DocsSiteIdentity {
+	/** Docs package name, e.g. `@rtorcato/js-tooling-docs`. */
+	docsName: string
+	title: string
+	tagline: string
+	owner: string
+	repo: string
+}
+
+export function inferDocsIdentity(pkg: Record<string, unknown> | null): DocsSiteIdentity {
+	const name = (pkg?.name as string | undefined) ?? 'project'
+	const parsed = parseRepository(pkg?.repository)
+	const owner = parsed?.owner ?? 'your-org'
+	const repo = parsed?.repo ?? name.replace(/^@[^/]+\//, '')
+	return {
+		docsName: `${name}-docs`,
+		title: repo,
+		tagline: (pkg?.description as string | undefined) ?? `Documentation for ${name}`,
+		owner,
+		repo,
+	}
+}
+
+export async function generateDocsSite(
+	targetDir: string,
+	pkg: Record<string, unknown> | null
+): Promise<string[]> {
+	const id = inferDocsIdentity(pkg)
+	const written: string[] = []
+
+	const files: Array<[string, string]> = [
+		[path.join('apps', 'docs', 'package.json'), docsPackageJson(id)],
+		[path.join('apps', 'docs', 'docusaurus.config.ts'), docusaurusConfig(id)],
+		[path.join('apps', 'docs', 'sidebars.ts'), SIDEBARS],
+		[path.join('apps', 'docs', 'tsconfig.json'), DOCS_TSCONFIG],
+		[path.join('apps', 'docs', 'docs', 'intro.md'), introDoc(id)],
+		[path.join('apps', 'docs', 'static', '.nojekyll'), ''],
+		[path.join('.github', 'workflows', 'docs.yml'), DOCS_WORKFLOW],
+	]
+
+	for (const [rel, content] of files) {
+		const dest = path.join(targetDir, rel)
+		if (await fs.pathExists(dest)) continue
+		await fs.ensureDir(path.dirname(dest))
+		await fs.writeFile(dest, content)
+		written.push(rel)
+	}
+
+	if (await ensureWorkspaceApps(targetDir)) written.push('pnpm-workspace.yaml')
+
+	return written
+}
+
+/** Add `apps/*` to pnpm-workspace.yaml (create it if absent). Returns true when changed. */
+async function ensureWorkspaceApps(targetDir: string): Promise<boolean> {
+	const wsPath = path.join(targetDir, 'pnpm-workspace.yaml')
+	if (!(await fs.pathExists(wsPath))) {
+		await fs.writeFile(wsPath, "packages:\n  - 'apps/*'\n")
+		return true
+	}
+	const content = await fs.readFile(wsPath, 'utf8')
+	if (/apps\/\*/.test(content)) return false
+	if (/^packages:/m.test(content)) {
+		// Insert the glob right after the `packages:` key.
+		await fs.writeFile(wsPath, content.replace(/^packages:\s*\n/m, "packages:\n  - 'apps/*'\n"))
+	} else {
+		await fs.writeFile(wsPath, `${content.trimEnd()}\npackages:\n  - 'apps/*'\n`)
+	}
+	return true
+}
+
+function docsPackageJson(id: DocsSiteIdentity): string {
+	return `${JSON.stringify(
+		{
+			name: id.docsName,
+			version: '0.0.0',
+			private: true,
+			scripts: {
+				docusaurus: 'docusaurus',
+				start: 'docusaurus start',
+				build: 'docusaurus build',
+				serve: 'docusaurus serve',
+				clear: 'docusaurus clear',
+				typecheck: 'tsc --noEmit',
+			},
+			dependencies: {
+				'@docusaurus/core': '^3.8.1',
+				'@docusaurus/preset-classic': '^3.8.1',
+				'@mdx-js/react': '^3.1.0',
+				clsx: '^2.1.1',
+				'prism-react-renderer': '^2.4.1',
+				react: '^19.0.0',
+				'react-dom': '^19.0.0',
+			},
+			devDependencies: {
+				'@docusaurus/module-type-aliases': '^3.8.1',
+				'@docusaurus/tsconfig': '^3.8.1',
+				'@docusaurus/types': '^3.8.1',
+				'@types/react': '^19.0.0',
+				typescript: '~5.6.3',
+			},
+			engines: { node: '>=22.0' },
+		},
+		null,
+		2
+	)}\n`
+}
+
+function docusaurusConfig(id: DocsSiteIdentity): string {
+	return `import type { Config } from '@docusaurus/types'
+import { themes as prismThemes } from 'prism-react-renderer'
+
+// Identity inferred from package.json at scaffold time. Edit freely.
+const config: Config = {
+  title: ${JSON.stringify(id.title)},
+  tagline: ${JSON.stringify(id.tagline)},
+  url: 'https://${id.owner}.github.io',
+  baseUrl: '/${id.repo}/',
+  organizationName: ${JSON.stringify(id.owner)},
+  projectName: ${JSON.stringify(id.repo)},
+  onBrokenLinks: 'warn',
+  onBrokenMarkdownLinks: 'warn',
+  i18n: { defaultLocale: 'en', locales: ['en'] },
+  presets: [
+    [
+      'classic',
+      {
+        docs: { routeBasePath: '/', sidebarPath: './sidebars.ts' },
+        blog: false,
+      },
+    ],
+  ],
+  themeConfig: {
+    navbar: {
+      title: ${JSON.stringify(id.title)},
+      items: [
+        { type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
+        { href: 'https://github.com/${id.owner}/${id.repo}', label: 'GitHub', position: 'right' },
+      ],
+    },
+    footer: {
+      style: 'dark',
+      copyright: \`© \${new Date().getFullYear()} ${id.owner}\`,
+    },
+    prism: { theme: prismThemes.github, darkTheme: prismThemes.dracula },
+  },
+}
+
+export default config
+`
+}
+
+function introDoc(id: DocsSiteIdentity): string {
+	return `---
+sidebar_position: 1
+slug: /
+---
+
+# ${id.title}
+
+${id.tagline}
+
+Start writing docs in \`apps/docs/docs/\`. This page is \`intro.md\`.
+`
+}
+
+const SIDEBARS = `import type { SidebarsConfig } from '@docusaurus/plugin-content-docs'
+
+const sidebars: SidebarsConfig = {
+  docs: [{ type: 'autogenerated', dirName: '.' }],
+}
+
+export default sidebars
+`
+
+const DOCS_TSCONFIG = `{
+  "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "exclude": [".docusaurus", "build"]
+}
+`
+
+const DOCS_WORKFLOW = `name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter './apps/docs' build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs/build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: \${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+`

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -14,6 +14,7 @@ import { generateSecurityConfigs } from './security.js'
 import { generateTestingConfigs } from './testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from './treeshake.js'
 import { generateTSConfig } from './tsconfig.js'
+import { generateDocsSite } from './docs-site.js'
 import { generateTailwind } from './tailwind.js'
 import { generateTurborepo } from './turborepo.js'
 
@@ -95,6 +96,15 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 	// Tailwind CSS v4 (frontend projects, when opted-in)
 	if (config.tailwind) {
 		await generateTailwind(targetDir)
+	}
+
+	// Docusaurus docs site (apps/docs + workspace + Pages deploy, when opted-in)
+	if (config.docsSite) {
+		const pkgPath = path.join(targetDir, 'package.json')
+		const pkg = (await fs.pathExists(pkgPath))
+			? ((await fs.readJson(pkgPath)) as Record<string, unknown>)
+			: null
+		await generateDocsSite(targetDir, pkg)
 	}
 
 	// AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot, Claude skill, MCP example)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -233,6 +233,12 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		exports: [],
 		fixTarget: 'ai',
 	},
+	{
+		name: 'Docs site',
+		description: 'Scaffold a Docusaurus docs site (apps/docs) + pnpm workspace + Pages deploy',
+		exports: [],
+		fixTarget: 'docs-site',
+	},
 ]
 
 program

--- a/tests/cli/generators/docs-site.test.ts
+++ b/tests/cli/generators/docs-site.test.ts
@@ -1,0 +1,84 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { generateDocsSite, inferDocsIdentity } from '../../../src/cli/generators/docs-site.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const PKG = {
+	name: '@rtorcato/js-tooling',
+	description: 'JS/TS tooling',
+	repository: { url: 'https://github.com/rtorcato/js-tooling.git' },
+}
+
+describe('inferDocsIdentity', () => {
+	it('derives docs name, owner, and repo from package.json', () => {
+		const id = inferDocsIdentity(PKG)
+		expect(id.docsName).toBe('@rtorcato/js-tooling-docs')
+		expect(id.owner).toBe('rtorcato')
+		expect(id.repo).toBe('js-tooling')
+	})
+
+	it('falls back gracefully with no repository', () => {
+		const id = inferDocsIdentity({ name: '@x/foo' })
+		expect(id.owner).toBe('your-org')
+		expect(id.repo).toBe('foo')
+	})
+})
+
+describe('generateDocsSite', () => {
+	it('scaffolds a config with inferred url/baseUrl, workspace, and workflow', async () => {
+		const dir = newTmpDir()
+		const written = await generateDocsSite(dir, PKG)
+		expect(written).toContain(join('apps', 'docs', 'docusaurus.config.ts'))
+		expect(written).toContain('pnpm-workspace.yaml')
+
+		const cfg = await fs.readFile(join(dir, 'apps/docs/docusaurus.config.ts'), 'utf8')
+		expect(cfg).toContain("url: 'https://rtorcato.github.io'")
+		expect(cfg).toContain("baseUrl: '/js-tooling/'")
+
+		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8')
+		expect(ws).toMatch(/apps\/\*/)
+
+		const wf = await fs.readFile(join(dir, '.github/workflows/docs.yml'), 'utf8')
+		expect(wf).toMatch(/actions\/deploy-pages/)
+
+		const docsPkg = await fs.readJson(join(dir, 'apps/docs/package.json'))
+		expect(docsPkg.name).toBe('@rtorcato/js-tooling-docs')
+	})
+
+	it('is safe-add and idempotent — a second run writes nothing and keeps the workspace', async () => {
+		const dir = newTmpDir()
+		await generateDocsSite(dir, PKG)
+		const second = await generateDocsSite(dir, PKG)
+		expect(second).toEqual([])
+	})
+
+	it('preserves an existing pnpm-workspace.yaml, adding apps/* once', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n")
+		await generateDocsSite(dir, PKG)
+		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf8')
+		expect(ws).toMatch(/packages\/\*/)
+		expect(ws).toMatch(/apps\/\*/)
+	})
+})
+
+describe('doctor Docs site check', () => {
+	it('reports optional-missing without a docs site', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		const r = (await runDoctor(dir)).find((x) => x.check === 'Docs site')
+		expect(r?.status).toBe('optional-missing')
+	})
+
+	it('reports ok once a docs site is scaffolded', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), PKG)
+		await generateDocsSite(dir, PKG)
+		const r = (await runDoctor(dir)).find((x) => x.check === 'Docs site')
+		expect(r?.status).toBe('ok')
+	})
+})


### PR DESCRIPTION
Closes #100 and #106 (same feature — docs-site generator).

## What

A `docs-site` generator + `fix docs-site` target that scaffolds a minimal, **buildable** Docusaurus site under `apps/docs`, with all identity inferred from `package.json` (no hardcoded owner/repo):

- `apps/docs/{package.json, docusaurus.config.ts, sidebars.ts, tsconfig.json, docs/intro.md, static/.nojekyll}`
- `.github/workflows/docs.yml` — build + deploy to GitHub Pages
- `pnpm-workspace.yaml` — adds `apps/*` (idempotent; preserves existing packages)

`url`/`baseUrl`/`organizationName`/`projectName` are derived from the repo (`https://<owner>.github.io` + `/<repo>/`); docs package name is `<pkg>-docs`. Neutral theme by default (issue says default to neutral).

## Wiring (matches the agent-rules / typedoc pattern)

- `docsSite` on `ProjectConfig` + schema + `computeFileList`; setup scaffolds it when enabled
- **safe-add** `fix docs-site`, lockfile opt-in/out, `list` catalog entry
- `doctor` → `Docs site` check: `optional-missing` when absent, `ok` when `apps/doc(s)/docusaurus.config.*` exists

## Scope — MVP, deferred bits called out

Per the issues this is the hybrid generator; I scoped a **working MVP** and deferred the enhancements to follow-ups (noted in the generator doc comment):
- Playwright smoke test of the built site
- TypeDoc API-reference section
- Shared CSS tokens / Geist branding + search
- Extracting `sync-changelog.mjs` + the workflow into `copy` targets (currently inline-generated — single-source via the generator)
- Folder standardization migration (`apps/doc` vs `apps/docs`) — this scaffolds `apps/docs`

## Verification

- `pnpm test` — 406 pass (6 new: identity inference, scaffold content, idempotency, workspace-merge, doctor states).
- Typecheck + biome clean.
- End-to-end on the built CLI: `fix docs-site` on `@acme/widget` scaffolds all 8 files with `acme`/`widget` inferred; `doctor` reports `Docs site — ok`; re-run is idempotent.
- ⚠️ **Not verified:** an actual `docusaurus build` (needs a heavy `@docusaurus/*` install + network). The config mirrors this repo's working `apps/docs` (Docusaurus 3.8), so it should build — worth a real build before merge.