### PR TITLE
feat(docs): make sync-changelog target configurable (Fumadocs-ready)

### DIFF
--- a/scripts/sync-changelog.mjs
+++ b/scripts/sync-changelog.mjs
@@ -1,20 +1,27 @@
-// Canonical sync-changelog for @rtorcato/* Docusaurus sites (shipped by
+// Canonical sync-changelog for @rtorcato/* docs sites (shipped by
 // @rtorcato/js-tooling — copy via `js-tooling copy docusaurus-sync-changelog`).
 //
-// Copies the root CHANGELOG.md into apps/docs/docs/changelog.md with Docusaurus
+// Copies the root CHANGELOG.md into the docs site's changelog page with
 // frontmatter, so semantic-release keeps owning a single canonical changelog
 // while the docs site renders it in-nav. The output file is gitignored — it is
-// regenerated on every docs build (wire it into apps/docs's `build`/`start`
+// regenerated on every docs build (wire it into the docs app's `build`/`start`
 // scripts; pnpm 8 doesn't run `pre*` hooks reliably, so chain it explicitly).
+//
+// The target defaults to Docusaurus's `apps/docs/docs/changelog.md`. Override
+// with the CHANGELOG_TARGET env var (path relative to the repo root) for other
+// layouts — e.g. a Fumadocs content root:
+//   CHANGELOG_TARGET=apps/web/content/docs/changelog.mdx node scripts/sync-changelog.mjs
+// The title/description frontmatter is framework-neutral (both Docusaurus and
+// Fumadocs read it), so only the path changes between frameworks.
 
-import { readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(here, '..')
 const source = resolve(repoRoot, 'CHANGELOG.md')
-const target = resolve(repoRoot, 'apps/docs/docs/changelog.md')
+const target = resolve(repoRoot, process.env.CHANGELOG_TARGET ?? 'apps/docs/docs/changelog.md')
 
 const frontmatter = `---
 title: Changelog
@@ -30,5 +37,6 @@ try {
 	body = '# Changelog\n\nNo releases recorded yet.\n'
 }
 
+mkdirSync(dirname(target), { recursive: true })
 writeFileSync(target, frontmatter + body)
 console.log(`sync-changelog: wrote ${target}`)

--- a/tooling/docusaurus/sync-changelog.mjs
+++ b/tooling/docusaurus/sync-changelog.mjs
@@ -1,20 +1,27 @@
-// Canonical sync-changelog for @rtorcato/* Docusaurus sites (shipped by
+// Canonical sync-changelog for @rtorcato/* docs sites (shipped by
 // @rtorcato/js-tooling — copy via `js-tooling copy docusaurus-sync-changelog`).
 //
-// Copies the root CHANGELOG.md into apps/docs/docs/changelog.md with Docusaurus
+// Copies the root CHANGELOG.md into the docs site's changelog page with
 // frontmatter, so semantic-release keeps owning a single canonical changelog
 // while the docs site renders it in-nav. The output file is gitignored — it is
-// regenerated on every docs build (wire it into apps/docs's `build`/`start`
+// regenerated on every docs build (wire it into the docs app's `build`/`start`
 // scripts; pnpm 8 doesn't run `pre*` hooks reliably, so chain it explicitly).
+//
+// The target defaults to Docusaurus's `apps/docs/docs/changelog.md`. Override
+// with the CHANGELOG_TARGET env var (path relative to the repo root) for other
+// layouts — e.g. a Fumadocs content root:
+//   CHANGELOG_TARGET=apps/web/content/docs/changelog.mdx node scripts/sync-changelog.mjs
+// The title/description frontmatter is framework-neutral (both Docusaurus and
+// Fumadocs read it), so only the path changes between frameworks.
 
-import { readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(here, '..')
 const source = resolve(repoRoot, 'CHANGELOG.md')
-const target = resolve(repoRoot, 'apps/docs/docs/changelog.md')
+const target = resolve(repoRoot, process.env.CHANGELOG_TARGET ?? 'apps/docs/docs/changelog.md')
 
 const frontmatter = `---
 title: Changelog
@@ -30,5 +37,6 @@ try {
 	body = '# Changelog\n\nNo releases recorded yet.\n'
 }
 
+mkdirSync(dirname(target), { recursive: true })
 writeFileSync(target, frontmatter + body)
 console.log(`sync-changelog: wrote ${target}`)


### PR DESCRIPTION
Phase 0 of the docs-framework work — refs #261.

## What

The shared `sync-changelog.mjs` hardcoded the Docusaurus content path (`apps/docs/docs/changelog.md`). This reads the target from a **`CHANGELOG_TARGET`** env var, defaulting to that same path, and `mkdir -p`s the parent so a fresh content root works.

Lets a Fumadocs (or any) docs site point the shared changelog sync at its own content root:

```bash
CHANGELOG_TARGET=apps/web/content/docs/changelog.mdx node scripts/sync-changelog.mjs
```

The `title`/`description` frontmatter is framework-neutral (both Docusaurus and Fumadocs read it), so **only the path** differs — no framework enum needed in the script.

## Why this slice

Per the investigation on #261, the concrete, non-speculative pain was this hardcoded path. It's backward-compatible (default unchanged) and independent of the larger architecture work (shared-docs `/fumadocs` adapter + a js-tooling framework selector), which is deferred to Phase 1/2.

## Changed

- `tooling/docusaurus/sync-changelog.mjs` (the shipped preset)
- `scripts/sync-changelog.mjs` (this repo's dogfooded copy — kept identical)

## Testing

- Default run → still writes `apps/docs/docs/changelog.md` (gitignored, no tracked diff)
- `CHANGELOG_TARGET=…/content/docs/changelog.mdx` → creates the nested dir and writes there
- Biome + typecheck clean (pre-commit passed)

## Note

No behavior change for current consumers. The preset key stays `docusaurus-sync-changelog` for now; renaming it framework-neutral can come with the Phase 2 framework selector.