### PR TITLE
feat(cli): add Cypress preset (peer to Playwright)

### DIFF
--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -73,7 +73,7 @@ Running `setup` (or its alias `init`) launches an interactive wizard:
 | TS config variant | `base`, `react`, `next`, `node`, `express` (context-filtered) |
 | Linting/formatting tool | `biome` (recommended), `eslint`, `both`, `none` |
 | ESLint config *(if ESLint)* | `base` or `nextjs` |
-| Testing framework | `vitest` (recommended), `jest`, `playwright`, `none` |
+| Testing framework | `vitest` (recommended), `jest`, `playwright`, `cypress`, `none` |
 | Test environment *(if Jest)* | `node`, `browser`, `both` |
 | Git hooks (Husky + lint-staged)? | yes/no |
 | Conventional commit linting? | yes/no *(if git hooks enabled)* |

--- a/apps/docs/docs/reference/cypress.md
+++ b/apps/docs/docs/reference/cypress.md
@@ -1,0 +1,77 @@
+---
+title: Cypress
+description: Cypress end-to-end testing preset — a peer to the Playwright preset.
+---
+
+Cypress is offered as a peer to Playwright for end-to-end testing. Pick it in
+the setup wizard (`🌲 Cypress (E2E)`) or scaffold it into an existing project
+with `js-tooling fix cypress`.
+
+## Config
+
+The generated `cypress.config.ts` re-exports the shipped preset:
+
+```typescript
+// cypress.config.ts
+export { default } from '@rtorcato/js-tooling/cypress'
+```
+
+The preset points Cypress at `tests/e2e/`, retries twice in CI, and reads its
+base URL from `CYPRESS_BASE_URL` (default `http://localhost:3000`):
+
+```javascript
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    baseUrl: process.env.CYPRESS_BASE_URL ?? 'http://localhost:3000',
+    specPattern: 'tests/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    supportFile: 'cypress/support/e2e.ts',
+    video: false,
+    retries: { runMode: process.env.CI ? 2 : 0, openMode: 0 },
+  },
+})
+```
+
+To override, spread the preset and extend it:
+
+```typescript
+// cypress.config.ts
+import { defineConfig } from 'cypress'
+import preset from '@rtorcato/js-tooling/cypress'
+
+export default defineConfig({
+  ...preset,
+  e2e: { ...preset.e2e, baseUrl: 'http://localhost:5173' },
+})
+```
+
+## Scaffolded layout
+
+`fix cypress` (and the setup wizard) create the config plus starter boilerplate,
+never clobbering files that already exist:
+
+```
+cypress.config.ts
+cypress/support/e2e.ts        # loads custom commands
+cypress/support/commands.ts   # add Cypress.Commands.add(...) here
+tests/e2e/example.cy.ts       # example spec
+```
+
+## Scripts
+
+Choosing Cypress adds:
+
+| Script | Command | Use case |
+|---|---|---|
+| `test:e2e` | `cypress run` | Headless run (CI) |
+| `test:e2e:ui` | `cypress open` | Interactive runner |
+
+`test:e2e` is what the generated `verify` chain and the GitLab CI job call, so
+Cypress and Playwright are interchangeable there.
+
+## Import path
+
+| Export | Use case |
+|---|---|
+| `@rtorcato/js-tooling/cypress` | Cypress `defineConfig` preset |

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
         'reference/biome',
         'reference/changesets',
         'reference/commitlint',
+        'reference/cypress',
         'reference/esbuild',
         'reference/eslint',
         'reference/github-actions',

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
 		"tooling/jest-presets/**",
 		"tooling/playwright/playwright.config.mjs",
 		"tooling/playwright/playwright.config.d.mts",
+		"tooling/cypress/cypress.config.mjs",
+		"tooling/cypress/cypress.config.d.mts",
 		"tooling/prettier/index.mjs",
 		"tooling/prettier/index.d.mts",
 		"tooling/typescript/*.json",
@@ -117,6 +119,10 @@
 		"./playwright": {
 			"types": "./tooling/playwright/playwright.config.d.mts",
 			"import": "./tooling/playwright/playwright.config.mjs"
+		},
+		"./cypress": {
+			"types": "./tooling/cypress/cypress.config.d.mts",
+			"import": "./tooling/cypress/cypress.config.mjs"
 		},
 		"./prettier": {
 			"types": "./tooling/prettier/index.d.mts",

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -35,7 +35,7 @@ import {
 	generateDependabotConfig,
 	generateRenovateConfig,
 } from '../generators/security.js'
-import { generateVitestConfig } from '../generators/testing.js'
+import { generateCypressConfig, generateVitestConfig } from '../generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../generators/treeshake.js'
 import { generateTailwind } from '../generators/tailwind.js'
 import { generateTurborepo } from '../generators/turborepo.js'
@@ -256,6 +256,25 @@ const FIXERS: Fixer[] = [
 				await fs.writeFile(setupPath, savedSetup)
 			}
 			return { filesWritten: ['vitest.config.ts'] }
+		},
+	},
+	{
+		target: 'cypress',
+		description:
+			'Scaffold cypress.config.ts (re-exports the preset) + tests/e2e and cypress/support boilerplate',
+		// No doctor check — E2E is opt-in, so this runs only when explicitly targeted.
+		appliesTo: [],
+		outputs: [
+			'cypress.config.ts',
+			'cypress/support/e2e.ts',
+			'cypress/support/commands.ts',
+			'tests/e2e/example.cy.ts',
+		],
+		// safe-add: regenerates the config re-export but never clobbers existing specs/support.
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const filesWritten = await generateCypressConfig(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -130,7 +130,7 @@ export const CONFIG_SCHEMA = {
 			additionalProperties: false,
 			required: ['framework'],
 			properties: {
-				framework: { type: 'string', enum: ['vitest', 'jest', 'playwright', 'none'] },
+				framework: { type: 'string', enum: ['vitest', 'jest', 'playwright', 'cypress', 'none'] },
 				environment: { type: 'string', enum: ['node', 'browser', 'both'] },
 			},
 		},
@@ -198,6 +198,14 @@ export function computeFileList(config: ProjectConfig): string[] {
 	}
 	if (config.testing.framework === 'playwright') {
 		files.push('playwright.config.ts')
+	}
+	if (config.testing.framework === 'cypress') {
+		files.push(
+			'cypress.config.ts',
+			'cypress/support/e2e.ts',
+			'cypress/support/commands.ts',
+			'tests/e2e/example.cy.ts'
+		)
 	}
 	if (config.gitHooks) {
 		files.push('.husky/pre-commit', '.gitignore')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -36,7 +36,7 @@ export interface ProjectConfig {
 		tool: 'biome' | 'prettier' | 'none'
 	}
 	testing: {
-		framework: 'vitest' | 'jest' | 'playwright' | 'none'
+		framework: 'vitest' | 'jest' | 'playwright' | 'cypress' | 'none'
 		environment?: 'node' | 'browser' | 'both'
 	}
 	gitHooks: boolean
@@ -241,6 +241,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 				{ name: '⚡ Vitest (Fast, Vite-powered)', value: 'vitest' },
 				{ name: '🃏 Jest (Traditional)', value: 'jest' },
 				{ name: '🎭 Playwright (E2E)', value: 'playwright' },
+				{ name: '🌲 Cypress (E2E)', value: 'cypress' },
 				{ name: '❌ None', value: 'none' },
 			],
 			default: 'vitest',

--- a/src/cli/generators/git.ts
+++ b/src/cli/generators/git.ts
@@ -174,5 +174,14 @@ coverage/
 `
 	}
 
+	if (config.testing.framework === 'cypress') {
+		gitignoreContent += `
+# Cypress
+/cypress/videos/
+/cypress/screenshots/
+/cypress/downloads/
+`
+	}
+
 	await fs.writeFile(gitignorePath, gitignoreContent)
 }

--- a/src/cli/generators/gitlab-ci.ts
+++ b/src/cli/generators/gitlab-ci.ts
@@ -44,7 +44,7 @@ function renderGitLabCI(config: ProjectConfig): string {
 		const testCmd =
 			config.testing.framework === 'vitest'
 				? 'pnpm exec vitest run'
-				: config.testing.framework === 'playwright'
+				: config.testing.framework === 'playwright' || config.testing.framework === 'cypress'
 					? 'pnpm test:e2e'
 					: 'pnpm test'
 		jobs.push(`test:

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -115,6 +115,9 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 	} else if (config.testing.framework === 'playwright') {
 		scripts['test:e2e'] = 'playwright test'
 		scripts['test:e2e:ui'] = 'playwright test --ui'
+	} else if (config.testing.framework === 'cypress') {
+		scripts['test:e2e'] = 'cypress run'
+		scripts['test:e2e:ui'] = 'cypress open'
 	}
 
 	// Build scripts
@@ -191,7 +194,7 @@ export function composeVerifyScript(
 		cmds.push('pnpm exec vitest run')
 	} else if (config.testing.framework === 'jest') {
 		cmds.push('pnpm test --ci')
-	} else if (config.testing.framework === 'playwright') {
+	} else if (config.testing.framework === 'playwright' || config.testing.framework === 'cypress') {
 		cmds.push('pnpm test:e2e')
 	}
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
@@ -223,7 +226,7 @@ export function composeVerifyScriptFromPkg(
 	else if (scripts.lint && !scripts.check) cmds.push('pnpm lint')
 	if (deps.vitest) cmds.push('pnpm exec vitest run')
 	else if (deps.jest) cmds.push('pnpm test --ci')
-	else if (deps['@playwright/test']) cmds.push('pnpm test:e2e')
+	else if (deps['@playwright/test'] || deps.cypress) cmds.push('pnpm test:e2e')
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
 	if (deps.publint || scripts.publint) cmds.push('pnpm publint')
 	return cmds.length >= 2 ? cmds.join(' && ') : null
@@ -264,6 +267,8 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		}
 	} else if (config.testing.framework === 'playwright') {
 		deps['@playwright/test'] = '^1.60.0'
+	} else if (config.testing.framework === 'cypress') {
+		deps['cypress'] = '^13.0.0'
 	}
 
 	// Build tools

--- a/src/cli/generators/readme.ts
+++ b/src/cli/generators/readme.ts
@@ -60,6 +60,7 @@ ${config.linting.tool === 'eslint' ? '├── prettier.config.mjs  # Prettier 
 ${config.testing.framework === 'vitest' ? '├── vitest.config.ts     # Vitest configuration' : ''}
 ${config.testing.framework === 'jest' ? '├── jest.config.mjs     # Jest configuration' : ''}
 ${config.testing.framework === 'playwright' ? '├── playwright.config.ts # Playwright configuration' : ''}
+${config.testing.framework === 'cypress' ? '├── cypress.config.ts   # Cypress configuration' : ''}
 ${config.bundler === 'tsup' ? '├── tsup.config.ts       # tsup configuration' : ''}
 ${config.bundler === 'esbuild' ? '├── build.mjs           # esbuild configuration' : ''}
 ${config.bundler === 'vite' ? '├── vite.config.ts       # Vite configuration' : ''}
@@ -180,6 +181,9 @@ function generateTestingSection(config: ProjectConfig): string {
 	} else if (config.testing.framework === 'playwright') {
 		commands.push('pnpm test:e2e      # Run E2E tests')
 		commands.push('pnpm test:e2e:ui   # Run E2E tests with UI')
+	} else if (config.testing.framework === 'cypress') {
+		commands.push('pnpm test:e2e      # Run E2E tests (headless)')
+		commands.push('pnpm test:e2e:ui   # Open the Cypress runner')
 	}
 
 	return `\`\`\`bash\n${commands.join('\n')}\n\`\`\``
@@ -257,6 +261,8 @@ function generateToolingList(config: ProjectConfig): string {
 		tools.push('- **Jest** - Testing framework')
 	} else if (config.testing.framework === 'playwright') {
 		tools.push('- **Playwright** - End-to-end testing')
+	} else if (config.testing.framework === 'cypress') {
+		tools.push('- **Cypress** - End-to-end testing')
 	}
 
 	if (config.bundler === 'tsup') {

--- a/src/cli/generators/testing.ts
+++ b/src/cli/generators/testing.ts
@@ -9,6 +9,8 @@ export async function generateTestingConfigs(config: ProjectConfig, targetDir: s
 		await generateJestConfig(config, targetDir)
 	} else if (config.testing.framework === 'playwright') {
 		await generatePlaywrightConfig(targetDir)
+	} else if (config.testing.framework === 'cypress') {
+		await generateCypressConfig(targetDir)
 	}
 }
 
@@ -57,4 +59,43 @@ export async function generatePlaywrightConfig(targetDir: string) {
 	const playwrightConfig = `export { default } from '@rtorcato/js-tooling/playwright'
 `
 	await fs.writeFile(playwrightConfigPath, playwrightConfig)
+}
+
+const CYPRESS_EXAMPLE_SPEC = `describe('example', () => {
+  it('loads the app', () => {
+    cy.visit('/')
+  })
+})
+`
+
+/**
+ * Scaffolds cypress.config.ts (a re-export of the shipped preset) plus the
+ * tests/e2e + cypress/support boilerplate. The config re-export is regenerated
+ * every run (idempotent); boilerplate/specs are only created when absent, so
+ * real tests are never clobbered. Returns the relative paths written.
+ */
+export async function generateCypressConfig(targetDir: string): Promise<string[]> {
+	const written: string[] = []
+	await fs.writeFile(
+		path.join(targetDir, 'cypress.config.ts'),
+		`export { default } from '@rtorcato/js-tooling/cypress'\n`
+	)
+	written.push('cypress.config.ts')
+
+	const boilerplate: Array<[string, string]> = [
+		['cypress/support/e2e.ts', `import './commands'\n`],
+		[
+			'cypress/support/commands.ts',
+			`// Add custom commands via Cypress.Commands.add(...).\nexport {}\n`,
+		],
+		['tests/e2e/example.cy.ts', CYPRESS_EXAMPLE_SPEC],
+	]
+	for (const [rel, content] of boilerplate) {
+		const filePath = path.join(targetDir, rel)
+		if (await fs.pathExists(filePath)) continue
+		await fs.ensureDir(path.dirname(filePath))
+		await fs.writeFile(filePath, content)
+		written.push(rel)
+	}
+	return written
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -128,6 +128,12 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: null,
 	},
 	{
+		name: 'Cypress',
+		description: 'End-to-end testing configuration',
+		exports: ['@rtorcato/js-tooling/cypress'],
+		fixTarget: 'cypress',
+	},
+	{
 		name: 'Commitlint',
 		description: 'Conventional commit linting',
 		exports: ['@rtorcato/js-tooling/commitlint/config'],

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -70,6 +70,26 @@ describe('fix registry', () => {
 			'Workflow permissions',
 		])
 	})
+
+	it('registers a safe-add cypress fixer', () => {
+		const fixer = getFixers().find((f) => f.target === 'cypress')
+		expect(fixer).toBeTruthy()
+		expect(fixer?.riskLevel).toBe('safe-add')
+		expect(fixer?.outputs).toContain('cypress.config.ts')
+	})
+})
+
+describe('fix cypress', () => {
+	it('scaffolds cypress.config.ts + boilerplate when targeted', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('cypress', { directory: dir, yes: true })
+		expect(await fs.readFile(join(dir, 'cypress.config.ts'), 'utf-8')).toContain(
+			"from '@rtorcato/js-tooling/cypress'"
+		)
+		expect(await fs.pathExists(join(dir, 'cypress', 'support', 'e2e.ts'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'tests', 'e2e', 'example.cy.ts'))).toBe(true)
+	})
 })
 
 describe('fix --list', () => {

--- a/tests/cli/generators/git.test.ts
+++ b/tests/cli/generators/git.test.ts
@@ -132,6 +132,16 @@ describe('generateGitConfigs', () => {
 		expect(gitignore).toContain('/playwright-report/')
 	})
 
+	it('appends Cypress entries to .gitignore', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateGitConfigs(baseConfig({ testing: { framework: 'cypress' } }), dir)
+
+		const gitignore = await fs.readFile(join(dir, '.gitignore'), 'utf-8')
+		expect(gitignore).toContain('/cypress/videos/')
+		expect(gitignore).toContain('/cypress/screenshots/')
+	})
+
 	it('ignores Claude Code worktrees and local settings (but not shared agents/commands)', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/gitlab-ci.test.ts
+++ b/tests/cli/generators/gitlab-ci.test.ts
@@ -70,4 +70,11 @@ describe('generateGitLabCI', () => {
 		const yaml = await fs.readFile(join(dir, '.gitlab-ci.yml'), 'utf-8')
 		expect(yaml).toContain('pnpm test:e2e')
 	})
+
+	it('uses pnpm test:e2e for cypress projects', async () => {
+		const dir = newTmpDir()
+		await generateGitLabCI(baseConfig({ testing: { framework: 'cypress' } }), dir)
+		const yaml = await fs.readFile(join(dir, '.gitlab-ci.yml'), 'utf-8')
+		expect(yaml).toContain('pnpm test:e2e')
+	})
 })

--- a/tests/cli/generators/testing.test.ts
+++ b/tests/cli/generators/testing.test.ts
@@ -74,6 +74,33 @@ describe('generateTestingConfigs', () => {
 		expect(preset).toMatch(/\bdevices\b/)
 	})
 
+	it('writes a cypress config re-export plus tests/e2e + support boilerplate', async () => {
+		const dir = newTmpDir()
+		await generateTestingConfigs(baseConfig({ testing: { framework: 'cypress' } }), dir)
+
+		const cypressConfig = await fs.readFile(join(dir, 'cypress.config.ts'), 'utf-8')
+		expect(cypressConfig).toContain("from '@rtorcato/js-tooling/cypress'")
+		expect(await fs.pathExists(join(dir, 'cypress/support/e2e.ts'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'cypress/support/commands.ts'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'tests/e2e/example.cy.ts'))).toBe(true)
+	})
+
+	it('does not clobber an existing cypress spec', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(join(dir, 'tests/e2e/example.cy.ts'), '// my real spec\n')
+		await generateTestingConfigs(baseConfig({ testing: { framework: 'cypress' } }), dir)
+		expect(await fs.readFile(join(dir, 'tests/e2e/example.cy.ts'), 'utf-8')).toBe('// my real spec\n')
+	})
+
+	it('the shipped cypress preset references cypress defineConfig', async () => {
+		const preset = await fs.readFile(
+			join(process.cwd(), 'tooling/cypress/cypress.config.mjs'),
+			'utf-8'
+		)
+		expect(preset).toMatch(/from 'cypress'/)
+		expect(preset).toMatch(/\bdefineConfig\b/)
+	})
+
 	it('writes nothing when framework is none', async () => {
 		const dir = newTmpDir()
 		await generateTestingConfigs(baseConfig({ testing: { framework: 'none' } }), dir)

--- a/tooling/cypress/cypress.config.d.mts
+++ b/tooling/cypress/cypress.config.d.mts
@@ -1,0 +1,4 @@
+/// <reference types="cypress" />
+
+declare const config: Cypress.ConfigOptions
+export default config

--- a/tooling/cypress/cypress.config.mjs
+++ b/tooling/cypress/cypress.config.mjs
@@ -1,0 +1,11 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+	e2e: {
+		baseUrl: process.env.CYPRESS_BASE_URL ?? 'http://localhost:3000',
+		specPattern: 'tests/e2e/**/*.cy.{js,jsx,ts,tsx}',
+		supportFile: 'cypress/support/e2e.ts',
+		video: false,
+		retries: { runMode: process.env.CI ? 2 : 0, openMode: 0 },
+	},
+})


### PR DESCRIPTION
Closes #67. Adds Cypress as an E2E testing peer to Playwright.

## What's included (issue scope)
- **`tooling/cypress/cypress.config.mjs`** factory (+ `.d.mts`), exported as `@rtorcato/js-tooling/cypress`.
- **Setup wizard** `testing.framework` gains a `🌲 Cypress (E2E)` choice; `--config` schema enum and `computeFileList` updated.
- **Generator** `generateCypressConfig` — writes a `cypress.config.ts` re-export plus `tests/e2e/` + `cypress/support/` boilerplate, never clobbering existing specs/support.
- **`fix cypress`** scaffolder (safe-add; targeted-only since E2E is opt-in).
- **Doctor** recognises either Cypress *or* Playwright with no preference — both share the `test:e2e` script that doctor's test-recognition already accepts. (No new nagging e2e check; Playwright has none either.)
- **`docs/reference/cypress.md`** + sidebar entry + getting-started table row.

Also wired everywhere Playwright is: scripts (`test:e2e` = `cypress run`, `test:e2e:ui` = `cypress open`), the `verify` chain (setup + fix paths), deps (`cypress`), `.gitignore`, GitLab CI test command, README (structure/commands/tooling), and the `list` tool catalog.

## Deliberate calls (noted, not oversights)
- **No VS Code extension signal** for Cypress — there's no canonical first-party extension (Playwright's `ms-playwright.playwright` is MS-official). Skipped rather than recommend a community one.
- **Cypress not added to js-tooling's own devDependencies** — its npm install pulls a heavy binary. The preset's types resolve in the consumer context (where Cypress is installed), and consumers get `cypress` via the generator's deps. Matches how the preset ships as a plain re-export.

## Verified
- 414 tests pass (+7 new: config generation, no-clobber, shipped-preset shape, gitignore, GitLab CI, fixer registration + scaffold), typecheck + biome clean.
- Real CLI: `fix cypress` in a scratch dir writes `cypress.config.ts`, `cypress/support/{e2e,commands}.ts`, `tests/e2e/example.cy.ts`.