### PR TITLE
docs: sweep core docs for new fix targets & features (#240)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,11 @@ npx @rtorcato/js-tooling doctor --json -d ./existing-repo
 ### Targeted fixes
 
 ```bash
-# Apply one fixer from the list
+# Apply one fixer from the list (run `list --json` for every target)
 npx @rtorcato/js-tooling fix dependabot --yes --json
 npx @rtorcato/js-tooling fix engines --yes --json
+npx @rtorcato/js-tooling fix docs-site --yes --json   # scaffold a Docusaurus docs site under apps/docs
+npx @rtorcato/js-tooling fix bun --yes --json         # Bun runtime/test config
 ```
 
 ## Drift policy (important)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See the [Getting Started guide](https://rtorcato.github.io/js-tooling/guides/get
 | `doctor` | Diagnose an existing project for missing or drifted tooling. | `npx @rtorcato/js-tooling doctor` |
 | `fix [target]` | Apply scaffolders for what `doctor` flagged (`--yes`, `--dry-run`, `--diff`). | `npx @rtorcato/js-tooling fix` |
 
-Every command takes `-d, --directory <path>`; run any with `--help` for its full flags.
+Every command takes `-d, --directory <path>`; run any with `--help` for its full flags. Run `list` (or `list --json`) for the full set of `fix` targets — it's the source of truth. Notable ones include `fix docs-site` (scaffold a [Docusaurus docs site](https://rtorcato.github.io/js-tooling/guides/docs-site/)) and `fix bun` (Bun runtime config).
 
 ## The `.js-tooling.json` lockfile
 

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -22,7 +22,9 @@ npx @rtorcato/js-tooling copy biome     # → biome.json
 npx @rtorcato/js-tooling copy tsconfig  # → tsconfig.json
 ```
 
-**Why only two?** Biome doesn't support configuration extension, so the only way to customise it is to own the file. TypeScript configs also benefit from being local so editors resolve them without hunting up the tree. All other configs (ESLint, Prettier, Vitest, etc.) can be imported or extended directly — see the [Configuration Reference](../reference/biome.md) for usage.
+Available presets: `biome`, `tsconfig`, `bun`, `nx`, `changesets`, `release-please`, `oxlint`, `claude-skill`, `mcp-example`, `docusaurus-sync-changelog`, `docusaurus-theme-tokens`.
+
+`copy` is for configs you must *own* rather than extend — Biome doesn't support configuration extension, and TypeScript configs resolve more reliably when local. Most other configs (ESLint, Prettier, Vitest, etc.) can be imported or extended directly — see the [Configuration Reference](../reference/biome.md) for usage.
 
 ## list / ls
 
@@ -58,8 +60,10 @@ Each row reports one of:
 | Environment | Node version (vs. minimum + LTS patch level), `engines.node` field |
 | Repo baseline | `package.json`, `.editorconfig`, `.nvmrc` / `.node-version`, `.vscode/extensions.json` |
 | Tooling presets | TypeScript, Biome, ESLint, Prettier, Vitest, Commitlint |
-| Automation | Husky, `lint-staged`, semantic-release, knip |
+| Automation | Husky, `lint-staged`, `verify` script, semantic-release, knip |
 | CI / supply chain | GitHub Actions, coverage upload, Dependabot, CodeQL, GitLab CI |
+| Build / docs | TypeDoc, docs site (Docusaurus), size-limit |
+| Ecosystem | Bun runtime, Turborepo / Nx, Tailwind / PostCSS |
 
 After the per-row results, doctor prints a **Next steps:** footer listing the exact `fix` command to run for each non-ok item:
 
@@ -135,32 +139,89 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 
 ### Available targets
 
-| Target | Doctor check it covers | Outputs |
-|---|---|---|
-| `package-json` | `package.json` | adds `@rtorcato/js-tooling` to `devDependencies` |
-| `engines` | `engines.node` | sets `engines.node` (never overwrites) |
-| `editorconfig` | `EditorConfig` | `.editorconfig` |
-| `vscode-extensions` | `VS Code extensions` | `.vscode/extensions.json` (merge-friendly) |
-| `nvmrc` | `Node version pin` | `.nvmrc` |
-| `tsconfig` | `TypeScript` | `tsconfig.json` |
-| `biome` | `Biome` | `biome.json` |
-| `eslint` | `ESLint` | `eslint.config.mjs` |
-| `prettier` | `Prettier` | `prettier.config.mjs` |
-| `vitest` | `Vitest` | `vitest.config.ts` (preserves existing `vitest.setup.ts`) |
-| `commitlint` | `Commitlint` | `commitlint.config.mjs` |
-| `husky` | `Husky` + `lint-staged` | `.husky/pre-commit`, package.json `lint-staged` field (deep-merges) |
-| `semantic-release` | `semantic-release` | `release.config.mjs` (skipped on private packages) |
-| `knip` | `knip` | `knip.json` |
-| `github-actions` | `GitHub Actions` + `Coverage upload` | `.github/workflows/ci.yml` (+ `codecov.yml`; Vitest jobs run `pnpm coverage` and upload to Codecov) |
-| `dependabot` | `Dependabot` | `.github/dependabot.yml` |
-| `codeql` | `CodeQL` | `.github/workflows/codeql.yml` |
-| `attw` | `are-the-types-wrong` | adds `@arethetypeswrong/cli` + an `attw` script (esm-only profile when applicable), wires it into `verify` |
-| `publint` | `publint` | adds `publint` + a `publint --strict` script, wires it into `verify` |
-| `badges` | `README badges` | inserts a status-badge row (CI, npm, coverage, license) into `README.md`, derived from `package.json` |
-| `claude-skill` | _(opt-in)_ | installs the Claude Code skill at `.claude/skills/js-tooling.md` |
-| `cursor-rules` | _(opt-in)_ | installs the rules for Cursor at `.cursor/rules/js-tooling.mdc` |
-| `copilot-instructions` | _(opt-in)_ | upserts the rules block into `.github/copilot-instructions.md` |
-| `agents-md` | _(opt-in)_ | upserts the rules block into `AGENTS.md` (universal) |
+`doctor` and `list --json` are the source of truth — run them for the exact set in the version you have; new targets are added regularly. The current set:
+
+**Core config**
+
+| Target | Scaffolds |
+|---|---|
+| `package-json` | adds `@rtorcato/js-tooling` to `devDependencies` |
+| `engines` | `engines.node` in `package.json` (never overwrites) |
+| `tsconfig` | `tsconfig.json` |
+| `biome` | `biome.json` |
+| `eslint` | `eslint.config.mjs` |
+| `prettier` | `prettier.config.mjs` |
+| `editorconfig` | `.editorconfig` |
+| `vscode-extensions` | `.vscode/extensions.json` (merge-friendly) |
+| `nvmrc` | `.nvmrc` pinned to Node 22 |
+| `node-version` | points CI at `node-version-file: .nvmrc` (one Node source of truth) |
+
+**Testing & verify**
+
+| Target | Scaffolds |
+|---|---|
+| `vitest` | `vitest.config.ts` (preserves existing `vitest.setup.ts`) |
+| `cypress` | `cypress.config.ts` + `cypress/support` + `tests/e2e` boilerplate |
+| `commitlint` | `commitlint.config.mjs` |
+| `husky` | `.husky/pre-commit`, `.husky/pre-push`, package.json `lint-staged` (deep-merges) |
+| `verify` | unified `verify` script (typecheck && lint && tests) in `package.json` |
+| `knip` | `knip.json` |
+
+**Release**
+
+| Target | Scaffolds |
+|---|---|
+| `semantic-release` | `release.config.mjs` + plugins (skipped on private packages) |
+| `changesets` | `.changeset/config.json` (alternative to semantic-release) |
+| `release-please` | `release-please-config.json` + manifest + workflow (alternative) |
+| `attw` | `@arethetypeswrong/cli` + an `attw` script, wired into `verify` |
+| `publint` | `publint` + a `publint --strict` script, wired into `verify` |
+| `badges` | status-badge row (CI, npm, coverage, license) in `README.md` |
+
+**CI & supply chain**
+
+| Target | Scaffolds |
+|---|---|
+| `github-actions` | `.github/workflows/ci.yml` (+ `codecov.yml`; Vitest jobs upload coverage) |
+| `gitlab-ci` | `.gitlab-ci.yml` (lint/typecheck/test/build mirrored from GitHub Actions) |
+| `dependabot` | `.github/dependabot.yml` (weekly npm + actions, grouped) |
+| `renovate` | `renovate.json` (alternative to Dependabot) |
+| `codeql` | `.github/workflows/codeql.yml` (security scanning) |
+| `github-settings` | branch protection + auto-merge + workflow permissions via `gh api` (mutates the remote repo) |
+| `codeowners` | `.github/CODEOWNERS` with commented examples |
+| `community-health` | `CONTRIBUTING.md`, `SECURITY.md`, PR + issue templates |
+| `lockfile` | records current tool choices in the js-tooling lockfile |
+
+**Build, bundling & monorepo**
+
+| Target | Scaffolds |
+|---|---|
+| `bun` | `bunfig.toml` + a Bun-typed `tsconfig.json` for Bun runtime/test users |
+| `rollup` | `rollup.config.mjs` re-exporting the shared library preset |
+| `rolldown` | `rolldown.config.mjs` re-exporting the shared library preset |
+| `size-limit` | a size-limit budget (`.size-limit.cjs`/`.json`) |
+| `treeshake-check` | `apps/treeshake-check` — esbuild + metafile bundle assertion |
+| `turborepo` | `turbo.json` task pipeline (pnpm-workspace monorepos) |
+| `nx` | `nx.json` task orchestrator (alternative to Turborepo) |
+| `tailwind` | Tailwind CSS v4 (`postcss.config.mjs` + `src/styles/globals.css`) |
+| `postcss` | `postcss.config.mjs` with autoprefixer (non-Tailwind pipelines) |
+
+**Docs**
+
+| Target | Scaffolds |
+|---|---|
+| `typedoc` | `typedoc.json` + `.github/workflows/docs.yml` (GitHub Pages) |
+| `docs-site` | a Docusaurus site under `apps/docs` (config/sidebars/tokens + Pages deploy) — see [Docs site](./docs-site.md) |
+
+**AI agents** _(opt-in)_
+
+| Target | Scaffolds |
+|---|---|
+| `ai` | all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example) |
+| `claude-skill` | the Claude Code skill at `.claude/skills/js-tooling.md` |
+| `cursor-rules` | the rules for Cursor at `.cursor/rules/js-tooling.mdc` |
+| `copilot-instructions` | the rules block in `.github/copilot-instructions.md` |
+| `agents-md` | the rules block in `AGENTS.md` (universal) |
 
 ### Typical workflow
 


### PR DESCRIPTION
Closes #240.

Post-merge consistency sweep: the cross-cutting docs had drifted from the CLI surface that landed this cycle (docs-site generator, Bun runtime, and ~20 other `fix` targets).

## Changes

- **`apps/docs/docs/guides/cli.md`** (primary offender) — the "Available targets" table stopped at `agents-md` and was missing ~22 real targets including `docs-site` and `bun`. Replaced it with the **complete current set, grouped**, plus a note that `list --json` / `doctor` is the source of truth so it stops drifting each release. Also fixed the stale `copy` "why only two?" claim (now 11 presets) and refreshed the "What gets checked" groups (Bun, Turborepo/Nx, Tailwind/PostCSS, TypeDoc, docs site).
- **`README.md`** — cross-link `fix docs-site` (→ Docs site guide) and `fix bun`, and point at `list` as the target source of truth.
- **`AGENTS.md`** — added `docs-site`/`bun` to the targeted-fix examples.

## Deliberately left alone

The two skill files (`tooling/claude/js-tooling.md`, `skills/js-tooling/SKILL.md`) both defer to `list --json`, so they're surface-accurate. Their divergences are context-appropriate, not drift: `npm-publish` is a sibling skill only in the plugin bundle (referencing it from the copied consumer skill would dangle), and the issue-safety section fits the consumer copy. Forcing them identical would introduce a broken reference.

## Verification

`docusaurus build` passes with no broken links (Docusaurus throws on broken links by default), so all new cross-links resolve.