### PR TITLE
feat(cli): add Nx preset (alternative to Turborepo)

### DIFF
--- a/apps/docs/docs/reference/nx.md
+++ b/apps/docs/docs/reference/nx.md
@@ -1,0 +1,73 @@
+---
+title: Nx
+description: Starter nx.json task orchestrator for pnpm-workspace monorepos. Alternative to Turborepo.
+---
+
+[Nx](https://nx.dev) is a monorepo task orchestrator with an affected-build model
+and a deep plugin ecosystem. js-tooling scaffolds a minimal `nx.json` with a
+`targetDefaults` pipeline covering build/lint/typecheck/test — a peer to
+[Turborepo](./turborepo.md). Plugin generators are deferred; start from the
+minimal pnpm-workspace shape and add plugins as you need them.
+
+Like Turborepo, it only makes sense in a monorepo, so the setup wizard offers a
+**Monorepo task orchestrator?** choice — Turborepo (default), Nx, or none — only
+when the target directory contains `pnpm-workspace.yaml`. Pick one; `doctor`
+flags a repo running both.
+
+## Usage
+
+Scaffold it into an existing monorepo:
+
+```bash
+npx @rtorcato/js-tooling fix nx
+```
+
+The fixer is **safe-add** — it never overwrites an existing `nx.json`.
+
+## Generated `nx.json`
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/nx-schema.json",
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "production": ["default"],
+    "sharedGlobals": []
+  },
+  "targetDefaults": {
+    "build": { "dependsOn": ["^build"], "outputs": ["{projectRoot}/dist"], "cache": true },
+    "lint": { "cache": true },
+    "typecheck": { "dependsOn": ["^build"], "cache": true },
+    "test": { "dependsOn": ["^build"], "cache": true }
+  }
+}
+```
+
+- `dependsOn: ["^build"]` — a target waits for the same target in upstream
+  workspace dependencies (the `^` means "dependencies first").
+- `outputs` — the files Nx caches per target. Adjust `{projectRoot}/dist` to what
+  each package emits.
+- `cache: true` — enables Nx's local (and, if configured, remote) task cache.
+
+## Peer dependency
+
+Add `nx` to the workspace root `devDependencies` and run tasks through it:
+
+```bash
+pnpm add -Dw nx
+pnpm nx run-many -t build
+pnpm nx affected -t test   # only projects touched by your changes
+```
+
+## Choosing between Nx and Turborepo
+
+- **Nx** — affected-graph builds, a large plugin/generator ecosystem, and
+  distributed task execution for big monorepos.
+- **Turborepo** — a lighter, config-first pipeline when you mainly want caching
+  and parallelism without the plugin surface.
+
+## Doctor behaviour
+
+- In a pnpm workspace, `doctor` reports the orchestrator check ok when either
+  `turbo.json` or `nx.json` is present — no preference.
+- If **both** are present, it flags drift — pick one and remove the other.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
         'reference/eslint',
         'reference/github-actions',
         'reference/jest',
+        'reference/nx',
         'reference/oxlint',
         'reference/postcss',
         'reference/prettier',

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
 		"tooling/docusaurus/index.mjs",
 		"tooling/docusaurus/index.d.mts",
 		"tooling/biome/biome.json",
+		"tooling/nx/nx.json",
 		"tooling/changesets/config.json",
 		"tooling/release-please/release-please-config.json",
 		"tooling/release-please/.release-please-manifest.json",
@@ -176,6 +177,7 @@
 			"import": "./tooling/docusaurus/index.mjs"
 		},
 		"./biome": "./tooling/biome/biome.json",
+		"./nx": "./tooling/nx/nx.json",
 		"./changesets": "./tooling/changesets/config.json",
 		"./release-please": "./tooling/release-please/release-please-config.json",
 		"./oxlint": "./tooling/oxlint/oxlintrc.json",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1346,16 +1346,26 @@ async function checkAiSetup(dir: string): Promise<CheckResult> {
 }
 
 // Only called for pnpm-workspace monorepos (see runDoctor) — a single-package
-// repo has no use for turbo.json, so the check would be noise there.
+// repo has no use for a task orchestrator, so the check would be noise there.
+// Accepts either Turborepo or Nx (no preference); flags a repo running both.
 async function checkTurborepo(dir: string): Promise<CheckResult> {
-	if (await fs.pathExists(path.join(dir, 'turbo.json'))) {
-		return { check: 'Turborepo', status: 'ok', detail: 'turbo.json found' }
+	const hasTurbo = await fs.pathExists(path.join(dir, 'turbo.json'))
+	const hasNx = await fs.pathExists(path.join(dir, 'nx.json'))
+	if (hasTurbo && hasNx) {
+		return {
+			check: 'Turborepo',
+			status: 'drift',
+			detail: 'both turbo.json and nx.json present',
+			hint: 'Pick one monorepo orchestrator — remove either turbo.json or nx.json',
+		}
 	}
+	if (hasTurbo) return { check: 'Turborepo', status: 'ok', detail: 'turbo.json found' }
+	if (hasNx) return { check: 'Turborepo', status: 'ok', detail: 'nx.json found (using Nx)' }
 	return {
 		check: 'Turborepo',
 		status: 'optional-missing',
-		detail: 'pnpm workspace without turbo.json',
-		hint: 'Run `npx @rtorcato/js-tooling fix turborepo` to scaffold a task pipeline',
+		detail: 'pnpm workspace without a task orchestrator',
+		hint: 'Run `npx @rtorcato/js-tooling fix turborepo` (or `fix nx`) to scaffold a task pipeline',
 	}
 }
 

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -159,6 +159,8 @@ export function lockfilePatchForTarget(
 			return c.aiSetup ? null : { aiSetup: true }
 		case 'turborepo':
 			return c.turborepo ? null : { turborepo: true }
+		case 'nx':
+			return c.nx ? null : { nx: true }
 		case 'tailwind':
 			return c.tailwind ? null : { tailwind: true }
 		default:

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -43,6 +43,7 @@ import { generateCypressConfig, generateVitestConfig } from '../generators/testi
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../generators/treeshake.js'
 import { generateTailwind } from '../generators/tailwind.js'
 import { generateTurborepo } from '../generators/turborepo.js'
+import { generateNx } from '../generators/nx.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../generators/typedoc.js'
 import { copyPreset } from '../utils/copy-preset.js'
 import { applyGithubSettings } from '../utils/github-settings.js'
@@ -521,6 +522,19 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const written = await generateTurborepo(targetDir)
 			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'nx',
+		description: 'Scaffold nx.json task orchestrator (alternative to Turborepo)',
+		// No doctor check — orchestrator is opt-in and Turborepo is the default;
+		// runs only when explicitly targeted. generateNx never clobbers nx.json.
+		appliesTo: [],
+		outputs: ['nx.json'],
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			const filesWritten = await generateNx(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -147,6 +147,7 @@ export const CONFIG_SCHEMA = {
 		badges: { type: 'boolean' },
 		aiSetup: { type: 'boolean' },
 		turborepo: { type: 'boolean' },
+		nx: { type: 'boolean' },
 		tailwind: { type: 'boolean' },
 	},
 } as const
@@ -256,6 +257,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 		)
 	}
 	if (config.turborepo) files.push('turbo.json')
+	if (config.nx) files.push('nx.json')
 	if (config.tailwind) files.push('postcss.config.mjs', 'src/styles/globals.css')
 	files.push('README.md')
 	return files

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -56,6 +56,8 @@ export interface ProjectConfig {
 	aiSetup?: boolean
 	/** Scaffold a turbo.json task pipeline (pnpm-workspace monorepos). */
 	turborepo?: boolean
+	/** Scaffold an nx.json task orchestrator (Turborepo alternative). */
+	nx?: boolean
 	/** Scaffold Tailwind CSS v4 (PostCSS plugin + CSS entry) for frontend projects. */
 	tailwind?: boolean
 }
@@ -318,10 +320,15 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 			default: true,
 		},
 		{
-			type: 'confirm',
-			name: 'turborepo',
-			message: '🚀 Add a Turborepo task pipeline (turbo.json)?',
-			default: true,
+			type: 'list',
+			name: 'orchestrator',
+			message: '🚀 Monorepo task orchestrator?',
+			choices: [
+				{ name: '⚡ Turborepo (turbo.json)', value: 'turbo' },
+				{ name: '🔷 Nx (nx.json)', value: 'nx' },
+				{ name: '❌ None', value: 'none' },
+			],
+			default: 'turbo',
 			when: () => hasWorkspace,
 		},
 		{
@@ -395,7 +402,8 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 		publint: answers.publint ?? false,
 		badges: answers.badges ?? false,
 		aiSetup: answers.aiSetup ?? false,
-		turborepo: answers.turborepo ?? false,
+		turborepo: answers.orchestrator === 'turbo',
+		nx: answers.orchestrator === 'nx',
 		tailwind: answers.tailwind ?? false,
 	}
 }

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -16,6 +16,7 @@ import { generateTreeshakeCheck, inferSubpathsFromExports } from './treeshake.js
 import { generateTSConfig } from './tsconfig.js'
 import { generateTailwind } from './tailwind.js'
 import { generateTurborepo } from './turborepo.js'
+import { generateNx } from './nx.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -90,6 +91,11 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 	// Turborepo task pipeline (pnpm-workspace monorepos, when opted-in)
 	if (config.turborepo) {
 		await generateTurborepo(targetDir)
+	}
+
+	// Nx task orchestrator (alternative to Turborepo, when opted-in)
+	if (config.nx) {
+		await generateNx(targetDir)
 	}
 
 	// Tailwind CSS v4 (frontend projects, when opted-in)

--- a/src/cli/generators/nx.ts
+++ b/src/cli/generators/nx.ts
@@ -1,0 +1,16 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * Scaffold a starter nx.json for a pnpm-workspace monorepo (the Turborepo
+ * alternative). Copies the shipped preset — a minimal `targetDefaults` pipeline;
+ * plugin generators are deferred. Never clobbers a hand-tuned nx.json (there is
+ * no doctor "ok" short-circuit for the targeted `fix nx` path). Returns the
+ * relative path written, or [] when nx.json already exists.
+ */
+export async function generateNx(targetDir: string): Promise<string[]> {
+	if (await fs.pathExists(path.join(targetDir, 'nx.json'))) return []
+	const { copyPreset } = await import('../utils/copy-preset.js')
+	const result = await copyPreset('nx', targetDir)
+	return [result.target]
+}

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 
 export type PresetName =
 	| 'biome'
+	| 'nx'
 	| 'changesets'
 	| 'release-please'
 	| 'oxlint'
@@ -21,6 +22,11 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/biome/biome.json',
 		target: 'biome.json',
 		desc: 'Biome formatter and linter configuration',
+	},
+	nx: {
+		source: 'tooling/nx/nx.json',
+		target: 'nx.json',
+		desc: 'Nx monorepo task-orchestrator configuration',
 	},
 	changesets: {
 		source: 'tooling/changesets/config.json',

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -104,6 +104,21 @@ describe('fix release-please', () => {
 	})
 })
 
+describe('fix nx', () => {
+	it('scaffolds nx.json when targeted, and never clobbers it', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('nx', { directory: dir, yes: true })
+		const nx = await fs.readJson(join(dir, 'nx.json'))
+		expect(nx.$schema).toContain('nrwl/nx')
+
+		// Re-running is a no-op — an existing nx.json is preserved.
+		await fs.writeJson(join(dir, 'nx.json'), { custom: true })
+		await fixCommand('nx', { directory: dir, yes: true })
+		expect((await fs.readJson(join(dir, 'nx.json'))).custom).toBe(true)
+	})
+})
+
 describe('fix --list', () => {
 	it('emits a json payload listing every fixer when --list --json', async () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/tests/cli/generators/turborepo.test.ts
+++ b/tests/cli/generators/turborepo.test.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { generateNx } from '../../../src/cli/generators/nx.js'
 import { generateTurborepo } from '../../../src/cli/generators/turborepo.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -44,5 +45,43 @@ describe('doctor Turborepo check', () => {
 		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
 		await generateTurborepo(dir)
 		expect(findTurbo(await runDoctor(dir))?.status).toBe('ok')
+	})
+
+	it('reports ok in a workspace with nx.json (using Nx)', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		await generateNx(dir)
+		const turbo = findTurbo(await runDoctor(dir))
+		expect(turbo?.status).toBe('ok')
+		expect(turbo?.detail).toMatch(/Nx/)
+	})
+
+	it('flags drift when both turbo.json and nx.json are present', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		await generateTurborepo(dir)
+		await generateNx(dir)
+		expect(findTurbo(await runDoctor(dir))?.status).toBe('drift')
+	})
+})
+
+describe('generateNx', () => {
+	it('writes a valid nx.json with targetDefaults', async () => {
+		const dir = newTmpDir()
+		const written = await generateNx(dir)
+		expect(written).toEqual(['nx.json'])
+
+		const nx = await fs.readJson(join(dir, 'nx.json'))
+		expect(nx.$schema).toContain('nrwl/nx')
+		expect(nx.targetDefaults.build.dependsOn).toEqual(['^build'])
+	})
+
+	it('never clobbers an existing nx.json', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'nx.json'), { custom: true })
+		expect(await generateNx(dir)).toEqual([])
+		expect((await fs.readJson(join(dir, 'nx.json'))).custom).toBe(true)
 	})
 })

--- a/tooling/nx/nx.json
+++ b/tooling/nx/nx.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://raw.githubusercontent.com/nrwl/nx/master/packages/nx/schemas/nx-schema.json",
+	"namedInputs": {
+		"default": ["{projectRoot}/**/*", "sharedGlobals"],
+		"production": ["default"],
+		"sharedGlobals": []
+	},
+	"targetDefaults": {
+		"build": {
+			"dependsOn": ["^build"],
+			"outputs": ["{projectRoot}/dist"],
+			"cache": true
+		},
+		"lint": { "cache": true },
+		"typecheck": {
+			"dependsOn": ["^build"],
+			"cache": true
+		},
+		"test": {
+			"dependsOn": ["^build"],
+			"cache": true
+		}
+	}
+}


### PR DESCRIPTION
Closes #62. Adds Nx as a monorepo task-orchestrator peer to Turborepo.

## Included (issue scope)
- **`tooling/nx/nx.json`** template — a minimal `targetDefaults` build/lint/typecheck/test pipeline (plugin generators deferred per the issue). Exported as `@rtorcato/js-tooling/nx`, copyable via `copy nx`.
- **Setup wizard** — the Turborepo yes/no confirm becomes a **"Monorepo task orchestrator?"** list: `⚡ Turborepo` (default), `🔷 Nx`, `❌ None`, still gated on `pnpm-workspace.yaml`. Adds `nx?: boolean` to `ProjectConfig`; answer maps to `turborepo`/`nx` booleans.
- **`fix nx`** scaffolder — `generateNx` copies the preset and is **safe-add** (never clobbers an existing `nx.json`; guarded in the generator since it's targeted-only).
- **Doctor accepts either, flags both** — the workspace orchestrator check now reports ok for `turbo.json` *or* `nx.json` (no preference) and `drift` when both are present.
- **`docs/reference/nx.md`** + sidebar entry.

## Design notes
- Nx follows the opt-in-alternative shape (like renovate/changesets): targeted-only fixer, no `FIX_TARGETS` entry so doctor never *nags* a workspace to adopt Nx — Turborepo stays the default the walk-all `fix` scaffolds.
- The doctor check keeps the name `Turborepo` for back-compat (fix-target mapping + existing tests); its detail says "using Nx" when nx.json is the orchestrator.

## Verified
- 424 tests pass (+5: nx generator, no-clobber, doctor ok-on-nx, doctor both-conflict, fix nx idempotent). typecheck + biome clean.
- Real CLI: `fix nx` writes `nx.json`; `doctor` on a workspace with both files → `drift: both turbo.json and nx.json present`.