### PR TITLE
feat(cli): canonical Dependabot config + auto-merge workflow (#111)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      day: 1
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
@@ -35,7 +34,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      day: 1
     commit-message:
       prefix: ci
       include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,25 +7,29 @@ updates:
       day: 1
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     versioning-strategy: increase
     commit-message:
       prefix: chore
       include: scope
     groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@typescript-eslint/*"
-          - "typescript-eslint"
-      semantic-release:
-        patterns:
-          - "semantic-release"
-          - "@semantic-release/*"
-      types:
-        patterns:
-          - "@types/*"
+      # Safe tier: runtime + dev minor/patch auto-merge on green (see the
+      # dependabot-automerge workflow). Grouped so react/react-dom move together.
+      production-minor:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # Majors batch into one PR per ecosystem — breaking by definition, so
+      # never auto-merged; triaged on the monthly cadence.
+      major-updates:
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -83,7 +83,7 @@ Applies scaffolders for items `doctor` flagged. Without a target it walks every 
 
 ```bash
 npx @rtorcato/js-tooling fix                    # walk all findings interactively
-npx @rtorcato/js-tooling fix dependabot         # scaffold just .github/dependabot.yml
+npx @rtorcato/js-tooling fix dependabot         # scaffold dependabot.yml + auto-merge workflow
 npx @rtorcato/js-tooling fix --yes              # apply every recommended fix without prompts
 npx @rtorcato/js-tooling fix biome --dry-run    # print what would change, write nothing
 npx @rtorcato/js-tooling fix biome --diff       # show the exact diff before confirming
@@ -184,7 +184,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 |---|---|
 | `github-actions` | `.github/workflows/ci.yml` (+ `codecov.yml`; Vitest jobs upload coverage) |
 | `gitlab-ci` | `.gitlab-ci.yml` (lint/typecheck/test/build mirrored from GitHub Actions) |
-| `dependabot` | `.github/dependabot.yml` (weekly npm + actions, grouped) |
+| `dependabot` | `.github/dependabot.yml` (monthly, grouped: production-minor/dev-minor/major-updates) + the `dependabot-automerge.yml` workflow — see [Dependabot strategy](./dependabot-strategy.md) |
 | `renovate` | `renovate.json` (alternative to Dependabot) |
 | `codeql` | `.github/workflows/codeql.yml` (security scanning) |
 | `github-settings` | branch protection + auto-merge + workflow permissions via `gh api` (mutates the remote repo) |

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -94,7 +94,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      day: 1
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
@@ -121,7 +120,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      day: 1
     commit-message:
       prefix: ci
       include: scope

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -906,22 +906,33 @@ async function checkDependabot(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
 		const candidatePath = path.join(dir, candidate)
 		if (await fs.pathExists(candidatePath)) {
-			// A config with no `groups:` predates the grouping/ignore defaults — a lone
-			// react-dom or TypeScript-major bump can never pass CI. Flag as drift so
-			// `fix dependabot` can bring it up to standard.
+			// The canonical standard (apps/docs/docs/guides/dependabot-strategy.md) is
+			// the safe-tier + major-tier grouping plus the auto-merge workflow that
+			// depends on it. Flag any config that predates it so `fix dependabot` can
+			// bring the pair up to standard.
 			const content = await fs.readFile(candidatePath, 'utf8')
-			if (!/^\s*groups:/m.test(content)) {
+			const deltas: string[] = []
+			for (const group of ['production-minor', 'dev-minor', 'major-updates']) {
+				if (!new RegExp(`^\\s*${group}:`, 'm').test(content)) {
+					deltas.push(`missing \`${group}\` group`)
+				}
+			}
+			const automergePath = path.join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+			if (!(await fs.pathExists(automergePath))) {
+				deltas.push('missing dependabot-automerge workflow')
+			}
+			if (deltas.length > 0) {
 				return {
 					check: 'Dependabot',
 					status: 'drift',
-					detail: `${candidate} missing recommended dependency grouping`,
-					hint: 'Run `npx @rtorcato/js-tooling fix dependabot` to add grouping + ignore rules',
+					detail: `${candidate} drifts from canonical (${deltas.join('; ')})`,
+					hint: 'Run `npx @rtorcato/js-tooling fix dependabot` to apply the canonical grouping + auto-merge workflow',
 				}
 			}
 			return {
 				check: 'Dependabot',
 				status: 'ok',
-				detail: `${candidate} found`,
+				detail: `${candidate} + auto-merge workflow`,
 			}
 		}
 	}

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -428,13 +428,14 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'dependabot',
-		description: 'Scaffold .github/dependabot.yml (weekly npm + actions updates, grouped)',
+		description:
+			'Scaffold the canonical .github/dependabot.yml (monthly, grouped: production-minor/dev-minor/major-updates) + the dependabot-automerge workflow',
 		appliesTo: ['Dependabot'],
-		outputs: ['.github/dependabot.yml'],
+		outputs: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
 		canFixDrift: true,
 		async run({ targetDir }) {
-			await generateDependabotConfig(targetDir)
-			return { filesWritten: ['.github/dependabot.yml'] }
+			const filesWritten = await generateDependabotConfig(targetDir)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -218,7 +218,11 @@ export function computeFileList(config: ProjectConfig): string[] {
 	}
 	files.push('.github/workflows/ci.yml')
 	if (config.securityAutomation) {
-		files.push('.github/dependabot.yml', '.github/workflows/codeql.yml')
+		files.push(
+			'.github/dependabot.yml',
+			'.github/workflows/dependabot-automerge.yml',
+			'.github/workflows/codeql.yml'
+		)
 	}
 	if (config.bundler === 'tsup') files.push('tsup.config.ts')
 	else if (config.bundler === 'esbuild') files.push('build.mjs')

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -8,7 +8,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      day: 1
       time: "06:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 5
@@ -39,7 +38,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      day: 1
     commit-message:
       prefix: ci
       include: scope

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -1,53 +1,105 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 
-export async function generateDependabotConfig(targetDir: string) {
-	await fs.ensureDir(path.join(targetDir, '.github'))
-	const filepath = path.join(targetDir, '.github', 'dependabot.yml')
-
-	const content = `version: 2
+/** The canonical dependency-update standard shared by every @rtorcato repo. */
+export const DEPENDABOT_CONFIG = `version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    versioning-strategy: "increase"
+      interval: monthly
+      day: 1
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
     commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    # TypeScript majors remove config options (7.0 dropped baseUrl) — a deliberate
-    # migration, not a dependabot bump. Take minor/patch only.
-    ignore:
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
+      prefix: chore
+      include: scope
     groups:
-      # react + react-dom must move in lockstep (React errors on mismatched versions),
-      # so group them; a lone react-dom bump can never pass CI. Inert in non-React repos.
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      # Fold every other minor/patch bump into one weekly PR to cut noise.
-      # Majors stay as individual PRs so breaking changes are reviewed on their own.
-      minor-and-patch:
-        patterns:
-          - "*"
+      # Safe tier: runtime + dev minor/patch auto-merge on green (see the
+      # dependabot-automerge workflow). Grouped so react/react-dom move together.
+      production-minor:
+        dependency-type: production
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
+      dev-minor:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      # Majors batch into one PR per ecosystem — breaking by definition, so
+      # never auto-merged; triaged on the monthly cadence.
+      major-updates:
+        update-types:
+          - major
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
+      day: 1
     commit-message:
-      prefix: "chore(ci)"
+      prefix: ci
+      include: scope
 `
 
-	await fs.writeFile(filepath, content)
+/**
+ * Auto-merges patch + minor Dependabot PRs once CI is green. Requires branch
+ * protection with required status checks on the target branch — without it,
+ * \`gh pr merge --auto\` never fires. Majors are excluded (they land in the
+ * major-updates group for manual triage).
+ */
+export const DEPENDABOT_AUTOMERGE_WORKFLOW = `name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: \${{ github.event.pull_request.html_url }}
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`
+
+/** Relative paths this generator owns, in a stable order for \`filesWritten\`. */
+export const DEPENDABOT_FILES = [
+	'.github/dependabot.yml',
+	'.github/workflows/dependabot-automerge.yml',
+] as const
+
+/**
+ * Scaffold the canonical Dependabot setup: the grouped \`dependabot.yml\` **and**
+ * the auto-merge workflow. They're a paired unit — the config batches updates
+ * into a safe tier and a major tier, and the workflow merges the safe tier on
+ * green. See \`apps/docs/docs/guides/dependabot-strategy.md\`.
+ */
+export async function generateDependabotConfig(targetDir: string) {
+	await fs.ensureDir(path.join(targetDir, '.github', 'workflows'))
+	await fs.writeFile(path.join(targetDir, '.github', 'dependabot.yml'), DEPENDABOT_CONFIG)
+	await fs.writeFile(
+		path.join(targetDir, '.github', 'workflows', 'dependabot-automerge.yml'),
+		DEPENDABOT_AUTOMERGE_WORKFLOW
+	)
+	return [...DEPENDABOT_FILES]
 }
 
 export async function generateRenovateConfig(targetDir: string) {

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -7,6 +7,7 @@ import {
 	runDoctor,
 	summarize,
 } from '../../../src/cli/commands/doctor.js'
+import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -583,7 +584,7 @@ describe('doctor security checks', () => {
 		expect(dep?.hint).toMatch(/fix dependabot/)
 	})
 
-	it('reports Dependabot ok when dependabot.yml has a groups block', async () => {
+	it('reports Dependabot drift when the config lacks the canonical groups', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.github'))
@@ -591,6 +592,14 @@ describe('doctor security checks', () => {
 			join(dir, '.github', 'dependabot.yml'),
 			'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    groups:\n      all:\n        patterns: ["*"]\n'
 		)
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('drift')
+	})
+
+	it('reports Dependabot ok with the canonical config + auto-merge workflow', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateDependabotConfig(dir)
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('ok')
 	})

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -3,6 +3,10 @@ import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fixCommand, getFixers, listFixers } from '../../../src/cli/commands/fix.js'
+import {
+	DEPENDABOT_AUTOMERGE_WORKFLOW,
+	DEPENDABOT_CONFIG,
+} from '../../../src/cli/generators/security.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 vi.mock('inquirer', () => ({
@@ -12,10 +16,17 @@ vi.mock('inquirer', () => ({
 const promptMock = vi.mocked(inquirer.prompt)
 const newTmpDir = useTmpDir()
 
-// A dependabot.yml with a `groups:` block reads as up-to-date (no drift), so the
-// fixer treats it as already-ok and leaves it alone.
-const GROUPED_DEPENDABOT =
-	'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    groups:\n      all:\n        patterns: ["*"]\n'
+// The canonical config + auto-merge workflow read as up-to-date (no drift), so
+// the fixer treats them as already-ok and leaves them alone. Both files are
+// required — the doctor check flags a config missing either half.
+const GROUPED_DEPENDABOT = DEPENDABOT_CONFIG
+async function seedCanonicalDependabot(dir: string) {
+	await fs.outputFile(join(dir, '.github', 'dependabot.yml'), DEPENDABOT_CONFIG)
+	await fs.outputFile(
+		join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+		DEPENDABOT_AUTOMERGE_WORKFLOW
+	)
+}
 
 async function seedPackageJson(dir: string, extra: Record<string, unknown> = {}) {
 	await fs.writeJson(join(dir, 'package.json'), {
@@ -209,25 +220,28 @@ describe('fix targeted', () => {
 		expect(await fs.pathExists(join(dir, 'renovate.json'))).toBe(true)
 	})
 
-	it('fix dependabot reports already-ok when renovate.json is present', async () => {
+	it('fix dependabot leaves a canonical config untouched (already-ok)', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.writeJson(join(dir, 'renovate.json'), { extends: ['config:recommended'] })
-		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+		await seedCanonicalDependabot(dir)
 		await fixCommand('dependabot', { directory: dir, yes: true })
-		// dependabot.yml should remain untouched (no overwrite) and no error thrown.
+		// Both files already canonical → no overwrite, no error.
 		const yaml = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
 		expect(yaml).toBe(GROUPED_DEPENDABOT)
 	})
 
-	it('fix dependabot upgrades an existing config that lacks grouping', async () => {
+	it('fix dependabot upgrades an existing config that lacks canonical grouping', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), 'version: 2\n')
 		await fixCommand('dependabot', { directory: dir, yes: true })
 		const yaml = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
-		expect(yaml).toMatch(/^\s*groups:/m)
-		expect(yaml).toMatch(/dependency-name: "typescript"/)
+		expect(yaml).toMatch(/^\s*production-minor:/m)
+		expect(yaml).toMatch(/^\s*major-updates:/m)
+		// and it scaffolds the paired auto-merge workflow
+		expect(
+			await fs.pathExists(join(dir, '.github', 'workflows', 'dependabot-automerge.yml'))
+		).toBe(true)
 	})
 
 	it('fix unknown-target exits non-zero', async () => {
@@ -682,8 +696,7 @@ describe('fix targeted', () => {
 	it('returns early when check is already ok', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.ensureDir(join(dir, '.github'))
-		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+		await seedCanonicalDependabot(dir)
 		// Should not call inquirer at all.
 		await fixCommand('dependabot', { directory: dir })
 		expect(promptMock).not.toHaveBeenCalled()
@@ -708,7 +721,10 @@ describe('fix --json', () => {
 				target: 'dependabot',
 				check: 'Dependabot',
 				status: 'applied',
-				filesWritten: ['.github/dependabot.yml'],
+				filesWritten: [
+					'.github/dependabot.yml',
+					'.github/workflows/dependabot-automerge.yml',
+				],
 			})
 		} finally {
 			logSpy.mockRestore()
@@ -785,8 +801,7 @@ describe('fix --json', () => {
 	it('reports already-ok for a check that passes', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.ensureDir(join(dir, '.github'))
-		await fs.writeFile(join(dir, '.github', 'dependabot.yml'), GROUPED_DEPENDABOT)
+		await seedCanonicalDependabot(dir)
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await fixCommand('dependabot', { directory: dir, json: true })

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -21,6 +21,9 @@ describe('generateDependabotConfig', () => {
 		expect(content).toMatch(/package-ecosystem: github-actions/)
 		expect(content).toMatch(/interval: monthly/)
 		expect(content).toMatch(/open-pull-requests-limit: 5/)
+		// `schedule.day` is weekly-only and must be a weekday name — invalid under
+		// monthly, which already runs on the 1st. Guard against it regressing.
+		expect(content).not.toMatch(/^\s*day:/m)
 	})
 
 	it('uses the canonical safe-tier + major-tier grouping', async () => {

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -17,20 +17,33 @@ describe('generateDependabotConfig', () => {
 		const filepath = join(dir, '.github', 'dependabot.yml')
 		expect(await fs.pathExists(filepath)).toBe(true)
 		const content = await fs.readFile(filepath, 'utf-8')
-		expect(content).toMatch(/package-ecosystem: "npm"/)
-		expect(content).toMatch(/package-ecosystem: "github-actions"/)
-		expect(content).toMatch(/interval: "weekly"/)
+		expect(content).toMatch(/package-ecosystem: npm/)
+		expect(content).toMatch(/package-ecosystem: github-actions/)
+		expect(content).toMatch(/interval: monthly/)
+		expect(content).toMatch(/open-pull-requests-limit: 5/)
 	})
 
-	it('groups react + react-dom and minor/patch bumps, and ignores typescript majors', async () => {
+	it('uses the canonical safe-tier + major-tier grouping', async () => {
 		const dir = newTmpDir()
 		await generateDependabotConfig(dir)
 		const content = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
-		expect(content).toMatch(/^\s*groups:/m)
-		expect(content).toMatch(/react-dom/)
-		expect(content).toMatch(/minor-and-patch/)
-		expect(content).toMatch(/dependency-name: "typescript"/)
-		expect(content).toMatch(/version-update:semver-major/)
+		expect(content).toMatch(/^\s*production-minor:/m)
+		expect(content).toMatch(/^\s*dev-minor:/m)
+		expect(content).toMatch(/^\s*major-updates:/m)
+	})
+
+	it('also scaffolds the auto-merge workflow and returns both paths', async () => {
+		const dir = newTmpDir()
+		const written = await generateDependabotConfig(dir)
+		const workflow = join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+		expect(await fs.pathExists(workflow)).toBe(true)
+		const content = await fs.readFile(workflow, 'utf-8')
+		expect(content).toMatch(/dependabot\/fetch-metadata/)
+		expect(content).toMatch(/gh pr merge --auto --squash/)
+		expect(written).toEqual([
+			'.github/dependabot.yml',
+			'.github/workflows/dependabot-automerge.yml',
+		])
 	})
 })
 


### PR DESCRIPTION
Closes #111.

Rolls out the agreed Dependabot standard from `apps/docs/docs/guides/dependabot-strategy.md`, unblocked now that branch protection on `main` is confirmed (#109).

## What changed

- **Generator** (`security.ts`) — `generateDependabotConfig` now emits the **canonical grouped config** (monthly; `production-minor`/`dev-minor` safe tiers + `major-updates` for manual triage; `open-pull-requests-limit: 5`) **and** scaffolds the paired `.github/workflows/dependabot-automerge.yml`. Exposed as `DEPENDABOT_CONFIG` / `DEPENDABOT_AUTOMERGE_WORKFLOW` / `DEPENDABOT_FILES`; returns the written paths.
- **`fix dependabot`** — writes both files (updated `outputs` + `filesWritten`).
- **`doctor`** — `checkDependabot` flags **drift** unless the config carries the three canonical groups *and* the auto-merge workflow exists (was: any `groups:` block passed).
- **`setup`** — `computeFileList` lists the auto-merge workflow so `--dry-run` is accurate.
- **This repo's own `.github/dependabot.yml`** updated to canonical (the auto-merge workflow already matched).
- **Docs** — `cli.md` dependabot row reflects monthly + the workflow.

## Acceptance (#111)

- ✅ patch/minor group PRs auto-merge on green — workflow gated to `semver-patch`/`semver-minor`, and `main` has the required checks (#109).
- ✅ majors arrive as a single `major-updates` PR, never auto-merged.
- ✅ `doctor` flags a drifted config; `fix dependabot` repairs it (config + workflow).

## Out of scope

Rolling the standard out to the sibling repos via `js-tooling fix` — that's the cross-repo follow-up, not this repo's PR.

## Verification

Full test suite (451) + typecheck + lint (`src scripts`) green. Test fixtures updated to the canonical pair; the doctor/fix "already-ok" paths now require both files.