### PR TITLE
chore: self-extend published Biome + TS bases via package exports (#80)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "extends": ["@rtorcato/js-tooling/biome"]
+}

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
 		"dev": "pnpm --filter @rtorcato/docs dev",
 		"docs:build": "pnpm --filter @rtorcato/docs build",
 		"==================== Common ====================": "",
-		"lint": "pnpm exec biome lint --config-path=tooling/biome/biome.json src scripts",
-		"format": "pnpm exec biome format --config-path=tooling/biome/biome.json src scripts",
-		"check:fix": "pnpm exec biome check --config-path=tooling/biome/biome.json --fix src scripts",
-		"check": "pnpm exec biome check --config-path=tooling/biome/biome.json src scripts",
+		"lint": "pnpm exec biome lint --config-path=biome.json src scripts",
+		"format": "pnpm exec biome format --config-path=biome.json src scripts",
+		"check:fix": "pnpm exec biome check --config-path=biome.json --fix src scripts",
+		"check": "pnpm exec biome check --config-path=biome.json src scripts",
 		"prepare": "is-ci || husky",
 		"typecheck": "tsc --noEmit --project src/cli/tsconfig.json",
 		"test": "vitest",
@@ -442,8 +442,8 @@
 	},
 	"lint-staged": {
 		"*.{js,ts,json,md}": [
-			"pnpm exec biome lint --config-path=tooling/biome/biome.json",
-			"pnpm exec biome format --config-path=tooling/biome/biome.json --write"
+			"pnpm exec biome lint --config-path=biome.json",
+			"pnpm exec biome format --config-path=biome.json --write"
 		]
 	},
 	"bin": {

--- a/src/cli/tsconfig.json
+++ b/src/cli/tsconfig.json
@@ -1,5 +1,8 @@
 {
-  "extends": "../../tooling/typescript/tsconfig.base.json",
+  // Dogfood (#80): extend the base via the package's own export, not a relative
+  // path, so a breaking change to the shipped base — or a broken export path —
+  // surfaces in this repo's own typecheck.
+  "extends": "@rtorcato/js-tooling/typescript/base",
   "compilerOptions": {
     // CLI-specific deltas over the published base. The base owns strictness so
     // a breaking change to it surfaces here (the point of #80); these only cover


### PR DESCRIPTION
Dogfoods the shipped presets so drift between *what we publish* and *what we use* gets caught in this repo's own CI.

## Finding

The repo already used the shipped `tooling/` files directly (biome via `--config-path=tooling/biome/biome.json`; `src/cli/tsconfig.json` extended `../../tooling/typescript/tsconfig.base.json`), so there was **no config duplication** and a breaking base change already surfaced locally. The remaining gap #80 names is the *export map itself* — nothing exercised `@rtorcato/js-tooling/biome` or `@rtorcato/js-tooling/typescript/base` internally, so a broken `exports` entry could ship unnoticed.

## Change

Resolve the bases through the package's **public exports** instead of relative paths:

- Add root `biome.json` extending `@rtorcato/js-tooling/biome`; repoint the biome scripts + lint-staged at it (`--config-path=biome.json`).
- `src/cli/tsconfig.json` extends `@rtorcato/js-tooling/typescript/base`.

Node's self-referencing resolves the package by its own `name` + `exports` with no `node_modules` symlink; verified both Biome (Rust) and tsc honor it. Now `pnpm check` / `pnpm typecheck` fail if either export path breaks or a shipped base regresses — exactly the drift signal #80 asked for.

## Verified

- `pnpm check` (biome via the specifier) — 37 files, clean.
- `pnpm typecheck` + `pnpm build-cli` — resolve the base via the specifier, clean.
- 437 tests pass.

Closes #80