### PR TITLE
feat(fix): github-settings target — apply branch protection + merge + workflow permissions via gh api

### DIFF
--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -26,6 +26,9 @@ export const FIX_TARGETS: Record<string, string> = {
 	'Coverage upload': 'github-actions',
 	Dependabot: 'dependabot',
 	CodeQL: 'codeql',
+	'Branch protection': 'github-settings',
+	'Merge settings': 'github-settings',
+	'Workflow permissions': 'github-settings',
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
 	Turborepo: 'turborepo',
@@ -142,6 +145,7 @@ export function lockfilePatchForTarget(
 		case 'dependabot':
 		case 'renovate':
 		case 'codeql':
+		case 'github-settings':
 			return c.securityAutomation ? null : { securityAutomation: true }
 		case 'tsconfig':
 			return c.typescript.enabled ? null : { typescript: { enabled: true, config: 'base' } }

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -41,6 +41,7 @@ import { generateTailwind } from '../generators/tailwind.js'
 import { generateTurborepo } from '../generators/turborepo.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../generators/typedoc.js'
 import { copyPreset } from '../utils/copy-preset.js'
+import { applyGithubSettings } from '../utils/github-settings.js'
 import {
 	type Lockfile,
 	LOCKFILE_NAME,
@@ -412,6 +413,21 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			await generateCodeQLWorkflow(targetDir)
 			return { filesWritten: ['.github/workflows/codeql.yml'] }
+		},
+	},
+	{
+		target: 'github-settings',
+		description:
+			'Apply branch protection + auto-merge + workflow permissions on GitHub via gh api (mutates the remote repo, not files)',
+		appliesTo: ['Branch protection', 'Merge settings', 'Workflow permissions'],
+		outputs: ['GitHub repo settings (remote, via gh api)'],
+		// safe-add is load-bearing: it exempts this fixer from the `--diff` shadow-run
+		// (previewFixer copies to tmp and *executes* run(), which would fire real
+		// `gh api` PUTs during a mere preview).
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await applyGithubSettings(targetDir) }
 		},
 	},
 	{

--- a/src/cli/utils/github-settings.ts
+++ b/src/cli/utils/github-settings.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import path from 'node:path'
+import chalk from 'chalk'
 import fs from 'fs-extra'
 import type { CheckResult } from '../commands/doctor.js'
 
@@ -20,12 +21,13 @@ export interface GhResult {
 	code: number | null
 }
 
-export type GhExec = (args: string[]) => Promise<GhResult>
+/** `stdin`, when given, is written to gh's stdin (for `--input -` bodies). */
+export type GhExec = (args: string[], stdin?: string) => Promise<GhResult>
 
 const GH_TIMEOUT_MS = 10_000
 
 /** Real `gh` runner — never rejects; a missing/failing gh resolves ok:false. */
-export const realGhExec: GhExec = (args) =>
+export const realGhExec: GhExec = (args, stdin) =>
 	new Promise((resolve) => {
 		let settled = false
 		const done = (r: GhResult) => {
@@ -36,21 +38,27 @@ export const realGhExec: GhExec = (args) =>
 		}
 		// gh args are internal/derived from gh itself (never user free-text), so
 		// shell:false + an args array keeps this injection-safe.
-		const child = spawn('gh', args, { stdio: ['ignore', 'pipe', 'pipe'] })
+		const child = spawn('gh', args, {
+			stdio: [stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+		})
 		let stdout = ''
 		let stderr = ''
 		const timer = setTimeout(() => {
 			child.kill()
 			done({ ok: false, stdout: '', stderr: 'gh timed out', code: null })
 		}, GH_TIMEOUT_MS)
-		child.stdout.on('data', (d) => {
+		child.stdout?.on('data', (d) => {
 			stdout += d
 		})
-		child.stderr.on('data', (d) => {
+		child.stderr?.on('data', (d) => {
 			stderr += d
 		})
 		child.on('close', (code) => done({ ok: code === 0, stdout, stderr, code }))
 		child.on('error', (err) => done({ ok: false, stdout: '', stderr: String(err), code: null }))
+		if (stdin !== undefined && child.stdin) {
+			child.stdin.write(stdin)
+			child.stdin.end()
+		}
 	})
 
 /** The standard doctor checks these settings against. */
@@ -211,4 +219,146 @@ async function checkWorkflowPermissions(exec: GhExec, nwo: string): Promise<Chec
 			hint: 'Set default workflow permissions to read-only and disable workflow PR approvals',
 		}
 	return { check, status: 'ok', detail: 'read-only default, no workflow PR approvals' }
+}
+
+// --- Fixer side (#138): apply the standard via gh api ---------------------
+
+/** Which of the three settings deviate from the standard and so need applying. */
+export interface GhApplyState {
+	nwo: string
+	branch: string
+	merge: boolean
+	protection: boolean
+	workflow: boolean
+}
+
+/** A single `gh api` mutation plus the human label reported once it succeeds. */
+export interface GhCommand {
+	label: string
+	args: string[]
+	/** JSON body piped to gh stdin (branch protection uses `--input -`). */
+	stdin?: string
+}
+
+/** The branch-protection body PUT to the API — mirrors the doctor standard. */
+const PROTECTION_BODY = JSON.stringify({
+	required_status_checks: { strict: false, contexts: GITHUB_STANDARD.requiredContexts },
+	// enforce_admins off so the App/RELEASE_TOKEN can bypass to push release commits.
+	enforce_admins: false,
+	// Required human review would deadlock solo Dependabot auto-merge.
+	required_pull_request_reviews: null,
+	restrictions: null,
+	allow_force_pushes: false,
+	allow_deletions: false,
+})
+
+/** Pure: the exact `gh api` invocations for whatever deviates ([] when compliant). */
+export function buildGhApplyCommands(state: GhApplyState): GhCommand[] {
+	const commands: GhCommand[] = []
+	if (state.merge)
+		commands.push({
+			label: 'merge settings (auto-merge, squash, delete-on-merge)',
+			args: [
+				'api',
+				'-X',
+				'PATCH',
+				`repos/${state.nwo}`,
+				'-F',
+				'allow_auto_merge=true',
+				'-F',
+				'allow_squash_merge=true',
+				'-F',
+				'delete_branch_on_merge=true',
+			],
+		})
+	if (state.protection)
+		commands.push({
+			label: `branch protection on ${state.branch}`,
+			args: [
+				'api',
+				'-X',
+				'PUT',
+				`repos/${state.nwo}/branches/${state.branch}/protection`,
+				'--input',
+				'-',
+			],
+			stdin: PROTECTION_BODY,
+		})
+	if (state.workflow)
+		commands.push({
+			label: 'workflow permissions (read-only)',
+			args: [
+				'api',
+				'-X',
+				'PUT',
+				`repos/${state.nwo}/actions/permissions/workflow`,
+				'-f',
+				'default_workflow_permissions=read',
+				'-F',
+				'can_approve_pull_request_reviews=false',
+			],
+		})
+	return commands
+}
+
+/**
+ * Re-reads GitHub state and applies only the deltas via `gh api` (idempotent —
+ * a compliant repo is a no-op). Returns human labels for what changed, or `[]`
+ * on skip (no gh/auth/remote, or already compliant), logging the reason. Mirrors
+ * the "no package.json found — skipping" fixer pattern. Read-only unless a delta
+ * exists, so re-runs (walk-all hits it up to 3×) are safe.
+ */
+export async function applyGithubSettings(
+	dir: string,
+	exec: GhExec = realGhExec
+): Promise<string[]> {
+	if (!(await fs.pathExists(path.join(dir, '.git')))) {
+		console.log(chalk.gray('   skipped — not a git repository'))
+		return []
+	}
+	const probe = await exec([
+		'repo',
+		'view',
+		'--json',
+		'nameWithOwner,defaultBranchRef,autoMergeAllowed,squashMergeAllowed,deleteBranchOnMerge',
+	])
+	if (!probe.ok) {
+		console.log(chalk.gray(`   skipped — ${probeFailureReason(probe)}`))
+		return []
+	}
+	let meta: RepoProbe
+	try {
+		meta = JSON.parse(probe.stdout) as RepoProbe
+	} catch {
+		console.log(chalk.gray('   skipped — could not parse gh output'))
+		return []
+	}
+	const nwo = meta.nameWithOwner
+	if (!nwo) {
+		console.log(chalk.gray('   skipped — no GitHub remote'))
+		return []
+	}
+	const branch = meta.defaultBranchRef?.name ?? 'main'
+
+	// Re-read via the same checks so the delta logic stays single-sourced. A 403
+	// (no admin) reports `ok` → treated as "nothing to apply", never a failed PUT.
+	const bp = await checkBranchProtection(exec, nwo, branch)
+	const wp = await checkWorkflowPermissions(exec, nwo)
+	const commands = buildGhApplyCommands({
+		nwo,
+		branch,
+		merge: checkMergeSettings(meta).status === 'drift',
+		protection: bp.status === 'optional-missing' || bp.status === 'drift',
+		workflow: wp.status === 'drift',
+	})
+
+	const applied: string[] = []
+	for (const cmd of commands) {
+		const r = await exec(cmd.args, cmd.stdin)
+		if (r.ok) applied.push(cmd.label)
+		else
+			console.log(chalk.yellow(`   could not apply ${cmd.label}: ${r.stderr.trim() || 'gh error'}`))
+	}
+	if (applied.length === 0) console.log(chalk.gray('   already configured — nothing to apply'))
+	return applied
 }

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -59,6 +59,17 @@ describe('fix registry', () => {
 			expect(typeof f.canFixDrift).toBe('boolean')
 		}
 	})
+
+	it('registers github-settings as a safe-add fixer (exempt from the diff shadow-run)', () => {
+		const fixer = getFixers().find((f) => f.target === 'github-settings')
+		expect(fixer).toBeTruthy()
+		expect(fixer?.riskLevel).toBe('safe-add')
+		expect(fixer?.appliesTo).toEqual([
+			'Branch protection',
+			'Merge settings',
+			'Workflow permissions',
+		])
+	})
 })
 
 describe('fix --list', () => {
@@ -652,6 +663,20 @@ describe('fix --json', () => {
 		} finally {
 			logSpy.mockRestore()
 			exitSpy.mockRestore()
+		}
+	})
+
+	it('fix github-settings --json --dry-run on a non-git dir mutates nothing', async () => {
+		const dir = newTmpDir()
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await fixCommand('github-settings', { directory: dir, json: true, dryRun: true })
+			// No .git → the checks skip to ok, so nothing is written or spawned.
+			expect(fs.readdirSync(dir)).toEqual([])
+			const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+			expect(payload.target).toBe('github-settings')
+		} finally {
+			logSpy.mockRestore()
 		}
 	})
 

--- a/tests/cli/utils/github-settings.test.ts
+++ b/tests/cli/utils/github-settings.test.ts
@@ -1,7 +1,13 @@
 import { join } from 'node:path'
 import fs from 'fs-extra'
-import { describe, expect, it, vi } from 'vitest'
-import { checkGitHubSettings, type GhExec, type GhResult } from '../../../src/cli/utils/github-settings.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	applyGithubSettings,
+	buildGhApplyCommands,
+	checkGitHubSettings,
+	type GhExec,
+	type GhResult,
+} from '../../../src/cli/utils/github-settings.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -141,5 +147,128 @@ describe('checkGitHubSettings — drift', () => {
 		const wp = byName(await checkGitHubSettings(gitRepo(), fakeGh({ workflow })), 'Workflow permissions')
 		expect(wp?.status).toBe('drift')
 		expect(wp?.detail).toContain('write')
+	})
+})
+
+describe('buildGhApplyCommands', () => {
+	const state = { nwo: 'owner/repo', branch: 'main' }
+
+	it('returns the exact PATCH/PUT/PUT invocations for a fully-drifted repo', () => {
+		const cmds = buildGhApplyCommands({ ...state, merge: true, protection: true, workflow: true })
+		expect(cmds.map((c) => c.args)).toEqual([
+			[
+				'api',
+				'-X',
+				'PATCH',
+				'repos/owner/repo',
+				'-F',
+				'allow_auto_merge=true',
+				'-F',
+				'allow_squash_merge=true',
+				'-F',
+				'delete_branch_on_merge=true',
+			],
+			['api', '-X', 'PUT', 'repos/owner/repo/branches/main/protection', '--input', '-'],
+			[
+				'api',
+				'-X',
+				'PUT',
+				'repos/owner/repo/actions/permissions/workflow',
+				'-f',
+				'default_workflow_permissions=read',
+				'-F',
+				'can_approve_pull_request_reviews=false',
+			],
+		])
+		// The protection PUT carries the standard body on stdin.
+		const body = JSON.parse(cmds[1]?.stdin ?? '{}')
+		expect(body.required_status_checks).toEqual({
+			strict: false,
+			contexts: ['lint', 'typecheck', 'build', 'test'],
+		})
+		expect(body.enforce_admins).toBe(false)
+		expect(body.required_pull_request_reviews).toBeNull()
+	})
+
+	it('returns [] when nothing deviates', () => {
+		expect(
+			buildGhApplyCommands({ ...state, merge: false, protection: false, workflow: false })
+		).toEqual([])
+	})
+})
+
+describe('applyGithubSettings', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {})
+	})
+
+	/** Records every gh call; canned responses drive which deltas fire. */
+	function recordingGh(
+		overrides: { probe?: GhResult; protection?: GhResult; workflow?: GhResult } = {}
+	) {
+		const calls: { args: string[]; stdin?: string }[] = []
+		const exec: GhExec = vi.fn(async (args: string[], stdin?: string) => {
+			calls.push({ args, stdin })
+			if (args[0] === 'repo') return overrides.probe ?? ok(COMPLIANT_PROBE)
+			if (args.includes('--input')) return ok('') // protection PUT
+			if (args[1]?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
+			if (args[1]?.includes('/actions/permissions/workflow'))
+				return overrides.workflow ?? ok(COMPLIANT_WORKFLOW)
+			if (args.includes('PATCH')) return ok('') // merge PATCH
+			return ok('')
+		})
+		return { exec, calls }
+	}
+
+	it('never spawns gh outside a git repo', async () => {
+		const { exec } = recordingGh()
+		expect(await applyGithubSettings(newTmpDir(), exec)).toEqual([])
+		expect(exec).not.toHaveBeenCalled()
+	})
+
+	it('applies all three deltas and returns their labels, in order', async () => {
+		const driftedProbe = ok(
+			JSON.stringify({
+				nameWithOwner: 'owner/repo',
+				defaultBranchRef: { name: 'main' },
+				autoMergeAllowed: false,
+				squashMergeAllowed: false,
+				deleteBranchOnMerge: false,
+			})
+		)
+		const { exec, calls } = recordingGh({
+			probe: driftedProbe,
+			protection: fail('gh: Not Found (HTTP 404)'),
+			workflow: ok(
+				JSON.stringify({
+					default_workflow_permissions: 'write',
+					can_approve_pull_request_reviews: false,
+				})
+			),
+		})
+		const labels = await applyGithubSettings(gitRepo(), exec)
+		expect(labels).toEqual([
+			'merge settings (auto-merge, squash, delete-on-merge)',
+			'branch protection on main',
+			'workflow permissions (read-only)',
+		])
+		// The three mutating calls fire after the read probes, PATCH before the PUTs.
+		const mutations = calls.filter(
+			(c) => c.args.includes('PATCH') || c.args.includes('PUT')
+		)
+		expect(mutations.map((c) => c.args[2])).toEqual(['PATCH', 'PUT', 'PUT'])
+		const protectionPut = mutations.find((c) => c.args.includes('--input'))
+		expect(protectionPut?.stdin).toContain('required_status_checks')
+	})
+
+	it('is a no-op on a compliant repo', async () => {
+		const { exec } = recordingGh()
+		expect(await applyGithubSettings(gitRepo(), exec)).toEqual([])
+	})
+
+	it('skips (no mutation) when the probe fails', async () => {
+		const { exec, calls } = recordingGh({ probe: fail('gh auth login required') })
+		expect(await applyGithubSettings(gitRepo(), exec)).toEqual([])
+		expect(calls.every((c) => !c.args.includes('PUT') && !c.args.includes('PATCH'))).toBe(true)
 	})
 })


### PR DESCRIPTION
## What

Follow-up to #137 (read-only doctor checks). Adds the **applying** side so `fix github-settings` actually enforces the standard on the remote, gated by the existing confirm/`--yes` flow.

### `src/cli/utils/github-settings.ts`
- `GhExec` gains an optional `stdin` param; `realGhExec` pipes it (for the branch-protection `--input -` body).
- **`buildGhApplyCommands(state)`** — pure; returns the exact `gh api` invocations for whatever deviates (PATCH merge settings, PUT protection w/ standard JSON on stdin, PUT workflow permissions), `[]` when compliant.
- **`applyGithubSettings(dir, exec)`** — `.git` gate → probe → re-reads state via the existing check helpers (delta logic stays single-sourced), applies only the deltas, returns human labels. Logs the reason and returns `[]` on skip. Idempotent, so walk-all's up-to-3× hits are no-ops.

### `src/cli/commands/fix.ts`
- One `FIXERS` entry, `riskLevel: 'safe-add'` — **load-bearing**: exempts the fixer from the `--diff` shadow-run (`previewFixer` executes `run()` in a tmp copy, which would fire real `gh api` PUTs during a preview).

### `src/cli/commands/fix-targets.ts`
- Maps the 3 check names → `github-settings` in `FIX_TARGETS` so `doctor` emits the `fix github-settings` next-step (deferred from #137 until the fixer existed).
- Adds `github-settings` to the `securityAutomation` lockfile-resync group.

## Tests
- `github-settings.test.ts`: `buildGhApplyCommands` fully-drifted → exact 3 arg arrays + stdin body; compliant → `[]`. `applyGithubSettings` with a recording fake exec → PATCH→PUT→PUT order + labels; skip paths; no-op on compliant repo.
- `fix.test.ts`: registry includes `github-settings` (safe-add); `fix github-settings --json --dry-run` on a non-git dir mutates nothing.

Full suite: **407 pass**, typecheck + biome clean.

## Manual E2E (no CI coverage, deliberate)
Not yet run — needs a scratch GitHub repo.

Closes #138