### PR TITLE
feat(cli): add Rolldown preset (bundler option)

### DIFF
--- a/apps/docs/docs/reference/rolldown.md
+++ b/apps/docs/docs/reference/rolldown.md
@@ -1,0 +1,75 @@
+---
+title: Rolldown
+description: Rolldown bundler configuration factory for TypeScript libraries. Rust-based, Rollup-API-compatible.
+---
+
+[Rolldown](https://rolldown.rs) is the Rust-based, Rollup-API-compatible bundler
+that Vite uses internally. It's offered as a bundler peer to [Rollup](./rollup.md),
+[tsup](./tsup.md), and [esbuild](./esbuild.md). The preset produces unbundled,
+per-file ESM + CJS output and leaves every dependency external so the published
+library stays thin — the same shape as the Rollup preset, but Rolldown transpiles
+TypeScript natively, so there's no `@rollup/plugin-typescript` to install.
+
+## Usage
+
+Re-export the default config:
+
+```javascript
+// rolldown.config.mjs
+export { default } from '@rtorcato/js-tooling/rolldown'
+```
+
+…or customize the entry point:
+
+```javascript
+// rolldown.config.mjs
+import { getConfig } from '@rtorcato/js-tooling/rolldown'
+
+export default getConfig({ input: 'src/main.ts' })
+```
+
+Then wire it into `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "rolldown -c",
+    "build:watch": "rolldown -c --watch"
+  }
+}
+```
+
+`setup` scaffolds this for you when you pick Rolldown, and
+`npx @rtorcato/js-tooling fix rolldown` drops the `rolldown.config.mjs` into an
+existing project.
+
+## Peer dependency
+
+Only `rolldown` is needed (added automatically by `setup`/`fix`) — TypeScript is
+transpiled natively.
+
+## Type declarations
+
+Rolldown's `.d.ts` output is still experimental, so the preset doesn't emit
+declarations. Generate them with `tsc` alongside the bundle:
+
+```json
+{
+  "scripts": {
+    "build": "rolldown -c && tsc --emitDeclarationOnly --outDir dist"
+  }
+}
+```
+
+## API
+
+### `getConfig(options?)`
+
+Returns a Rolldown config with ESM + CJS outputs.
+
+| Option | Default | Meaning |
+|---|---|---|
+| `input` | `src/index.ts` | Library entry point |
+| `outDir` | `dist` | Output directory |
+| `sourcemap` | `true` | Emit sourcemaps |
+| `external` | every bare import | Which ids to leave external |

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -60,6 +60,7 @@ const sidebars: SidebarsConfig = {
         'reference/prettier',
         'reference/publint',
         'reference/release-please',
+        'reference/rolldown',
         'reference/rollup',
         'reference/semantic-release',
         'reference/tailwind',

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
 		"tooling/tsup/index.d.mts",
 		"tooling/rollup/rollup.config.mjs",
 		"tooling/rollup/rollup.config.d.mts",
+		"tooling/rolldown/rolldown.config.mjs",
+		"tooling/rolldown/rolldown.config.d.mts",
 		"tooling/docusaurus/index.mjs",
 		"tooling/docusaurus/index.d.mts",
 		"tooling/biome/biome.json",
@@ -173,6 +175,10 @@
 		"./rollup": {
 			"types": "./tooling/rollup/rollup.config.d.mts",
 			"import": "./tooling/rollup/rollup.config.mjs"
+		},
+		"./rolldown": {
+			"types": "./tooling/rolldown/rolldown.config.d.mts",
+			"import": "./tooling/rolldown/rolldown.config.mjs"
 		},
 		"./docusaurus": {
 			"types": "./tooling/docusaurus/index.d.mts",

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -8,6 +8,7 @@ import { installAgentRules, installAiSetup } from '../generators/agent-rules.js'
 import { buildBadgeBlock, parseRepository, upsertBadges } from '../generators/badges.js'
 import {
 	generateReleasePleaseConfig,
+	generateRolldownConfig,
 	generateRollupConfig,
 	generateSemanticReleaseConfig,
 } from '../generators/build.js'
@@ -654,6 +655,17 @@ const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			await generateRollupConfig(targetDir)
 			return { filesWritten: ['rollup.config.mjs'] }
+		},
+	},
+	{
+		target: 'rolldown',
+		description: 'Scaffold rolldown.config.mjs re-exporting the shared library preset',
+		appliesTo: [],
+		outputs: ['rolldown.config.mjs'],
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			await generateRolldownConfig(targetDir)
+			return { filesWritten: ['rolldown.config.mjs'] }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -141,7 +141,7 @@ export const CONFIG_SCHEMA = {
 		releasePlease: { type: 'boolean' },
 		oxlint: { type: 'boolean' },
 		securityAutomation: { type: 'boolean' },
-		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'rollup', 'vite', 'none'] },
+		bundler: { type: 'string', enum: ['tsup', 'esbuild', 'rollup', 'rolldown', 'vite', 'none'] },
 		treeshakeCheck: { type: 'boolean' },
 		publint: { type: 'boolean' },
 		badges: { type: 'boolean' },
@@ -222,6 +222,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 	if (config.bundler === 'tsup') files.push('tsup.config.ts')
 	else if (config.bundler === 'esbuild') files.push('build.mjs')
 	else if (config.bundler === 'rollup') files.push('rollup.config.mjs')
+	else if (config.bundler === 'rolldown') files.push('rolldown.config.mjs')
 	else if (config.bundler === 'vite') files.push('vite.config.ts')
 	if (config.semanticRelease) files.push('release.config.mjs')
 	if (config.changesets) files.push('.changeset/config.json')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -46,7 +46,7 @@ export interface ProjectConfig {
 	releasePlease?: boolean
 	oxlint?: boolean
 	securityAutomation: boolean
-	bundler: 'tsup' | 'esbuild' | 'rollup' | 'vite' | 'none'
+	bundler: 'tsup' | 'esbuild' | 'rollup' | 'rolldown' | 'vite' | 'none'
 	treeshakeCheck?: boolean
 	/** Add publint (validates package.json + dist for publishing mistakes). */
 	publint?: boolean
@@ -351,6 +351,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 					{ name: '📦 tsup (TypeScript packages)', value: 'tsup' },
 					{ name: '⚡ esbuild (Fast bundling)', value: 'esbuild' },
 					{ name: '🍣 Rollup (library bundler)', value: 'rollup' },
+					{ name: '🦀 Rolldown (Rust, Rollup-compatible)', value: 'rolldown' },
 					{ name: '❌ None', value: 'none' },
 				]
 

--- a/src/cli/generators/build.ts
+++ b/src/cli/generators/build.ts
@@ -43,6 +43,8 @@ export async function generateBuildConfigs(config: ProjectConfig, targetDir: str
 		await generateEsbuildConfig(targetDir)
 	} else if (config.bundler === 'rollup') {
 		await generateRollupConfig(targetDir)
+	} else if (config.bundler === 'rolldown') {
+		await generateRolldownConfig(targetDir)
 	} else if (config.bundler === 'vite') {
 		await generateViteConfig(config, targetDir)
 	}
@@ -114,6 +116,15 @@ export async function generateRollupConfig(targetDir: string) {
 `
 
 	await fs.writeFile(rollupConfigPath, rollupConfig)
+}
+
+export async function generateRolldownConfig(targetDir: string) {
+	const rolldownConfigPath = path.join(targetDir, 'rolldown.config.mjs')
+
+	const rolldownConfig = `export { default } from '@rtorcato/js-tooling/rolldown'
+`
+
+	await fs.writeFile(rolldownConfigPath, rolldownConfig)
 }
 
 export async function generateViteConfig(config: ProjectConfig, targetDir: string) {

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -129,6 +129,9 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 	} else if (config.bundler === 'rollup') {
 		scripts['build'] = 'rollup -c'
 		scripts['build:watch'] = 'rollup -c --watch'
+	} else if (config.bundler === 'rolldown') {
+		scripts['build'] = 'rolldown -c'
+		scripts['build:watch'] = 'rolldown -c --watch'
 	} else if (config.bundler === 'vite') {
 		scripts['build'] = 'vite build'
 		scripts['dev'] = 'vite'
@@ -280,6 +283,9 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['rollup'] = '^4.0.0'
 		deps['@rollup/plugin-typescript'] = '^12.0.0'
 		deps['tslib'] = '^2.0.0'
+	} else if (config.bundler === 'rolldown') {
+		// Rolldown transpiles TypeScript natively — no plugin-typescript/tslib.
+		deps['rolldown'] = '^1.0.0'
 	} else if (config.bundler === 'vite') {
 		deps['vite'] = '^6.0.0'
 	}

--- a/src/cli/generators/readme.ts
+++ b/src/cli/generators/readme.ts
@@ -63,6 +63,8 @@ ${config.testing.framework === 'playwright' ? '├── playwright.config.ts # 
 ${config.testing.framework === 'cypress' ? '├── cypress.config.ts   # Cypress configuration' : ''}
 ${config.bundler === 'tsup' ? '├── tsup.config.ts       # tsup configuration' : ''}
 ${config.bundler === 'esbuild' ? '├── build.mjs           # esbuild configuration' : ''}
+${config.bundler === 'rollup' ? '├── rollup.config.mjs   # Rollup configuration' : ''}
+${config.bundler === 'rolldown' ? '├── rolldown.config.mjs # Rolldown configuration' : ''}
 ${config.bundler === 'vite' ? '├── vite.config.ts       # Vite configuration' : ''}
 ${config.commitLint ? '├── commitlint.config.mjs # Commitlint configuration' : ''}
 ${config.gitHooks ? '├── .husky/             # Git hooks' : ''}

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -131,6 +131,17 @@ describe('fix bun', () => {
 	})
 })
 
+describe('fix rolldown', () => {
+	it('scaffolds rolldown.config.mjs re-exporting the preset', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('rolldown', { directory: dir, yes: true })
+		expect(await fs.readFile(join(dir, 'rolldown.config.mjs'), 'utf-8')).toContain(
+			"from '@rtorcato/js-tooling/rolldown'"
+		)
+	})
+})
+
 describe('fix --list', () => {
 	it('emits a json payload listing every fixer when --list --json', async () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})

--- a/tests/cli/generators/build.test.ts
+++ b/tests/cli/generators/build.test.ts
@@ -55,6 +55,24 @@ describe('generateBuildConfigs', () => {
 		expect(await fs.pathExists(join(dir, 'build.mjs'))).toBe(false)
 	})
 
+	it('writes rolldown.config.mjs re-exporting the preset', async () => {
+		const dir = newTmpDir()
+		await generateBuildConfigs(baseConfig({ bundler: 'rolldown' }), dir)
+
+		const content = await fs.readFile(join(dir, 'rolldown.config.mjs'), 'utf-8')
+		expect(content).toContain("from '@rtorcato/js-tooling/rolldown'")
+		expect(await fs.pathExists(join(dir, 'rollup.config.mjs'))).toBe(false)
+	})
+
+	it('the shipped rolldown preset uses rolldown defineConfig', async () => {
+		const preset = await fs.readFile(
+			join(process.cwd(), 'tooling/rolldown/rolldown.config.mjs'),
+			'utf-8'
+		)
+		expect(preset).toMatch(/from 'rolldown'/)
+		expect(preset).toMatch(/\bdefineConfig\b/)
+	})
+
 	it('writes vite.config.ts re-exporting the preset', async () => {
 		const dir = newTmpDir()
 		await generateBuildConfigs(baseConfig({ bundler: 'vite' }), dir)

--- a/tooling/rolldown/rolldown.config.d.mts
+++ b/tooling/rolldown/rolldown.config.d.mts
@@ -1,0 +1,18 @@
+import type { RolldownOptions } from 'rolldown'
+
+export interface GetConfigOptions {
+	/** Library entry point. Default: `src/index.ts`. */
+	input?: string
+	/** Output directory for the bundle. Default: `dist`. */
+	outDir?: string
+	/** Emit sourcemaps. Default: `true`. */
+	sourcemap?: boolean
+	/** Which ids to leave external. Default: every bare (non-relative) import. */
+	external?: RolldownOptions['external']
+}
+
+/** Build the ESM + CJS Rolldown config for a TypeScript library. */
+export declare function getConfig(options?: GetConfigOptions): RolldownOptions
+
+declare const config: RolldownOptions
+export default config

--- a/tooling/rolldown/rolldown.config.mjs
+++ b/tooling/rolldown/rolldown.config.mjs
@@ -1,0 +1,59 @@
+import { defineConfig } from 'rolldown'
+
+/**
+ * Rolldown config factory for TypeScript libraries.
+ *
+ * Rolldown is the Rust-based, Rollup-API-compatible bundler (the one Vite uses
+ * internally). Mirrors the rollup preset's intent — unbundled per-file output
+ * (`preserveModules`), dual ESM + CJS, and every bare import left external so
+ * dependencies aren't inlined — but needs no `@rollup/plugin-typescript`:
+ * Rolldown transpiles TypeScript natively.
+ *
+ * Consumers scaffold a `rolldown.config.mjs` that re-exports the default:
+ *
+ *   export { default } from '@rtorcato/js-tooling/rolldown'
+ *
+ * …or customize the entry / output:
+ *
+ *   import { getConfig } from '@rtorcato/js-tooling/rolldown'
+ *   export default getConfig({ input: 'src/main.ts' })
+ *
+ * Type declarations (`.d.ts`) are not emitted here — run `tsc --emitDeclarationOnly`
+ * (or Rolldown's experimental `dts` output) alongside the bundle.
+ *
+ * @param {import('./rolldown.config.d.mts').GetConfigOptions} [options]
+ */
+export function getConfig(options = {}) {
+	const { input = 'src/index.ts', outDir = 'dist', sourcemap = true, external = isBareImport } = options
+
+	return defineConfig({
+		input,
+		external,
+		output: [
+			{
+				dir: outDir,
+				format: 'esm',
+				entryFileNames: '[name].mjs',
+				preserveModules: true,
+				sourcemap,
+			},
+			{
+				dir: outDir,
+				format: 'cjs',
+				entryFileNames: '[name].cjs',
+				preserveModules: true,
+				exports: 'named',
+				sourcemap,
+			},
+		],
+	})
+}
+
+// Treat every non-relative, non-absolute id as an external dependency so the
+// library ships thin and deps resolve from the consumer's node_modules.
+// (`\0`-prefixed ids are virtual modules — never externalize those.)
+function isBareImport(id) {
+	return !id.startsWith('.') && !id.startsWith('/') && !id.startsWith('\0')
+}
+
+export default getConfig()


### PR DESCRIPTION
Closes #61. Adds Rolldown — the Rust-based, Rollup-API-compatible bundler Vite uses internally — as a bundler peer to Rollup/tsup/esbuild/Vite.

## Gate satisfied
The issue gated this on "Rolldown ships stable v1.0." Verified via the GitHub API: Rolldown's latest release is **v1.2.0, non-prerelease, published 2026-07-15** — well past 1.0.

## Included (issue scope)
- **`tooling/rolldown/rolldown.config.mjs`** factory (+ `.d.mts`) — a `getConfig` mirror of the Rollup preset (dual ESM + CJS, `preserveModules`, bare imports external), but with **no `@rollup/plugin-typescript`** since Rolldown transpiles TypeScript natively. Exported as `@rtorcato/js-tooling/rolldown`.
- **Setup wizard** `bundler` list gains `🦀 Rolldown`; schema enum + `computeFileList` updated. Build script (`rolldown -c`) and dep (`rolldown`) wired in `package-json.ts`.
- **`fix rolldown`** scaffolder (safe-add, mirrors `fix rollup`) + `generateRolldownConfig` re-export. README project-structure line (also filled the pre-existing Rollup gap there).
- **`docs/reference/rolldown.md`** + sidebar entry.

## Notes
- Rolldown's `.d.ts` output is still experimental, so the preset doesn't emit declarations — the docs show running `tsc --emitDeclarationOnly` alongside the bundle. This is the one honest deviation from the Rollup preset (which emits dts via plugin-typescript).

## Verified
- 431 tests pass (+3: build generator re-export, shipped-preset shape, `fix rolldown`). typecheck + biome clean.
- Real CLI: `fix rolldown` writes `rolldown.config.mjs` = `export { default } from '@rtorcato/js-tooling/rolldown'`; `fix --list` shows it as safe-add.