### PR TITLE
feat(doctor): flag release workflows still using NPM_TOKEN as drift

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -902,6 +902,41 @@ async function checkReleaseToken(dir: string): Promise<CheckResult> {
 	}
 }
 
+// Flags a release workflow still authenticating npm publish with a long-lived
+// NPM_TOKEN secret instead of OIDC trusted publishing (#201). npm is deprecating
+// 2FA-bypass tokens; OIDC needs no secret and adds provenance for free. Only
+// relevant for public packages that actually publish to npm.
+async function checkNpmOidcPublish(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const check = 'npm OIDC publish'
+	if (!pkg || pkg.private === true) {
+		return { check, status: 'optional-missing', detail: 'private package — no npm publish' }
+	}
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (!(await fs.pathExists(workflowsDir))) {
+		return { check, status: 'optional-missing', detail: 'no .github/workflows/' }
+	}
+	try {
+		const files = await fs.readdir(workflowsDir)
+		for (const f of files) {
+			if (!(f.endsWith('.yml') || f.endsWith('.yaml'))) continue
+			const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+			if (!/semantic-release/.test(content)) continue
+			if (/secrets\.NPM_TOKEN/.test(content)) {
+				return {
+					check,
+					status: 'drift',
+					detail: `${f} authenticates npm publish with NPM_TOKEN`,
+					hint: 'Migrate to OIDC trusted publishing: add a Trusted Publisher for each published package on npmjs.com (Settings → Trusted Publisher), then run `fix github-actions` to drop NPM_TOKEN (the release job keeps `id-token: write`). npm is deprecating 2FA-bypass tokens.',
+				}
+			}
+			return { check, status: 'ok', detail: `${f} publishes via OIDC (no NPM_TOKEN)` }
+		}
+		return { check, status: 'optional-missing', detail: 'no semantic-release workflow found' }
+	} catch {
+		return { check, status: 'optional-missing', detail: 'unable to read .github/workflows/' }
+	}
+}
+
 async function checkDependabot(dir: string): Promise<CheckResult> {
 	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
 		const candidatePath = path.join(dir, candidate)
@@ -1533,6 +1568,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkSizeLimit(targetDir, pkg))
 	results.push(await checkGitHubActions(targetDir))
 	results.push(await checkReleaseToken(targetDir))
+	results.push(await checkNpmOidcPublish(targetDir, pkg))
 	results.push(await checkDependabot(targetDir))
 	results.push(await checkCodeQL(targetDir))
 	// GitHub repo-settings drift (branch protection, merge settings, workflow

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -416,7 +416,7 @@ const FIXERS: Fixer[] = [
 	{
 		target: 'github-actions',
 		description: 'Scaffold .github/workflows/ci.yml (+ codecov.yml when tests run)',
-		appliesTo: ['GitHub Actions', 'Coverage upload'],
+		appliesTo: ['GitHub Actions', 'Coverage upload', 'npm OIDC publish'],
 		outputs: ['.github/workflows/ci.yml', 'codecov.yml'],
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -888,6 +888,49 @@ describe('nextStepSuggestions', () => {
 		const rt = results.find((r) => r.check === 'Release token')
 		expect(rt?.status).toBe('ok')
 	})
+
+	it('flags a release workflow still authenticating npm publish with NPM_TOKEN', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  release:\n    steps:\n      - run: npx semantic-release\n        env:\n          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}\n'
+		)
+
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'npm OIDC publish')
+		expect(r?.status).toBe('drift')
+		expect(r?.hint).toMatch(/Trusted Publisher/)
+	})
+
+	it('reports ok when the release workflow publishes via OIDC (no NPM_TOKEN)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  release:\n    permissions:\n      id-token: write\n    steps:\n      - run: npx semantic-release\n        env:\n          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n'
+		)
+
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'npm OIDC publish')
+		expect(r?.status).toBe('ok')
+	})
+
+	it('skips the npm OIDC check for private packages', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', version: '0.0.0', private: true })
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'jobs:\n  release:\n    steps:\n      - run: npx semantic-release\n        env:\n          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}\n'
+		)
+
+		const results = await runDoctor(dir)
+		const r = results.find((c) => c.check === 'npm OIDC publish')
+		expect(r?.status).toBe('optional-missing')
+	})
 })
 
 describe('doctor publint check', () => {


### PR DESCRIPTION
Follow-up to #264 (the OIDC switch). Refs #201.

## What

Adds an **`npm OIDC publish`** doctor check. For a **public** package whose release workflow runs semantic-release, it reports **drift** when the workflow still authenticates npm publish with a `secrets.NPM_TOKEN` — nudging the migration to OIDC trusted publishing. Private packages are skipped (they don't publish to npm).

- Hint tells the user to add a Trusted Publisher on npmjs.com and run `fix github-actions` (which now scaffolds the OIDC workflow).
- Mapped the check to the `github-actions` fixer's `appliesTo`, so `fix` (and the doctor "Next steps" footer) resolve it.

## Tests

- drift when the workflow wires `secrets.NPM_TOKEN`
- ok when it publishes via OIDC (no NPM_TOKEN)
- skipped for private packages

Full suite green (455 tests), typecheck + Biome clean.