### PR TITLE
fix(github-actions): drop NPM_TOKEN from generated release job (OIDC)

### DIFF
--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -295,10 +295,11 @@ ${
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: 🚀 Run semantic-release
+        # npm publish authenticates via OIDC trusted publishing (id-token: write
+        # above) — no npm secret needed. Add a Trusted Publisher for the package
+        # on npmjs.com. See doctor's "npm OIDC publish" check (#201).
         env:
           GITHUB_TOKEN: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx semantic-release`
 		: ''
 }

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -236,10 +236,11 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: 🚀 Run semantic-release
+        # npm publish authenticates via OIDC trusted publishing (id-token: write
+        # above) — no npm secret needed. Add a Trusted Publisher for the package
+        # on npmjs.com. See doctor's "npm OIDC publish" check (#201).
         env:
           GITHUB_TOKEN: \${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 "
 `;

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -167,7 +167,9 @@ describe('generateGitHubActions', () => {
 		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
 		expect(content).toContain('release:')
 		expect(content).toContain('semantic-release')
-		expect(content).toContain('NPM_TOKEN')
+		// Publishes via OIDC trusted publishing — no NPM_TOKEN secret (#201).
+		expect(content).toContain('id-token: write')
+		expect(content).not.toContain('NPM_TOKEN')
 	})
 
 	it('omits release job when semanticRelease is false', async () => {


### PR DESCRIPTION
## What

The `github-actions` generator set `id-token: write` on the release job but still wired `NPM_TOKEN`/`NODE_AUTH_TOKEN` into the semantic-release step — scaffolding a half-migrated workflow that the `npm OIDC publish` doctor check (#265) flags as **drift**. Net effect: `fix github-actions` re-introduced the exact drift `doctor` reports, and the fixer's own hint ("run `fix github-actions` to drop NPM_TOKEN") was a no-op.

This drops the two token env vars from the generated release step. OIDC trusted publishing needs no npm secret; `id-token: write` stays.

## Downstream

Once released, `fix github-actions` clears the 5 repos still on NPM_TOKEN: `shared-docs`, `js-common`, `cf-common`, `db-common`, `browser-common` (each already has `id-token: write` + a Trusted Publisher).

## Tests

- Updated the release-job test to assert `id-token: write` present and `NPM_TOKEN` absent.
- Regenerated the workflow snapshot.
- Full suite green (452), typecheck + Biome clean.

Closes #266. Refs #201, #264, #265.