### PR TITLE
fix(doctor): read GitHub merge settings via REST, not gh repo view

### DIFF
--- a/src/cli/utils/github-settings.ts
+++ b/src/cli/utils/github-settings.ts
@@ -78,12 +78,41 @@ function skip(check: string, reason: string): CheckResult {
 	return { check, status: 'ok', detail: `skipped — ${reason}` }
 }
 
-interface RepoProbe {
-	nameWithOwner?: string
-	defaultBranchRef?: { name?: string } | null
-	autoMergeAllowed?: boolean
-	squashMergeAllowed?: boolean
-	deleteBranchOnMerge?: boolean
+interface RepoInfo {
+	nwo: string
+	branch: string
+	autoMerge: boolean
+	squashMerge: boolean
+	deleteOnMerge: boolean
+}
+
+/**
+ * One combined probe: proves gh is installed + authed + has a GitHub remote +
+ * online, and carries identity, default branch, and the merge settings. Reads
+ * the REST repo endpoint (gh resolves the `{owner}/{repo}` placeholder from the
+ * remote) rather than `gh repo view --json` because auto-merge (`allow_auto_merge`)
+ * is not a `gh repo view` field at all — requesting it fails the whole call.
+ */
+async function probeRepo(exec: GhExec): Promise<{ info: RepoInfo } | { skip: string }> {
+	const r = await exec(['api', 'repos/{owner}/{repo}'])
+	if (!r.ok) return { skip: probeFailureReason(r) }
+	let d: Record<string, any>
+	try {
+		d = JSON.parse(r.stdout)
+	} catch {
+		return { skip: 'could not parse gh output' }
+	}
+	const nwo = typeof d.full_name === 'string' ? d.full_name : undefined
+	if (!nwo) return { skip: 'no GitHub remote' }
+	return {
+		info: {
+			nwo,
+			branch: typeof d.default_branch === 'string' ? d.default_branch : 'main',
+			autoMerge: d.allow_auto_merge === true,
+			squashMerge: d.allow_squash_merge === true,
+			deleteOnMerge: d.delete_branch_on_merge === true,
+		},
+	}
 }
 
 export async function checkGitHubSettings(
@@ -93,30 +122,13 @@ export async function checkGitHubSettings(
 	// Cheap gate first: no .git → never spawn (keeps tmp-dir doctor runs offline).
 	if (!(await fs.pathExists(path.join(dir, '.git')))) return skipAll('not a git repository')
 
-	// One combined probe: proves gh is installed + authed + has a GitHub remote
-	// + online, and carries the merge settings in the same call.
-	const probe = await exec([
-		'repo',
-		'view',
-		'--json',
-		'nameWithOwner,defaultBranchRef,autoMergeAllowed,squashMergeAllowed,deleteBranchOnMerge',
-	])
-	if (!probe.ok) return skipAll(probeFailureReason(probe))
-
-	let meta: RepoProbe
-	try {
-		meta = JSON.parse(probe.stdout) as RepoProbe
-	} catch {
-		return skipAll('could not parse gh output')
-	}
-	const nwo = meta.nameWithOwner
-	if (!nwo) return skipAll('no GitHub remote')
-	const branch = meta.defaultBranchRef?.name ?? 'main'
-
+	const probe = await probeRepo(exec)
+	if ('skip' in probe) return skipAll(probe.skip)
+	const { info } = probe
 	return [
-		await checkBranchProtection(exec, nwo, branch),
-		checkMergeSettings(meta),
-		await checkWorkflowPermissions(exec, nwo),
+		await checkBranchProtection(exec, info.nwo, info.branch),
+		checkMergeSettings(info),
+		await checkWorkflowPermissions(exec, info.nwo),
 	]
 }
 
@@ -177,12 +189,12 @@ async function checkBranchProtection(
 	return { check, status: 'ok', detail: `${branch} protected per standard` }
 }
 
-function checkMergeSettings(meta: RepoProbe): CheckResult {
+function checkMergeSettings(info: RepoInfo): CheckResult {
 	const check = 'Merge settings'
 	const deltas: string[] = []
-	if (!meta.autoMergeAllowed) deltas.push('auto-merge disabled')
-	if (!meta.squashMergeAllowed) deltas.push('squash-merge disabled')
-	if (!meta.deleteBranchOnMerge) deltas.push('delete-branch-on-merge disabled')
+	if (!info.autoMerge) deltas.push('auto-merge disabled')
+	if (!info.squashMerge) deltas.push('squash-merge disabled')
+	if (!info.deleteOnMerge) deltas.push('delete-branch-on-merge disabled')
 	if (deltas.length)
 		return {
 			check,
@@ -316,38 +328,21 @@ export async function applyGithubSettings(
 		console.log(chalk.gray('   skipped — not a git repository'))
 		return []
 	}
-	const probe = await exec([
-		'repo',
-		'view',
-		'--json',
-		'nameWithOwner,defaultBranchRef,autoMergeAllowed,squashMergeAllowed,deleteBranchOnMerge',
-	])
-	if (!probe.ok) {
-		console.log(chalk.gray(`   skipped — ${probeFailureReason(probe)}`))
+	const probe = await probeRepo(exec)
+	if ('skip' in probe) {
+		console.log(chalk.gray(`   skipped — ${probe.skip}`))
 		return []
 	}
-	let meta: RepoProbe
-	try {
-		meta = JSON.parse(probe.stdout) as RepoProbe
-	} catch {
-		console.log(chalk.gray('   skipped — could not parse gh output'))
-		return []
-	}
-	const nwo = meta.nameWithOwner
-	if (!nwo) {
-		console.log(chalk.gray('   skipped — no GitHub remote'))
-		return []
-	}
-	const branch = meta.defaultBranchRef?.name ?? 'main'
+	const { info } = probe
 
 	// Re-read via the same checks so the delta logic stays single-sourced. A 403
 	// (no admin) reports `ok` → treated as "nothing to apply", never a failed PUT.
-	const bp = await checkBranchProtection(exec, nwo, branch)
-	const wp = await checkWorkflowPermissions(exec, nwo)
+	const bp = await checkBranchProtection(exec, info.nwo, info.branch)
+	const wp = await checkWorkflowPermissions(exec, info.nwo)
 	const commands = buildGhApplyCommands({
-		nwo,
-		branch,
-		merge: checkMergeSettings(meta).status === 'drift',
+		nwo: info.nwo,
+		branch: info.branch,
+		merge: checkMergeSettings(info).status === 'drift',
 		protection: bp.status === 'optional-missing' || bp.status === 'drift',
 		workflow: wp.status === 'drift',
 	})

--- a/tests/cli/utils/github-settings.test.ts
+++ b/tests/cli/utils/github-settings.test.ts
@@ -27,12 +27,14 @@ const fail = (stderr: string, code: number | null = 1): GhResult => ({
 	code,
 })
 
-const COMPLIANT_PROBE = JSON.stringify({
-	nameWithOwner: 'owner/repo',
-	defaultBranchRef: { name: 'main' },
-	autoMergeAllowed: true,
-	squashMergeAllowed: true,
-	deleteBranchOnMerge: true,
+// The probe reads the REST repo endpoint (gh api repos/{owner}/{repo}), whose
+// field names are snake_case and include allow_auto_merge — unlike gh repo view.
+const COMPLIANT_REPO = JSON.stringify({
+	full_name: 'owner/repo',
+	default_branch: 'main',
+	allow_auto_merge: true,
+	allow_squash_merge: true,
+	delete_branch_on_merge: true,
 })
 const COMPLIANT_PROTECTION = JSON.stringify({
 	required_status_checks: { strict: false, contexts: ['lint', 'typecheck', 'build', 'test'] },
@@ -46,10 +48,12 @@ const COMPLIANT_WORKFLOW = JSON.stringify({
 	can_approve_pull_request_reviews: false,
 })
 
-/** Route canned responses by which gh subcommand is invoked. */
-function fakeGh(overrides: { probe?: GhResult; protection?: GhResult; workflow?: GhResult } = {}): GhExec {
+/** Route canned responses by which gh api path is invoked. */
+function fakeGh(
+	overrides: { repo?: GhResult; protection?: GhResult; workflow?: GhResult } = {}
+): GhExec {
 	return vi.fn(async (args: string[]) => {
-		if (args[0] === 'repo') return overrides.probe ?? ok(COMPLIANT_PROBE)
+		if (args[1] === 'repos/{owner}/{repo}') return overrides.repo ?? ok(COMPLIANT_REPO)
 		if (args[1]?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
 		if (args[1]?.includes('/actions/permissions/workflow'))
 			return overrides.workflow ?? ok(COMPLIANT_WORKFLOW)
@@ -70,14 +74,14 @@ describe('checkGitHubSettings — skip paths', () => {
 	})
 
 	it('skips all three when gh is not installed', async () => {
-		const exec = fakeGh({ probe: fail('spawn gh ENOENT', null) })
+		const exec = fakeGh({ repo: fail('spawn gh ENOENT', null) })
 		const results = await checkGitHubSettings(gitRepo(), exec)
 		expect(results.every((r) => r.status === 'ok')).toBe(true)
 		expect(byName(results, 'Branch protection')?.detail).toContain('gh not installed')
 	})
 
 	it('skips when the probe fails (no GitHub remote / not authed)', async () => {
-		const exec = fakeGh({ probe: fail('gh auth login required') })
+		const exec = fakeGh({ repo: fail('gh auth login required') })
 		const results = await checkGitHubSettings(gitRepo(), exec)
 		expect(results.every((r) => r.status === 'ok' && r.detail.includes('skipped'))).toBe(true)
 	})
@@ -122,17 +126,17 @@ describe('checkGitHubSettings — drift', () => {
 		expect(bp?.detail).toContain('typecheck')
 	})
 
-	it('drifts when merge settings are off (from the probe)', async () => {
-		const probe = ok(
+	it('drifts when merge settings are off (from the repo probe)', async () => {
+		const repo = ok(
 			JSON.stringify({
-				nameWithOwner: 'owner/repo',
-				defaultBranchRef: { name: 'main' },
-				autoMergeAllowed: false,
-				squashMergeAllowed: true,
-				deleteBranchOnMerge: true,
+				full_name: 'owner/repo',
+				default_branch: 'main',
+				allow_auto_merge: false,
+				allow_squash_merge: true,
+				delete_branch_on_merge: true,
 			})
 		)
-		const ms = byName(await checkGitHubSettings(gitRepo(), fakeGh({ probe })), 'Merge settings')
+		const ms = byName(await checkGitHubSettings(gitRepo(), fakeGh({ repo })), 'Merge settings')
 		expect(ms?.status).toBe('drift')
 		expect(ms?.detail).toContain('auto-merge disabled')
 	})
@@ -204,12 +208,12 @@ describe('applyGithubSettings', () => {
 
 	/** Records every gh call; canned responses drive which deltas fire. */
 	function recordingGh(
-		overrides: { probe?: GhResult; protection?: GhResult; workflow?: GhResult } = {}
+		overrides: { repo?: GhResult; protection?: GhResult; workflow?: GhResult } = {}
 	) {
 		const calls: { args: string[]; stdin?: string }[] = []
 		const exec: GhExec = vi.fn(async (args: string[], stdin?: string) => {
 			calls.push({ args, stdin })
-			if (args[0] === 'repo') return overrides.probe ?? ok(COMPLIANT_PROBE)
+			if (args[1] === 'repos/{owner}/{repo}') return overrides.repo ?? ok(COMPLIANT_REPO)
 			if (args.includes('--input')) return ok('') // protection PUT
 			if (args[1]?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
 			if (args[1]?.includes('/actions/permissions/workflow'))
@@ -227,17 +231,17 @@ describe('applyGithubSettings', () => {
 	})
 
 	it('applies all three deltas and returns their labels, in order', async () => {
-		const driftedProbe = ok(
+		const driftedRepo = ok(
 			JSON.stringify({
-				nameWithOwner: 'owner/repo',
-				defaultBranchRef: { name: 'main' },
-				autoMergeAllowed: false,
-				squashMergeAllowed: false,
-				deleteBranchOnMerge: false,
+				full_name: 'owner/repo',
+				default_branch: 'main',
+				allow_auto_merge: false,
+				allow_squash_merge: false,
+				delete_branch_on_merge: false,
 			})
 		)
 		const { exec, calls } = recordingGh({
-			probe: driftedProbe,
+			repo: driftedRepo,
 			protection: fail('gh: Not Found (HTTP 404)'),
 			workflow: ok(
 				JSON.stringify({
@@ -267,7 +271,7 @@ describe('applyGithubSettings', () => {
 	})
 
 	it('skips (no mutation) when the probe fails', async () => {
-		const { exec, calls } = recordingGh({ probe: fail('gh auth login required') })
+		const { exec, calls } = recordingGh({ repo: fail('gh auth login required') })
 		expect(await applyGithubSettings(gitRepo(), exec)).toEqual([])
 		expect(calls.every((c) => !c.args.includes('PUT') && !c.args.includes('PATCH'))).toBe(true)
 	})


### PR DESCRIPTION
## The bug

The github-settings probe requested `autoMergeAllowed` from `gh repo view --json` — **that field doesn't exist there**. gh rejects the entire `--json` call on an unknown field, so the probe **always failed on real repos**. Result: the branch-protection / merge-settings / workflow checks (#137) *and* the apply fixer (#138) silently skipped everywhere — the whole feature was a no-op outside of unit tests.

The unit tests missed it because the fake `GhExec` returned a `gh repo view` shape (`autoMergeAllowed`, `nameWithOwner`) that gh never actually emits.

Surfaced by the #138 manual E2E: `doctor` against a real repo reported `skipped — not a GitHub repo or gh unavailable` for all three.

## The fix

Probe **`gh api repos/{owner}/{repo}`** instead — one call that:
- proves gh is installed + authed + has a GitHub remote + online (same guarantees as before),
- carries `full_name` (nwo), `default_branch`, and the snake_case merge flags `allow_auto_merge` / `allow_squash_merge` / `delete_branch_on_merge` — **including auto-merge, which `gh repo view` cannot report at all**.

Extracted into a shared `probeRepo(exec)` used by both `checkGitHubSettings` and `applyGithubSettings`. Tests updated to the real REST field names.

## Verified live (read path)
`doctor` against a real repo now reads merge + workflow settings correctly and reports **real** branch-protection drift instead of skipping:
```
Branch protection  drift  missing required checks: test; strict status checks on (should be off)
Merge settings     ok     auto-merge, squash-merge, delete-on-merge all on
Workflow permissions ok   read-only default, no workflow PR approvals
```

407 tests pass, typecheck + biome clean.

## Known follow-up (not this PR)
The gh calls resolve the repo from `process.cwd()`, not the `-d/--directory` target — so `doctor -d /other/repo` reports the cwd repo's GitHub settings. Pre-existing since #137; normal usage (run from inside the repo) is unaffected. Worth a separate issue.