### PR TITLE
feat(cli): fix ai documents npx skills install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,14 @@ Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+<!-- js-tooling:skills:start -->
+## Install the skills (`npx skills`)
+
+Any agent that supports the [`skills`](https://www.npmjs.com/package/skills) CLI can install this repo's skills straight from GitHub — no clone, no package install:
+
+```bash
+npx skills add https://github.com/rtorcato/js-tooling --skill js-tooling
+npx skills add https://github.com/rtorcato/js-tooling --skill npm-publish
+```
+<!-- js-tooling:skills:end -->

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -20,6 +20,7 @@ All of it derives from **one source of truth** — the shipped Claude skill
 | `.github/copilot-instructions.md` | GitHub Copilot | Merge-safe delimited block |
 | `.claude/skills/js-tooling.md` | Claude Code skill | Copied verbatim |
 | `.mcp.json.example` | Model Context Protocol | Commented template (see below) |
+| `README.md` | Your repo's own skills | Merge-safe block, only if this repo ships `skills/<name>/SKILL.md` |
 
 Every file is either a merge-safe **delimited block** (`<!-- js-tooling:start -->`
 … `<!-- js-tooling:end -->`) or a `.example`, so re-running never clobbers your
@@ -42,6 +43,32 @@ npx @rtorcato/js-tooling fix ai
 `doctor` reports whether they're present (`AI setup` → `ok` /
 `optional-missing`), and the choice is recorded in `.js-tooling.json`, so
 `doctor` won't nag if you intentionally opt out.
+
+## Install a skill in one command
+
+The skills ship in this repo under `skills/<name>/SKILL.md`, the standard layout
+the [`skills`](https://www.npmjs.com/package/skills) CLI reads. So any agent that
+supports it can install them straight from GitHub — no clone, no `js-tooling`
+install needed:
+
+```bash
+# The tooling skill (audit / fix / scaffold via the CLI)
+npx skills add https://github.com/rtorcato/js-tooling --skill js-tooling
+
+# The npm-publish skill
+npx skills add https://github.com/rtorcato/js-tooling --skill npm-publish
+```
+
+This drops the skill into your agent's skills directory (e.g.
+`.claude/skills/`). Use this when you want the skill on its own; use
+`fix ai` (above) when you want the full set of agent rule files scaffolded
+together.
+
+If **your own** repo ships skills under `skills/<name>/SKILL.md`, `fix ai`
+auto-writes this same install section into your `README.md` — one
+`npx skills add` command per skill, with the GitHub URL derived from
+`package.json`'s `repository`. It's a merge-safe delimited block, so your own
+README content is never touched, and repos without a `skills/` dir get nothing.
 
 ## CLAUDE.md is a pointer, not a copy
 

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -906,6 +906,8 @@ const FIXERS: Fixer[] = [
 			'.github/copilot-instructions.md',
 			'.claude/skills/js-tooling.md',
 			'.mcp.json.example',
+			// Only written when the repo ships its own skills/<name>/SKILL.md.
+			'README.md',
 		],
 		// Every output is a delimited-block upsert or a `.example` file — existing
 		// user content is never clobbered.

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import { copyPreset, getPackageRoot } from '../utils/copy-preset.js'
+import { installSkillsInstallDocs } from './skills-install.js'
 
 /**
  * All agent rule files are generated from one source of truth — the shipped
@@ -33,14 +34,19 @@ async function readSkill(): Promise<Skill> {
  * existing block, appends if the file exists without one, creates otherwise.
  * Never clobbers surrounding content.
  */
-export async function upsertBlock(filePath: string, body: string): Promise<void> {
-	const block = `${BLOCK_START}\n${body}\n${BLOCK_END}`
+export async function upsertBlock(
+	filePath: string,
+	body: string,
+	markers: { start: string; end: string } = { start: BLOCK_START, end: BLOCK_END }
+): Promise<void> {
+	const { start: startMarker, end: endMarker } = markers
+	const block = `${startMarker}\n${body}\n${endMarker}`
 	if (await fs.pathExists(filePath)) {
 		const existing = await fs.readFile(filePath, 'utf8')
-		const start = existing.indexOf(BLOCK_START)
-		const end = existing.indexOf(BLOCK_END)
+		const start = existing.indexOf(startMarker)
+		const end = existing.indexOf(endMarker)
 		if (start !== -1 && end !== -1) {
-			const next = existing.slice(0, start) + block + existing.slice(end + BLOCK_END.length)
+			const next = existing.slice(0, start) + block + existing.slice(end + endMarker.length)
 			await fs.writeFile(filePath, next)
 			return
 		}
@@ -78,6 +84,10 @@ export async function installAiSetup(targetDir: string): Promise<string[]> {
 	written.push(await installAgentRules(targetDir, 'copilot'))
 	written.push((await copyPreset('claude-skill', targetDir)).target)
 	written.push((await copyPreset('mcp-example', targetDir)).target)
+	// If this repo ships its own skills (skills/<name>/SKILL.md), document their
+	// one-command `npx skills add` install in README.md. No-op for repos without.
+	const skillsDoc = await installSkillsInstallDocs(targetDir)
+	if (skillsDoc) written.push(skillsDoc)
 	return written
 }
 

--- a/src/cli/generators/skills-install.ts
+++ b/src/cli/generators/skills-install.ts
@@ -1,0 +1,68 @@
+// Documents the one-command `npx skills add` install for every agent skill a
+// repo ships under `skills/<name>/SKILL.md`. All values are derived from the
+// repo (its skills dir + package.json `repository`) so it works for any consumer.
+
+import path from 'node:path'
+import fs from 'fs-extra'
+import { upsertBlock } from './agent-rules.js'
+import { parseRepository } from './badges.js'
+
+export const SKILLS_DOCS_START = '<!-- js-tooling:skills:start -->'
+export const SKILLS_DOCS_END = '<!-- js-tooling:skills:end -->'
+
+/** Names of `skills/<name>/` directories that actually contain a SKILL.md. */
+export async function findSkills(targetDir: string): Promise<string[]> {
+	const skillsDir = path.join(targetDir, 'skills')
+	if (!(await fs.pathExists(skillsDir))) return []
+	const entries = await fs.readdir(skillsDir, { withFileTypes: true })
+	const names: string[] = []
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue
+		if (await fs.pathExists(path.join(skillsDir, entry.name, 'SKILL.md'))) names.push(entry.name)
+	}
+	return names.sort()
+}
+
+/**
+ * Build the README section body (inner content, no delimiters) listing one
+ * `npx skills add` command per skill. Returns '' when there are no skills.
+ */
+export function buildSkillsInstallBody(owner: string, repo: string, skills: string[]): string {
+	if (skills.length === 0) return ''
+	const commands = skills
+		.map((s) => `npx skills add https://github.com/${owner}/${repo} --skill ${s}`)
+		.join('\n')
+	const plural = skills.length > 1 ? 's' : ''
+	return [
+		`## Install the skill${plural} (\`npx skills\`)`,
+		'',
+		`Any agent that supports the [\`skills\`](https://www.npmjs.com/package/skills) CLI can install this repo's skill${plural} straight from GitHub — no clone, no package install:`,
+		'',
+		'```bash',
+		commands,
+		'```',
+	].join('\n')
+}
+
+/**
+ * Add or refresh a "Install the skill" block in README.md. No-op (returns null)
+ * when the repo ships no skills or package.json has no GitHub `repository` to
+ * build the URL from. Merge-safe: only the delimited block is touched.
+ */
+export async function installSkillsInstallDocs(targetDir: string): Promise<string | null> {
+	const skills = await findSkills(targetDir)
+	if (skills.length === 0) return null
+	const pkgPath = path.join(targetDir, 'package.json')
+	const pkg = (await fs.pathExists(pkgPath))
+		? ((await fs.readJson(pkgPath).catch(() => null)) as Record<string, unknown> | null)
+		: null
+	const parsed = parseRepository(pkg?.repository)
+	if (!parsed) return null
+	const body = buildSkillsInstallBody(parsed.owner, parsed.repo, skills)
+	if (!body) return null
+	await upsertBlock(path.join(targetDir, 'README.md'), body, {
+		start: SKILLS_DOCS_START,
+		end: SKILLS_DOCS_END,
+	})
+	return 'README.md'
+}

--- a/tests/cli/generators/skills-install.test.ts
+++ b/tests/cli/generators/skills-install.test.ts
@@ -1,0 +1,71 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import {
+	buildSkillsInstallBody,
+	installSkillsInstallDocs,
+} from '../../../src/cli/generators/skills-install.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+async function scaffoldSkill(dir: string, name: string): Promise<void> {
+	await fs.ensureDir(join(dir, 'skills', name))
+	await fs.writeFile(join(dir, 'skills', name, 'SKILL.md'), `---\nname: ${name}\n---\n`)
+}
+
+describe('buildSkillsInstallBody', () => {
+	it('emits one npx skills add command per skill, singular vs plural heading', () => {
+		expect(buildSkillsInstallBody('rtorcato', 'browser-common', ['browser-common'])).toContain(
+			'npx skills add https://github.com/rtorcato/browser-common --skill browser-common'
+		)
+		const multi = buildSkillsInstallBody('rtorcato', 'js-tooling', ['js-tooling', 'npm-publish'])
+		expect(multi).toContain('## Install the skills')
+		expect(multi).toContain('--skill js-tooling')
+		expect(multi).toContain('--skill npm-publish')
+	})
+
+	it('returns empty for no skills', () => {
+		expect(buildSkillsInstallBody('rtorcato', 'x', [])).toBe('')
+	})
+})
+
+describe('installSkillsInstallDocs', () => {
+	it('no-ops when the repo ships no skills', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'x',
+			repository: 'github:rtorcato/x',
+		})
+		expect(await installSkillsInstallDocs(dir)).toBeNull()
+		expect(await fs.pathExists(join(dir, 'README.md'))).toBe(false)
+	})
+
+	it('no-ops when package.json has no GitHub repository', async () => {
+		const dir = newTmpDir()
+		await scaffoldSkill(dir, 'browser-common')
+		await fs.writeJson(join(dir, 'package.json'), { name: 'browser-common' })
+		expect(await installSkillsInstallDocs(dir)).toBeNull()
+	})
+
+	it('upserts a merge-safe block into README, idempotently', async () => {
+		const dir = newTmpDir()
+		await scaffoldSkill(dir, 'browser-common')
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'browser-common',
+			repository: 'git+https://github.com/rtorcato/browser-common.git',
+		})
+		await fs.writeFile(join(dir, 'README.md'), '# browser-common\n\nMy notes.\n')
+
+		expect(await installSkillsInstallDocs(dir)).toBe('README.md')
+		await installSkillsInstallDocs(dir) // run twice
+
+		const readme = await fs.readFile(join(dir, 'README.md'), 'utf8')
+		expect(readme).toContain('# browser-common')
+		expect(readme).toContain('My notes.')
+		expect(readme).toContain(
+			'npx skills add https://github.com/rtorcato/browser-common --skill browser-common'
+		)
+		expect(readme.match(/<!-- js-tooling:skills:start -->/g)).toHaveLength(1)
+	})
+})


### PR DESCRIPTION
## What

Teach `fix ai` to document the one-command `npx skills add` install for any repo that ships its own agent skills.

When a repo has `skills/<name>/SKILL.md` directories, `fix ai` now upserts a merge-safe block into `README.md` with one `npx skills add https://github.com/<owner>/<repo> --skill <name>` command per skill — the GitHub URL derived from `package.json` `repository`. Repos without a `skills/` dir get nothing (no-op).

This makes the skills-install docs DRY across the whole family: every `*-common` library self-documents its skill install on `fix ai` instead of hand-editing each README.

## Changes

- **New generator** `src/cli/generators/skills-install.ts` — `findSkills`, `buildSkillsInstallBody`, `installSkillsInstallDocs`
- Generalized `upsertBlock` to accept custom markers (reused, not duplicated) for the `js-tooling:skills` delimited block
- Wired into `installAiSetup`; added `README.md` to the `ai` fixer outputs
- Documented in the AI Setup guide; js-tooling's own README block is now generator-owned (replaces the earlier hand-written section)
- Unit tests for the generator

## Testing

- `vitest run` on generators + fix suite — all green (268 tests)
- `tsc --noEmit` clean, Biome clean (pre-commit passed)

## Notes

The block is appended at end-of-file (consistent across all repos `fix ai` touches) and is merge-safe/idempotent — re-running updates it in place.