### PR TITLE
feat(cli): scaffold a Playwright smoke test in the docs-site generator (#230)

### DIFF
--- a/src/cli/generators/docs-site.ts
+++ b/src/cli/generators/docs-site.ts
@@ -85,6 +85,11 @@ async function ensureWorkspace(targetDir: string): Promise<string | null> {
 	return rel
 }
 
+/** The GitHub Pages base path Docusaurus serves under, e.g. `/js-tooling/`. */
+function siteBaseUrl(meta: SiteMeta): string {
+	return `/${meta.repo ?? meta.title}/`
+}
+
 function docusaurusConfig(meta: SiteMeta): string {
 	const owner = meta.owner ?? 'your-org'
 	const repo = meta.repo ?? meta.title
@@ -258,6 +263,9 @@ function docsPackageJson(meta: SiteMeta): string {
 			serve: 'docusaurus serve',
 			clear: 'docusaurus clear',
 			typecheck: 'tsc --noEmit',
+			// Opt-in smoke test — builds, serves, and checks the site renders. Heavy
+			// browser install, so it's a manual/CI-gated run, not part of `build`.
+			'test:e2e': 'playwright test',
 		},
 		dependencies: {
 			'@docusaurus/core': '^3.10.2',
@@ -273,6 +281,8 @@ function docsPackageJson(meta: SiteMeta): string {
 			'@docusaurus/module-type-aliases': '^3.10.2',
 			'@docusaurus/tsconfig': '^3.8.1',
 			'@docusaurus/types': '^3.10.2',
+			'@playwright/test': '^1.49.0',
+			'@rtorcato/js-tooling': '^2.47.0',
 			'@types/react': '^19.0.0',
 			typescript: '~5.6.3',
 		},
@@ -327,6 +337,51 @@ jobs:
 }
 
 /**
+ * Playwright config for the docs smoke test. Reuses the shipped preset, then
+ * builds + serves the site on :3000 and points the base URL at the site's
+ * GitHub Pages base path so routes resolve exactly as in production. One
+ * browser keeps the CI browser install light.
+ */
+function playwrightConfig(meta: SiteMeta): string {
+	const url = `http://localhost:3000${siteBaseUrl(meta)}`
+	return `import { defineConfig, devices } from '@playwright/test'
+import base from '@rtorcato/js-tooling/playwright'
+
+export default defineConfig({
+  ...base,
+  testDir: './tests',
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  use: {
+    ...base.use,
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? '${url}',
+  },
+  webServer: {
+    command: 'pnpm run build && pnpm exec docusaurus serve --port 3000',
+    url: process.env.PLAYWRIGHT_BASE_URL ?? '${url}',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+})
+`
+}
+
+const SMOKE_SPEC = `import { expect, test } from '@playwright/test'
+
+// Smoke test: assert the built site serves and its core UI renders. Deliberately
+// content-agnostic — it validates "the site builds and boots", not copy.
+test('homepage responds and renders the shell', async ({ page }) => {
+  const res = await page.goto('./')
+  expect(res?.ok()).toBeTruthy()
+  await expect(page.locator('.navbar')).toBeVisible()
+})
+
+test('the starter doc renders a heading', async ({ page }) => {
+  await page.goto('./')
+  await expect(page.locator('h1')).toBeVisible()
+})
+`
+
+/**
  * Scaffold the Docusaurus docs site. Writes each file only when missing and
  * returns the relative paths actually written, so `fix docs-site` is safe to
  * re-run. Also drops in the shared sync-changelog script + design tokens.
@@ -352,6 +407,8 @@ export async function generateDocsSite(
 		[`${DOCS_APP}/tsconfig.json`, TSCONFIG],
 		[`${DOCS_APP}/src/css/custom.css`, customCss(accent)],
 		[`${DOCS_APP}/docs/intro.md`, introDoc(meta)],
+		[`${DOCS_APP}/playwright.config.ts`, playwrightConfig(meta)],
+		[`${DOCS_APP}/tests/smoke.spec.ts`, SMOKE_SPEC],
 		['.github/workflows/docs.yml', docsWorkflow(meta)],
 	]
 	for (const [rel, contents] of files) {

--- a/tests/cli/docs-site.test.ts
+++ b/tests/cli/docs-site.test.ts
@@ -27,6 +27,8 @@ describe('generateDocsSite', () => {
 			'apps/docs/src/css/custom.css',
 			'apps/docs/src/css/_jt-tokens.css',
 			'apps/docs/docs/intro.md',
+			'apps/docs/playwright.config.ts',
+			'apps/docs/tests/smoke.spec.ts',
 			'scripts/sync-changelog.mjs',
 			'.github/workflows/docs.yml',
 			'pnpm-workspace.yaml',
@@ -39,6 +41,13 @@ describe('generateDocsSite', () => {
 		const docsPkg = await fs.readJson(join(dir, 'apps/docs/package.json'))
 		expect(docsPkg.name).toBe('@rtorcato/js-tooling-docs')
 		expect(docsPkg.scripts.build).toMatch(/sync-changelog/)
+		expect(docsPkg.scripts['test:e2e']).toBe('playwright test')
+		expect(docsPkg.devDependencies['@playwright/test']).toBeTruthy()
+
+		// Smoke test reuses the shipped preset and targets the site's base path.
+		const pw = await fs.readFile(join(dir, 'apps/docs/playwright.config.ts'), 'utf-8')
+		expect(pw).toContain("import base from '@rtorcato/js-tooling/playwright'")
+		expect(pw).toContain('http://localhost:3000/js-tooling/')
 
 		// Config infers org/repo → GitHub Pages url + baseUrl.
 		const config = await fs.readFile(join(dir, 'apps/docs/docusaurus.config.ts'), 'utf-8')


### PR DESCRIPTION
Phase 2b follow-up to the docs-site generator (#100, merged in #232). When `fix docs-site` scaffolds a site, it now also drops in a minimal Playwright smoke test.

## What

- **`apps/docs/playwright.config.ts`** — reuses the shipped `@rtorcato/js-tooling/playwright` preset, then adds a `webServer` that **builds + serves** the site on `:3000` and sets `baseURL` to the site's GitHub Pages base path (e.g. `http://localhost:3000/<repo>/`) so routes resolve as in production. Single browser (chromium) to keep the install light.
- **`apps/docs/tests/smoke.spec.ts`** — content-agnostic: asserts the homepage responds and the navbar/heading render (validates "the site builds and boots", not copy).
- Docs app gains a `test:e2e` script + `@playwright/test` (and `@rtorcato/js-tooling`) devDeps.

## Opt-in by design

The heavy Playwright browser install is **not** wired into the generated deploy workflow — `test:e2e` is there to run manually or gate behind a CI flag, per the issue's "browsers are a heavy CI install" note.

## Verified

- Unit tests extended (full scaffold now asserts the two new files + the `test:e2e` script + preset reuse + templated baseURL). 442 tests pass; typecheck + biome clean.
- Real CLI: `fix docs-site` on a scratch `@rtorcato/cf-common` repo emits a correct `playwright.config.ts` with `baseURL` `http://localhost:3000/cf-common/` and the smoke spec.

Closes #230