### PR TITLE
fix(cli): Dependabot cooldown to avoid min-release-age CI failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: monthly
       time: "06:00"
       timezone: Etc/UTC
+    # Let brand-new releases settle before opening a PR — keeps grouped bumps
+    # from tripping pnpm's minimumReleaseAge supply-chain check (a same-day
+    # release fails the frozen-lockfile install in CI).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     versioning-strategy: increase
     commit-message:

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -75,7 +75,11 @@ CI. Closing stale PRs is the normal, expected hygiene step — not a loss of wor
 - **Monthly** version updates (batched → low noise). Security updates remain
   always-on and are not subject to the monthly schedule.
 - `open-pull-requests-limit: 5` — grouping makes this ample and caps the backlog.
-- Optional `cooldown: 7 days` so brand-new releases settle before a PR opens.
+- `cooldown: { default-days: 7 }` so brand-new releases settle before a PR
+  opens. This is required, not optional, on repos that enforce pnpm's
+  `minimumReleaseAge` supply-chain policy: without it Dependabot bumps a
+  same-day release into the lockfile and the frozen-lockfile install fails CI
+  (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`), so the PR can never go green.
 
 ## 6. Single source of truth
 
@@ -96,6 +100,8 @@ updates:
       interval: monthly
       time: "06:00"
       timezone: Etc/UTC
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     versioning-strategy: increase
     commit-message:

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -10,6 +10,11 @@ updates:
       interval: monthly
       time: "06:00"
       timezone: Etc/UTC
+    # Let brand-new releases settle before opening a PR — keeps grouped bumps
+    # from tripping pnpm's minimumReleaseAge supply-chain check (a same-day
+    # release fails the frozen-lockfile install in CI).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     versioning-strategy: increase
     commit-message:

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -24,6 +24,9 @@ describe('generateDependabotConfig', () => {
 		// `schedule.day` is weekly-only and must be a weekday name — invalid under
 		// monthly, which already runs on the 1st. Guard against it regressing.
 		expect(content).not.toMatch(/^\s*day:/m)
+		// cooldown lets fresh releases settle so a same-day bump can't trip the
+		// minimumReleaseAge supply-chain check in CI.
+		expect(content).toMatch(/cooldown:\s*\n\s*default-days: 7/)
 	})
 
 	it('uses the canonical safe-tier + major-tier grouping', async () => {


### PR DESCRIPTION
## Problem

The canonical Dependabot config shipped in #111 opened grouped PRs immediately. The repo enforces pnpm's **24h `minimumReleaseAge`** supply-chain policy, so when Dependabot bumped a **same-day** upstream release into the lockfile, the `--frozen-lockfile` install failed CI with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — and the PR could never go green.

Surfaced this cycle on the `dev-minor` (#256) and `major-updates` (#257) group PRs: both bumped `@typescript-eslint/*` 8.65.0 etc., published ~3h before the run.

## Fix

Add `cooldown: { default-days: 7 }` to the npm ecosystem so Dependabot waits for releases to settle before opening a PR — comfortably clearing the 24h policy. Applied to:
- the `generateDependabotConfig` generator (`security.ts`)
- this repo's `.github/dependabot.yml`
- the strategy guide — cooldown is now documented as **required** (not optional) on repos enforcing `minimumReleaseAge`, with the failure mode spelled out.

## Verification

`security.test.ts` asserts the generated config carries the cooldown; full generator suite green.

## Follow-up

The two currently-red Dependabot PRs (#256, #257) were opened before this fix — their bumps are still <24h old. They'll be closed and recreated (settled) once Dependabot next runs with the cooldown in place; nothing to salvage in them.