### PR TITLE
feat(cli): docs-site generator (fix docs-site) (#100)

### DIFF
--- a/apps/docs/docs/guides/docs-site.md
+++ b/apps/docs/docs/guides/docs-site.md
@@ -11,6 +11,24 @@ shipping a module or cutting a version updates the docs with no manual step.
 This guide is the canonical setup; each repo's `CONTRIBUTING.md` links here and
 adds only its own module list.
 
+## Quick start
+
+Scaffold the whole site in one command — it infers the name, org, and repo from
+`package.json` and drops in the shared design tokens, sync-changelog script, and
+GitHub Pages workflow:
+
+```sh
+npx @rtorcato/js-tooling fix docs-site
+```
+
+It writes `apps/docs/` (Docusaurus config, sidebars, `src/css`, a starter
+`docs/intro.md`), `scripts/sync-changelog.mjs`, the `apps/*` pnpm workspace
+entry, and `.github/workflows/docs.yml`. Every file is written only when
+missing, so re-running never clobbers your edits. The accent colour defaults to
+a neutral green — override `--ifm-color-primary` in `apps/docs/src/css/custom.css`
+to brand it. The sections below cover the optional TypeDoc API reference and the
+deploy details.
+
 ## How it stays current
 
 - **API reference** — `docusaurus-plugin-typedoc` regenerates `docs/api/<mod>`

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -163,6 +163,8 @@ export function lockfilePatchForTarget(
 			return c.nx ? null : { nx: true }
 		case 'tailwind':
 			return c.tailwind ? null : { tailwind: true }
+		case 'docs-site':
+			return c.docsSite ? null : { docsSite: true }
 		default:
 			return null
 	}

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -46,6 +46,7 @@ import { generateTailwind } from '../generators/tailwind.js'
 import { generateTurborepo } from '../generators/turborepo.js'
 import { generateNx } from '../generators/nx.js'
 import { generateBun } from '../generators/bun.js'
+import { generateDocsSite } from '../generators/docs-site.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../generators/typedoc.js'
 import { copyPreset } from '../utils/copy-preset.js'
 import { applyGithubSettings } from '../utils/github-settings.js'
@@ -751,6 +752,25 @@ const FIXERS: Fixer[] = [
 					filesWritten.push('package.json')
 				}
 			}
+			return { filesWritten }
+		},
+	},
+	{
+		target: 'docs-site',
+		description:
+			'Scaffold a Docusaurus docs site under apps/docs (config/sidebars/tokens + reusable Pages deploy), inferring name/org/repo from package.json',
+		// Manual/opt-in target — the "Docs site" doctor check is opt-in (only
+		// surfaces once a site exists), so this never nags a repo without one.
+		appliesTo: [],
+		outputs: [
+			'apps/docs/**',
+			'scripts/sync-changelog.mjs',
+			'pnpm-workspace.yaml',
+			'.github/workflows/docs.yml',
+		],
+		riskLevel: 'safe-add',
+		async run({ targetDir, pkg }) {
+			const filesWritten = await generateDocsSite(pkg, targetDir)
 			return { filesWritten }
 		},
 	},

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -60,6 +60,8 @@ export interface ProjectConfig {
 	nx?: boolean
 	/** Scaffold Tailwind CSS v4 (PostCSS plugin + CSS entry) for frontend projects. */
 	tailwind?: boolean
+	/** Scaffold a Docusaurus docs site under apps/docs (deployed to GitHub Pages). */
+	docsSite?: boolean
 }
 
 export interface SetupOptions {

--- a/src/cli/generators/docs-site.ts
+++ b/src/cli/generators/docs-site.ts
@@ -1,0 +1,377 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+import { copyPreset, PRESETS } from '../utils/copy-preset.js'
+import { parseRepository } from './badges.js'
+
+type Pkg = Record<string, unknown> | null
+
+/**
+ * Docs-site (Docusaurus) generator — the Phase 2 counterpart to the shared
+ * assets shipped in #54. Scaffolds a working Docusaurus site under `apps/docs`,
+ * inferring name/org/repo from package.json (+ the shared design tokens and
+ * sync-changelog script), matching the layout the `Docs site` doctor check
+ * verifies. Every file is written only when absent, so `fix docs-site` is
+ * idempotent and never clobbers a hand-edited site.
+ */
+
+const DOCS_APP = 'apps/docs'
+/** Docusaurus's neutral green — the default accent, meant to be branded over. */
+const DEFAULT_ACCENT = { light: '#2e8555', dark: '#25c2a0' }
+
+export interface DocsSiteOptions {
+	/** Accent colour override, e.g. Cloudflare orange. Falls back per project. */
+	primaryColor?: { light: string; dark: string }
+}
+
+interface SiteMeta {
+	/** Docs package name, e.g. `@rtorcato/js-tooling-docs`. */
+	docsPkgName: string
+	/** Site title shown in the navbar. */
+	title: string
+	tagline: string
+	owner: string | null
+	repo: string | null
+}
+
+/** Derive the docs package name from the consumer's own name (`<name>-docs`). */
+function docsPackageName(pkgName: string | undefined): string {
+	if (!pkgName) return 'docs'
+	return `${pkgName}-docs`
+}
+
+function inferSiteMeta(pkg: Pkg): SiteMeta {
+	const pkgName = pkg?.name as string | undefined
+	const parsed = parseRepository(pkg?.repository)
+	const base = pkgName ? (pkgName.split('/').pop() ?? pkgName) : 'docs'
+	return {
+		docsPkgName: docsPackageName(pkgName),
+		title: parsed?.repo ?? base,
+		tagline: (pkg?.description as string | undefined) ?? 'Documentation',
+		owner: parsed?.owner ?? null,
+		repo: parsed?.repo ?? null,
+	}
+}
+
+/** Write `contents` at `rel` under targetDir only if it doesn't already exist. */
+async function writeIfMissing(
+	targetDir: string,
+	rel: string,
+	contents: string
+): Promise<string | null> {
+	const file = path.join(targetDir, rel)
+	if (await fs.pathExists(file)) return null
+	await fs.ensureDir(path.dirname(file))
+	await fs.writeFile(file, contents)
+	return rel
+}
+
+/** Ensure `pnpm-workspace.yaml` lists `apps/*` (idempotent). */
+async function ensureWorkspace(targetDir: string): Promise<string | null> {
+	const rel = 'pnpm-workspace.yaml'
+	const file = path.join(targetDir, rel)
+	if (await fs.pathExists(file)) {
+		const body = await fs.readFile(file, 'utf8')
+		// Already a workspace covering apps/* (either `apps/*` or a broader glob).
+		if (/^\s*-\s*['"]?apps\/\*/m.test(body)) return null
+		if (/^packages:/m.test(body)) {
+			const next = body.replace(/^packages:\n/m, "packages:\n  - 'apps/*'\n")
+			await fs.writeFile(file, next)
+			return rel
+		}
+		await fs.writeFile(file, `packages:\n  - 'apps/*'\n\n${body}`)
+		return rel
+	}
+	await fs.writeFile(file, "packages:\n  - 'apps/*'\n")
+	return rel
+}
+
+function docusaurusConfig(meta: SiteMeta): string {
+	const owner = meta.owner ?? 'your-org'
+	const repo = meta.repo ?? meta.title
+	const ghUrl = `https://github.com/${owner}/${repo}`
+	return `import type * as Preset from '@docusaurus/preset-classic'
+import type { Config } from '@docusaurus/types'
+import { themes as prismThemes } from 'prism-react-renderer'
+
+const config: Config = {
+  title: '${meta.title}',
+  tagline: ${JSON.stringify(meta.tagline)},
+  favicon: 'img/favicon.ico',
+
+  url: 'https://${owner}.github.io',
+  baseUrl: '/${repo}/',
+
+  organizationName: '${owner}',
+  projectName: '${repo}',
+
+  onBrokenLinks: 'warn',
+
+  markdown: {
+    format: 'detect',
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
+
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en'],
+  },
+
+  presets: [
+    [
+      'classic',
+      {
+        docs: {
+          sidebarPath: './sidebars.ts',
+          routeBasePath: '/docs',
+          editUrl: '${ghUrl}/edit/main/apps/docs/',
+        },
+        blog: false,
+        theme: {
+          customCss: './src/css/custom.css',
+        },
+      } satisfies Preset.Options,
+    ],
+  ],
+
+  plugins: [
+    [
+      '@easyops-cn/docusaurus-search-local',
+      {
+        hashed: true,
+        indexDocs: true,
+        indexBlog: false,
+        docsRouteBasePath: '/docs',
+        highlightSearchTermsOnTargetPage: true,
+        searchBarShortcutHint: false,
+      },
+    ],
+  ],
+
+  themeConfig: {
+    colorMode: {
+      defaultMode: 'dark',
+      respectPrefersColorScheme: true,
+    },
+    navbar: {
+      title: '${meta.title}',
+      items: [
+        { to: '/docs', position: 'left', label: 'Docs' },
+        {
+          href: '${ghUrl}',
+          label: 'GitHub',
+          position: 'right',
+        },
+      ],
+    },
+    footer: {
+      style: 'dark',
+      links: [
+        {
+          title: 'Docs',
+          items: [{ label: 'Getting Started', to: '/docs' }],
+        },
+        {
+          title: 'More',
+          items: [
+            { label: 'GitHub', href: '${ghUrl}' },
+            { label: 'Issues', href: '${ghUrl}/issues' },
+          ],
+        },
+      ],
+      copyright: \`Copyright © \${new Date().getFullYear()} ${meta.title}. Built with Docusaurus.\`,
+    },
+    prism: {
+      theme: prismThemes.vsDark,
+      darkTheme: prismThemes.vsDark,
+      additionalLanguages: ['bash', 'json', 'typescript'],
+    },
+  } satisfies Preset.ThemeConfig,
+}
+
+export default config
+`
+}
+
+const SIDEBARS = `import type { SidebarsConfig } from '@docusaurus/plugin-content-docs'
+
+// Autogenerated from the docs/ folder structure — add markdown files and they
+// appear here. Swap for an explicit list when you want to control ordering.
+const sidebars: SidebarsConfig = {
+  docs: [{ type: 'autogenerated', dirName: '.' }],
+}
+
+export default sidebars
+`
+
+const TSCONFIG = `// Improves IDE type-checking; not used by \`docusaurus start/build\`.
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "strict": true,
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": [".docusaurus", "build"]
+}
+`
+
+function customCss(accent: { light: string; dark: string }): string {
+	// Import the shared tokens, then override only the accent (per #54's model).
+	return `/* Site theme: shared @rtorcato tokens + this project's accent. */
+@import "./_jt-tokens.css";
+
+:root {
+  --ifm-color-primary: ${accent.light};
+  --jt-accent: ${accent.light};
+}
+
+[data-theme="dark"] {
+  --ifm-color-primary: ${accent.dark};
+  --jt-accent: ${accent.dark};
+}
+`
+}
+
+function docsPackageJson(meta: SiteMeta): string {
+	const pkg = {
+		name: meta.docsPkgName,
+		version: '0.0.1',
+		private: true,
+		scripts: {
+			docusaurus: 'docusaurus',
+			'sync-changelog': 'node ../../scripts/sync-changelog.mjs',
+			// pnpm 8 doesn't run pre* hooks reliably — chain sync-changelog explicitly.
+			start: 'pnpm run sync-changelog && docusaurus start',
+			dev: 'pnpm run sync-changelog && docusaurus start',
+			build: 'pnpm run sync-changelog && docusaurus build',
+			serve: 'docusaurus serve',
+			clear: 'docusaurus clear',
+			typecheck: 'tsc --noEmit',
+		},
+		dependencies: {
+			'@docusaurus/core': '^3.10.2',
+			'@docusaurus/preset-classic': '^3.8.1',
+			'@easyops-cn/docusaurus-search-local': '^0.55.2',
+			'@mdx-js/react': '^3.1.0',
+			clsx: '^2.1.1',
+			'prism-react-renderer': '^2.4.1',
+			react: '^19.0.0',
+			'react-dom': '^19.0.0',
+		},
+		devDependencies: {
+			'@docusaurus/module-type-aliases': '^3.10.2',
+			'@docusaurus/tsconfig': '^3.8.1',
+			'@docusaurus/types': '^3.10.2',
+			'@types/react': '^19.0.0',
+			typescript: '~5.6.3',
+		},
+		browserslist: {
+			production: ['>0.5%', 'not dead', 'not op_mini all'],
+			development: ['last 3 chrome version', 'last 3 firefox version', 'last 5 safari version'],
+		},
+		engines: { node: '>=22.0' },
+	}
+	return `${JSON.stringify(pkg, null, 2)}\n`
+}
+
+function introDoc(meta: SiteMeta): string {
+	return `---
+title: ${meta.title}
+slug: /
+sidebar_position: 0
+---
+
+# ${meta.title}
+
+${meta.tagline}
+
+Welcome to the docs. Edit \`apps/docs/docs/intro.md\` to get started, and add
+more markdown files under \`apps/docs/docs/\` — they appear in the sidebar
+automatically.
+`
+}
+
+/** The per-repo workflow that drives the shared reusable deploy on push to main. */
+function docsWorkflow(meta: SiteMeta): string {
+	return `name: 📚 Docs
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/docs/**'
+      - 'CHANGELOG.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  docs:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: rtorcato/js-tooling/.github/workflows/docs-deploy.yml@main
+    with:
+      build-filter: '${meta.docsPkgName}'
+`
+}
+
+/**
+ * Scaffold the Docusaurus docs site. Writes each file only when missing and
+ * returns the relative paths actually written, so `fix docs-site` is safe to
+ * re-run. Also drops in the shared sync-changelog script + design tokens.
+ */
+export async function generateDocsSite(
+	pkg: Pkg,
+	targetDir: string,
+	options: DocsSiteOptions = {}
+): Promise<string[]> {
+	const meta = inferSiteMeta(pkg)
+	const accent = options.primaryColor ?? DEFAULT_ACCENT
+	const written: string[] = []
+
+	// Shared assets (only-if-missing copies of the shipped presets).
+	written.push(...(await copyPresetIfMissing('docusaurus-sync-changelog', targetDir)))
+	written.push(...(await copyPresetIfMissing('docusaurus-theme-tokens', targetDir)))
+
+	// Project-specific scaffold.
+	const files: Array<[string, string]> = [
+		[`${DOCS_APP}/package.json`, docsPackageJson(meta)],
+		[`${DOCS_APP}/docusaurus.config.ts`, docusaurusConfig(meta)],
+		[`${DOCS_APP}/sidebars.ts`, SIDEBARS],
+		[`${DOCS_APP}/tsconfig.json`, TSCONFIG],
+		[`${DOCS_APP}/src/css/custom.css`, customCss(accent)],
+		[`${DOCS_APP}/docs/intro.md`, introDoc(meta)],
+		['.github/workflows/docs.yml', docsWorkflow(meta)],
+	]
+	for (const [rel, contents] of files) {
+		const w = await writeIfMissing(targetDir, rel, contents)
+		if (w) written.push(w)
+	}
+
+	const ws = await ensureWorkspace(targetDir)
+	if (ws) written.push(ws)
+
+	return written
+}
+
+/** Copy a shipped preset only when its target file is absent. */
+async function copyPresetIfMissing(
+	name: 'docusaurus-sync-changelog' | 'docusaurus-theme-tokens',
+	targetDir: string
+): Promise<string[]> {
+	const rel = PRESETS[name].target
+	if (await fs.pathExists(path.join(targetDir, rel))) return []
+	const res = await copyPreset(name, targetDir)
+	return [res.target]
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -199,6 +199,12 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: 'typedoc',
 	},
 	{
+		name: 'Docs site',
+		description: 'Docusaurus docs site (apps/docs) with shared tokens + GitHub Pages deploy',
+		exports: [],
+		fixTarget: 'docs-site',
+	},
+	{
 		name: 'esbuild',
 		description: 'Fast JavaScript bundler configuration',
 		exports: ['@rtorcato/js-tooling/esbuild'],

--- a/tests/cli/docs-site.test.ts
+++ b/tests/cli/docs-site.test.ts
@@ -1,0 +1,100 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../src/cli/commands/doctor.js'
+import { generateDocsSite } from '../../src/cli/generators/docs-site.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const PKG = {
+	name: '@rtorcato/js-tooling',
+	description: 'JS/TS tooling.',
+	repository: 'git+https://github.com/rtorcato/js-tooling.git',
+}
+
+describe('generateDocsSite', () => {
+	it('scaffolds a full site, inferring name/org/repo from package.json', async () => {
+		const dir = newTmpDir()
+		const written = await generateDocsSite(PKG, dir)
+
+		// The whole file set lands.
+		for (const rel of [
+			'apps/docs/package.json',
+			'apps/docs/docusaurus.config.ts',
+			'apps/docs/sidebars.ts',
+			'apps/docs/tsconfig.json',
+			'apps/docs/src/css/custom.css',
+			'apps/docs/src/css/_jt-tokens.css',
+			'apps/docs/docs/intro.md',
+			'scripts/sync-changelog.mjs',
+			'.github/workflows/docs.yml',
+			'pnpm-workspace.yaml',
+		]) {
+			expect(written).toContain(rel)
+			expect(await fs.pathExists(join(dir, rel))).toBe(true)
+		}
+
+		// Docs package name = <name>-docs; build chains sync-changelog.
+		const docsPkg = await fs.readJson(join(dir, 'apps/docs/package.json'))
+		expect(docsPkg.name).toBe('@rtorcato/js-tooling-docs')
+		expect(docsPkg.scripts.build).toMatch(/sync-changelog/)
+
+		// Config infers org/repo → GitHub Pages url + baseUrl.
+		const config = await fs.readFile(join(dir, 'apps/docs/docusaurus.config.ts'), 'utf-8')
+		expect(config).toContain("url: 'https://rtorcato.github.io'")
+		expect(config).toContain("baseUrl: '/js-tooling/'")
+
+		// Workflow drives the shared reusable deploy with the docs package filter.
+		const wf = await fs.readFile(join(dir, '.github/workflows/docs.yml'), 'utf-8')
+		expect(wf).toContain('rtorcato/js-tooling/.github/workflows/docs-deploy.yml@main')
+		expect(wf).toContain("build-filter: '@rtorcato/js-tooling-docs'")
+
+		// custom.css imports the shared tokens, then overrides the accent.
+		const css = await fs.readFile(join(dir, 'apps/docs/src/css/custom.css'), 'utf-8')
+		expect(css).toContain('@import "./_jt-tokens.css"')
+		expect(css).toMatch(/--ifm-color-primary/)
+	})
+
+	it('honours a primary-color override', async () => {
+		const dir = newTmpDir()
+		await generateDocsSite(PKG, dir, { primaryColor: { light: '#F38020', dark: '#ff9a4d' } })
+		const css = await fs.readFile(join(dir, 'apps/docs/src/css/custom.css'), 'utf-8')
+		expect(css).toContain('#F38020')
+		expect(css).toContain('#ff9a4d')
+	})
+
+	it('is idempotent — a second run writes nothing and preserves edits', async () => {
+		const dir = newTmpDir()
+		await generateDocsSite(PKG, dir)
+		// Hand-edit a generated file; the re-run must not clobber it.
+		const configPath = join(dir, 'apps/docs/docusaurus.config.ts')
+		await fs.writeFile(configPath, '// edited by hand\n')
+
+		const second = await generateDocsSite(PKG, dir)
+		expect(second).toEqual([])
+		expect(await fs.readFile(configPath, 'utf-8')).toBe('// edited by hand\n')
+	})
+
+	it('adds apps/* to an existing pnpm-workspace without duplicating', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+		await generateDocsSite(PKG, dir)
+		const ws = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
+		expect(ws).toMatch(/apps\/\*/)
+		expect(ws).toMatch(/packages\/\*/)
+
+		// Re-running does not add a second apps/* entry.
+		await generateDocsSite(PKG, dir)
+		const ws2 = await fs.readFile(join(dir, 'pnpm-workspace.yaml'), 'utf-8')
+		expect(ws2.match(/apps\/\*/g)?.length).toBe(1)
+	})
+
+	it('produces a site the doctor Docs site check reports as ok', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), PKG)
+		await generateDocsSite(PKG, dir)
+		const docs = (await runDoctor(dir)).find((r) => r.check === 'Docs site')
+		expect(docs?.status).toBe('ok')
+	})
+})


### PR DESCRIPTION
**Phase 2** of the docs-site work, following the shared assets shipped in #54/#228. Adds the full site generator behind a new `fix docs-site` target.

## What it does

`npx @rtorcato/js-tooling fix docs-site` scaffolds a working Docusaurus site under `apps/docs`, inferring name/org/repo from `package.json`:

- `apps/docs/` — `docusaurus.config.ts` (title/url/baseUrl/editUrl inferred), `sidebars.ts` (autogenerated), `tsconfig.json`, `src/css/custom.css`, a starter `docs/intro.md`, `package.json` (`@rtorcato/<name>-docs`, build chains sync-changelog).
- `scripts/sync-changelog.mjs` + `apps/docs/src/css/_jt-tokens.css` — copied from the #54 shared presets (only if missing).
- `pnpm-workspace.yaml` — ensures `apps/*` (idempotent, merges into an existing workspace).
- `.github/workflows/docs.yml` — thin caller of the reusable `docs-deploy.yml`, with `build-filter` set to the docs package.

## Wiring

- New generator `src/cli/generators/docs-site.ts`; `safe-add` fix target in `fix.ts`; lockfile intent (`docsSite`) in `fix-targets.ts`; `ProjectConfig.docsSite`; `list` catalog entry.
- Manual/opt-in target — the "Docs site" doctor check (#54) stays opt-in (only surfaces once a site exists), so this never nags a repo without one.
- Accent colour overridable in `custom.css` (neutral green default).

## Acceptance criteria (#100/#106)

- [x] `fix docs-site` scaffolds a site that builds + deploys to Pages out of the box
- [x] Generated config infers name/org/repo; accent overridable
- [x] `sync-changelog.mjs` + tokens come from the single shared source (#54), not re-pasted
- [x] Re-running is idempotent / never clobbers edits (every file written only-if-missing)
- [x] Existing "Docs site" doctor check reports `ok` on generated output

## Verified

- 442 tests pass (+5: full scaffold w/ inference, accent override, idempotent re-run, workspace merge, doctor-ok end-to-end). typecheck + biome clean.
- Real CLI: `fix docs-site` on a scratch `@rtorcato/cf-common` repo writes the full set with `/cf-common/` baseUrl + `@rtorcato/cf-common-docs` filter; second run writes nothing.

## Out of scope (follow-ups already filed)

- TypeDoc API-reference section (#229), Playwright smoke test (#230), retro-migrating sibling repos (#231).
- No interactive `setup` prompt yet — target is manual/`fix`-driven for now.

Closes #100. Covers #106.