### PR TITLE
docs: consume @rtorcato/shared-docs for the sibling-family list

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,21 +1,13 @@
 import type * as Preset from '@docusaurus/preset-classic'
 import type { Config } from '@docusaurus/types'
+import { GITHUB_PROFILE, projectFamilyItems } from '@rtorcato/shared-docs'
 import { themes as prismThemes } from 'prism-react-renderer'
 
-// The @rtorcato open-source family. Surfaced as a navbar "Projects" dropdown
-// (Docusaurus renders navbar items in the mobile menu too) and in the footer,
-// so every sibling site cross-links to the rest. Keep in sync across repos.
-const GITHUB_PROFILE = 'https://github.com/rtorcato'
-const PROJECT_FAMILY = [
-  { label: 'js-common', href: 'https://rtorcato.github.io/js-common/' },
-  { label: 'api-common', href: 'https://rtorcato.github.io/api-common/' },
-  { label: 'browser-common', href: 'https://rtorcato.github.io/browser-common/' },
-  { label: 'db-common', href: 'https://rtorcato.github.io/db-common/' },
-  { label: 'cf-common', href: 'https://rtorcato.github.io/cf-common/' },
-  { label: 'react-common', href: 'https://github.com/rtorcato/react-common' },
-  { label: 'swift-common', href: 'https://rtorcato.github.io/swift-common/' },
-  { label: 'js-tooling', href: 'https://rtorcato.github.io/js-tooling/' },
-]
+// The @rtorcato open-source family, from the shared single source of truth
+// (@rtorcato/shared-docs). Surfaced as a navbar "Projects" dropdown (Docusaurus
+// renders navbar items in the mobile menu too) and in the footer, so every
+// sibling site cross-links to the rest.
+const PROJECT_FAMILY = projectFamilyItems()
 
 const config: Config = {
   title: 'js-tooling',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,6 +29,7 @@
 		"@docusaurus/module-type-aliases": "^3.10.2",
 		"@docusaurus/tsconfig": "^3.10.2",
 		"@docusaurus/types": "^3.10.2",
+		"@rtorcato/shared-docs": "github:rtorcato/shared-docs",
 		"@types/react": "^19.0.0",
 		"typescript": "~5.6.3"
 	},

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -3,6 +3,7 @@ import CodeBlock from '@theme/CodeBlock'
 import Layout from '@theme/Layout'
 import TabItem from '@theme/TabItem'
 import Tabs from '@theme/Tabs'
+import { siblings } from '@rtorcato/shared-docs'
 import clsx from 'clsx'
 import type { ReactElement } from 'react'
 import InstallTabs from '@site/src/components/InstallTabs'
@@ -341,69 +342,9 @@ function Categories(): ReactElement {
 	)
 }
 
-type Sibling = {
-	name: string
-	tagline: string
-	/** Prefer the published docs site; fall back to the GitHub repo when there isn't one yet. */
-	href: string
-	/** Short label rendered in the card's top-right indicating where the link goes. */
-	dest: 'Docs' | 'GitHub'
-	/** Each project's brand hue used to tint the card title. */
-	accent: string
-}
-
-const SIBLINGS: Sibling[] = [
-	{
-		name: '@rtorcato/api-common',
-		tagline:
-			'Framework-agnostic building blocks for Node.js APIs — errors, auth, rate limiting, OpenAPI, Express + Hono.',
-		href: 'https://rtorcato.github.io/api-common/',
-		dest: 'Docs',
-		accent: '#e879f9',
-	},
-	{
-		name: '@rtorcato/browser-common',
-		tagline: 'Tree-shakeable TypeScript wrappers around 40+ browser Web APIs — one subpath per spec.',
-		href: 'https://rtorcato.github.io/browser-common/',
-		dest: 'Docs',
-		accent: '#58a6ff',
-	},
-	{
-		name: '@rtorcato/js-common',
-		tagline: 'Tree-shakeable TypeScript utilities — tiny bundles, full type safety, CLI included.',
-		href: 'https://rtorcato.github.io/js-common/',
-		dest: 'Docs',
-		accent: '#f2cc60',
-	},
-	{
-		name: '@rtorcato/db-common',
-		tagline: 'Shared, tree-shakeable TypeScript database utilities for Node projects.',
-		href: 'https://rtorcato.github.io/db-common/',
-		dest: 'Docs',
-		accent: '#a78bfa',
-	},
-	{
-		name: '@rtorcato/cf-common',
-		tagline: 'Common helpers for Cloudflare developers — Workers, Pages, and the edge runtime.',
-		href: 'https://rtorcato.github.io/cf-common/',
-		dest: 'Docs',
-		accent: '#f6821f',
-	},
-	{
-		name: '@rtorcato/react-common',
-		tagline: 'Published React 19 component library — shared UI primitives.',
-		href: 'https://github.com/rtorcato/react-common',
-		dest: 'GitHub',
-		accent: '#818cf8',
-	},
-	{
-		name: '@rtorcato/swift-common',
-		tagline: 'SwiftUI package of reusable views and helpers to build apps faster.',
-		href: 'https://rtorcato.github.io/swift-common/',
-		dest: 'Docs',
-		accent: '#ff6f4d',
-	},
-]
+// Sibling projects from the shared single source of truth
+// (@rtorcato/shared-docs), excluding js-tooling itself.
+const SIBLINGS = siblings('@rtorcato/js-tooling')
 
 function Siblings(): ReactElement {
 	return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       '@docusaurus/types':
         specifier: ^3.10.2
         version: 3.10.2(esbuild@0.28.1)(postcss@8.5.19)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rtorcato/shared-docs':
+        specifier: github:rtorcato/shared-docs
+        version: https://codeload.github.com/rtorcato/shared-docs/tar.gz/3b9778f59b1a07055fab1f4e9cfa4a0446d48785(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -3145,6 +3148,14 @@ packages:
     resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
+
+  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/3b9778f59b1a07055fab1f4e9cfa4a0446d48785':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/rtorcato/shared-docs/tar.gz/3b9778f59b1a07055fab1f4e9cfa4a0446d48785}
+    version: 1.0.0
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -14347,6 +14358,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
+
+  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/3b9778f59b1a07055fab1f4e9cfa4a0446d48785(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@rtsao/scc@1.1.0': {}
 


### PR DESCRIPTION
Closes #178.

Replaces the two locally duplicated `@rtorcato` family lists in the docs site with the shared single source of truth ([@rtorcato/shared-docs](https://github.com/rtorcato/shared-docs)), so the family stops drifting across sibling repos. Mirrors the data-consumption half of cf-common#87.

## Changes
- Add the `github:rtorcato/shared-docs` git dep to `apps/docs` (not on npm; ships committed `dist/`, so no install-time build).
- **`docusaurus.config.ts`** — `const PROJECT_FAMILY = projectFamilyItems()`; import `GITHUB_PROFILE` from shared-docs. Drops the local 8-entry array + `GITHUB_PROFILE` const.
- **`src/pages/index.tsx`** — `const SIBLINGS = siblings('@rtorcato/js-tooling')`; drops the local `Sibling` type + 7-entry array. Local rendering unchanged.

Net **-77** source lines.

## Rendered effect
Not byte-identical (by design): the nav dropdown, footer, and sibling grid now also include **supabase-common** (the local lists omitted it) and pick up shared-docs' cf-common tagline/accent.

## Verification
- `pnpm --filter docs build` succeeds; both the Node-side config import and browser-side page import resolve; supabase-common renders in the built HTML.
- Lockfile diff is minimal (+16 lines: just the pinned git dep).

## Out of scope
Shared components (`InstallTabs` + mobile-sidebar swizzles) — a later phase, per the issue.

## Note (pre-existing, unrelated)
`apps/docs` `pnpm typecheck` errors on `ignoreDeprecations: "6.0"` in `tsconfig.json` — reproduces on `main` without this change, and docs CI runs `build` (not that typecheck), so it doesn't gate.