### PR TITLE
feat(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,12 +183,7 @@ jobs:
             echo "✅ GITHUB_TOKEN is available"
           fi
 
-          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "⚠️  NPM_TOKEN is not set - required for publishing"
-            echo "   Add NPM_TOKEN to repository secrets for publishing to work"
-          else
-            echo "✅ NPM_TOKEN is available"
-          fi
+          # npm publish uses OIDC trusted publishing (no NPM_TOKEN secret needed).
 
   # Testing — run on every supported Node major
   test:
@@ -359,8 +354,9 @@ jobs:
         run: pnpm run build-cli
 
       - name: 🚀 Run semantic-release
+        # Publishes to npm via OIDC trusted publishing — no NPM_TOKEN. Requires
+        # the `id-token: write` permission above + a trusted publisher configured
+        # for the package on npmjs.com (Settings → Trusted Publisher).
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -295,10 +295,11 @@ ${
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: 🚀 Run semantic-release
+        # Publishes to npm via OIDC trusted publishing — no NPM_TOKEN. Requires
+        # the \`id-token: write\` permission above + a trusted publisher configured
+        # for the package on npmjs.com (Settings → Trusted Publisher).
         env:
           GITHUB_TOKEN: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx semantic-release`
 		: ''
 }

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -236,10 +236,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: 🚀 Run semantic-release
+        # Publishes to npm via OIDC trusted publishing — no NPM_TOKEN. Requires
+        # the \`id-token: write\` permission above + a trusted publisher configured
+        # for the package on npmjs.com (Settings → Trusted Publisher).
         env:
           GITHUB_TOKEN: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 "
 `;

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -167,7 +167,9 @@ describe('generateGitHubActions', () => {
 		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
 		expect(content).toContain('release:')
 		expect(content).toContain('semantic-release')
-		expect(content).toContain('NPM_TOKEN')
+		// Publishes via OIDC trusted publishing — id-token permission, no NPM_TOKEN secret.
+		expect(content).toContain('id-token: write')
+		expect(content).not.toContain('secrets.NPM_TOKEN')
 	})
 
 	it('omits release job when semanticRelease is false', async () => {

--- a/tooling/semantic-release/github.mjs
+++ b/tooling/semantic-release/github.mjs
@@ -51,11 +51,13 @@ export default {
 				changelogFile: 'CHANGELOG.md',
 			},
 		],
-		// npm publishing is opt-in via NPM_TOKEN: a repo that provides the token
-		// (e.g. js-tooling's own CI) publishes; one that doesn't (GitHub-releases
-		// only) gets a green release instead of an EINVALIDNPMTOKEN failure. The
-		// version in package.json is still bumped either way.
-		['@semantic-release/npm', { npmPublish: Boolean(process.env.NPM_TOKEN), pkgRoot: '.' }],
+		// npm publishing goes through OIDC trusted publishing — no NPM_TOKEN. The
+		// release job runs with `id-token: write` and npm (>=11.5.1) authenticates
+		// via the GitHub Actions trusted publisher configured on the package, and
+		// gets provenance for free. Private packages are skipped automatically by
+		// @semantic-release/npm; a public repo that only wants GitHub releases can
+		// opt out with NPM_PUBLISH=false (the version in package.json is still bumped).
+		['@semantic-release/npm', { npmPublish: process.env.NPM_PUBLISH !== 'false', pkgRoot: '.' }],
 		[
 			'@semantic-release/git',
 			{

--- a/tooling/semantic-release/index.mjs
+++ b/tooling/semantic-release/index.mjs
@@ -52,11 +52,13 @@ export default {
 				changelogFile: 'CHANGELOG.md',
 			},
 		],
-		// npm publishing is opt-in via NPM_TOKEN: a repo that provides the token
-		// publishes; one that doesn't (GitLab releases only) gets a green release
-		// instead of an EINVALIDNPMTOKEN failure. The version in package.json is
-		// still bumped either way.
-		['@semantic-release/npm', { npmPublish: Boolean(process.env.NPM_TOKEN), pkgRoot: '.' }],
+		// npm publishing goes through OIDC trusted publishing — no NPM_TOKEN. The
+		// release job runs with `id-token: write` and npm (>=11.5.1) authenticates
+		// via the CI trusted publisher configured on the package, and gets
+		// provenance for free. Private packages are skipped automatically by
+		// @semantic-release/npm; a repo that only wants VCS releases can opt out
+		// with NPM_PUBLISH=false (the version in package.json is still bumped).
+		['@semantic-release/npm', { npmPublish: process.env.NPM_PUBLISH !== 'false', pkgRoot: '.' }],
 		[
 			'@semantic-release/git',
 			{


### PR DESCRIPTION
Closes #201 (js-tooling scaffold portion).

## What

Switches the release path off long-lived `NPM_TOKEN` secrets to **npm OIDC trusted publishing**. The trusted publisher for `@rtorcato/js-tooling` is already configured on npmjs.com (`rtorcato/js-tooling` · `ci.yml` · `npm publish`), and the release job already has `id-token: write`. The pinned tools already support it (`semantic-release ^25`, `@semantic-release/npm ^13`).

## Changes

- **semantic-release presets** (`tooling/semantic-release/{github,index}.mjs`): the npm plugin no longer gates on `NPM_TOKEN`. `npmPublish` now defaults `true` — private packages are auto-skipped by the plugin; a public repo that only wants VCS releases opts out with `NPM_PUBLISH=false`.
- **`.github/workflows/ci.yml`**: drop `NPM_TOKEN` / `NODE_AUTH_TOKEN` from the semantic-release step and the stale "NPM_TOKEN is not set" check. Keep `registry-url` + `id-token: write`.
- **`github-actions` generator**: same removal, so **scaffolded consumer workflows get OIDC by default**.
- Tests + snapshot updated to assert `id-token: write` and no `secrets.NPM_TOKEN`.

## Verified

- Full suite green (452 tests), typecheck + Biome clean, generator snapshot regenerated.
- npm authenticates via OIDC (no token); **provenance** is emitted automatically.

## Rollout note (rest of #201)

This is the scaffold + js-tooling's own release. For each other published repo: configure a Trusted Publisher on npmjs.com, run `fix github-actions` to pick up the OIDC workflow, verify a release, then delete the `NPM_TOKEN` secret. Sequencing matters — configure the trusted publisher **before** removing the token, or the in-between release can't auth.

Follow-up (not in this PR): a `doctor` check that flags a release workflow still wiring `NPM_TOKEN` as drift.