### PR TITLE
fix(release): upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,10 +353,16 @@ jobs:
       - name: 🏗️ Build CLI
         run: pnpm run build-cli
 
+      # OIDC trusted publishing needs npm CLI >= 11.5.1; Node 22 ships 10.x, so
+      # semantic-release's own OIDC token exchange succeeds but the `npm publish`
+      # it shells out to fails with ENEEDAUTH. Upgrade npm so it can use the token.
+      - name: 📦 Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: 🚀 Run semantic-release
         # Publishes to npm via OIDC trusted publishing — no NPM_TOKEN. Requires
         # the `id-token: write` permission above + a trusted publisher configured
-        # for the package on npmjs.com (Settings → Trusted Publisher).
+        # for the package on npmjs.com (Settings → Trusted Publisher, workflow ci.yml).
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Problem
The OIDC migration (#264) dropped `NPM_TOKEN`, but the release has failed ever since — the last real publish (2.56.0) was token-based. Run [29926196761](https://github.com/rtorcato/js-tooling/actions/runs/29926196761) shows why:

```
[@semantic-release/npm] OIDC token exchange with the npm registry succeeded
...
npm error code ENEEDAUTH   the npm publish subprocess could not auth
```

semantic-release does the OIDC *token exchange* fine, but then shells out to `npm publish`, and the runner's npm (10.x on Node 22) is too old to *use* the OIDC credential. **OIDC trusted publishing needs npm >= 11.5.1.**

## Fix
Add `npm install -g npm@latest` before `npx semantic-release` — the exact step that makes `api-common`'s OIDC release work. Trusted publisher + `id-token: write` are already in place.

## Note
The trusted publisher's **Workflow filename must be `ci.yml`** (this repo publishes from the `release:` job in ci.yml — there is no release.yml).

Once merged, the next releasable commit should publish via OIDC for real.