### PR TITLE
feat(doctor): require code-scanning results before merge (branch ruleset)

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -187,7 +187,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `dependabot` | `.github/dependabot.yml` (monthly, grouped: production-minor/dev-minor/major-updates) + the `dependabot-automerge.yml` workflow — see [Dependabot strategy](./dependabot-strategy.md) |
 | `renovate` | `renovate.json` (alternative to Dependabot) |
 | `codeql` | `.github/workflows/codeql.yml` (security scanning) |
-| `github-settings` | branch protection + auto-merge + workflow permissions via `gh api` (mutates the remote repo) |
+| `github-settings` | branch protection + auto-merge + workflow permissions + a code-scanning branch ruleset (when CodeQL is on) via `gh api` (mutates the remote repo) |
 | `codeowners` | `.github/CODEOWNERS` with commented examples |
 | `community-health` | `CONTRIBUTING.md`, `SECURITY.md`, PR + issue templates |
 | `lockfile` | records current tool choices in the js-tooling lockfile |

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -29,6 +29,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'Branch protection': 'github-settings',
 	'Merge settings': 'github-settings',
 	'Workflow permissions': 'github-settings',
+	'Code-scanning gate': 'github-settings',
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
 	Turborepo: 'turborepo',
@@ -87,6 +88,7 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 		case 'Branch protection':
 		case 'Merge settings':
 		case 'Workflow permissions':
+		case 'Code-scanning gate':
 			return c.securityAutomation === false
 		case 'publint':
 			return c.publint === false

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -462,8 +462,13 @@ const FIXERS: Fixer[] = [
 	{
 		target: 'github-settings',
 		description:
-			'Apply branch protection + auto-merge + workflow permissions on GitHub via gh api (mutates the remote repo, not files)',
-		appliesTo: ['Branch protection', 'Merge settings', 'Workflow permissions'],
+			'Apply branch protection + auto-merge + workflow permissions + code-scanning ruleset on GitHub via gh api (mutates the remote repo, not files)',
+		appliesTo: [
+			'Branch protection',
+			'Merge settings',
+			'Workflow permissions',
+			'Code-scanning gate',
+		],
 		outputs: ['GitHub repo settings (remote, via gh api)'],
 		// safe-add is load-bearing: it exempts this fixer from the `--diff` shadow-run
 		// (previewFixer copies to tmp and *executes* run(), which would fire real

--- a/src/cli/utils/github-settings.ts
+++ b/src/cli/utils/github-settings.ts
@@ -74,7 +74,40 @@ export const GITHUB_STANDARD = {
 	requiredContexts: ['lint', 'typecheck', 'build', 'test'],
 } as const
 
-const CHECK_NAMES = ['Branch protection', 'Merge settings', 'Workflow permissions'] as const
+const CODE_SCANNING_CHECK = 'Code-scanning gate'
+const CHECK_NAMES = [
+	'Branch protection',
+	'Merge settings',
+	'Workflow permissions',
+	CODE_SCANNING_CHECK,
+] as const
+
+// Recommended CodeQL alert thresholds — GitHub's UI defaults. This is the
+// override surface: bump them here for a stricter/looser fleet-wide baseline.
+// ponytail: module constants, not per-repo config, until a repo actually needs to differ.
+const CODE_SCANNING_THRESHOLDS = {
+	security_alerts_threshold: 'high_or_higher',
+	alerts_threshold: 'errors',
+} as const
+
+const CODE_SCANNING_RULESET_NAME = 'code-scanning-main'
+
+/** The branch ruleset POSTed to require code-scanning results before merge (#269). */
+const CODE_SCANNING_RULESET_BODY = JSON.stringify({
+	name: CODE_SCANNING_RULESET_NAME,
+	target: 'branch',
+	enforcement: 'active',
+	// ~DEFAULT_BRANCH keeps this branch-name-agnostic across the fleet.
+	conditions: { ref_name: { include: ['~DEFAULT_BRANCH'], exclude: [] } },
+	rules: [
+		{
+			type: 'code_scanning',
+			parameters: {
+				code_scanning_tools: [{ tool: 'CodeQL', ...CODE_SCANNING_THRESHOLDS }],
+			},
+		},
+	],
+})
 
 /** All three checks as an `ok` skip — keeps them out of next-steps and exit code. */
 function skipAll(reason: string): CheckResult[] {
@@ -135,6 +168,7 @@ export async function checkGitHubSettings(dir: string, exec?: GhExec): Promise<C
 		await checkBranchProtection(gh, info.nwo, info.branch),
 		checkMergeSettings(info),
 		await checkWorkflowPermissions(gh, info.nwo),
+		await checkCodeScanningRuleset(gh, info.nwo, info.branch, dir),
 	]
 }
 
@@ -237,6 +271,112 @@ async function checkWorkflowPermissions(exec: GhExec, nwo: string): Promise<Chec
 			hint: 'Set default workflow permissions to read-only and disable workflow PR approvals',
 		}
 	return { check, status: 'ok', detail: 'read-only default, no workflow PR approvals' }
+}
+
+/**
+ * True when CodeQL/code-scanning is enabled for the repo. Covers both ways it
+ * ships: an advanced-setup workflow on disk (what `fix codeql` scaffolds) or
+ * GitHub's default setup (no file — ask the code-scanning API). Mirrors doctor's
+ * on-disk CodeQL check; kept inline to avoid a doctor↔settings import cycle.
+ */
+async function codeqlEnabled(gh: GhExec, nwo: string, dir: string): Promise<boolean> {
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (await fs.pathExists(workflowsDir)) {
+		try {
+			for (const f of await fs.readdir(workflowsDir)) {
+				if (!/\.ya?ml$/.test(f)) continue
+				const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+				if (/github\/codeql-action/.test(content)) return true
+			}
+		} catch {
+			// fall through to the API probe
+		}
+	}
+	// Default setup leaves no workflow file — the API is the only signal.
+	const r = await gh(['api', `repos/${nwo}/code-scanning/default-setup`])
+	if (!r.ok) return false
+	try {
+		return (JSON.parse(r.stdout) as { state?: string }).state === 'configured'
+	} catch {
+		return false
+	}
+}
+
+/** True when a ruleset's ref_name conditions cover the default branch. */
+function rulesetTargetsBranch(
+	conditions: Record<string, any> | undefined,
+	branch: string
+): boolean {
+	const include: string[] = conditions?.ref_name?.include ?? []
+	return include.some(
+		(ref) => ref === '~DEFAULT_BRANCH' || ref === '~ALL' || ref === `refs/heads/${branch}`
+	)
+}
+
+/**
+ * Does an active branch ruleset enforce a code_scanning rule on the default
+ * branch? The list endpoint omits rules/conditions, so active branch rulesets
+ * are fetched by id to inspect them. 'skip' on any read failure (self-skips like
+ * the other checks).
+ */
+async function hasCodeScanningRuleset(
+	gh: GhExec,
+	nwo: string,
+	branch: string
+): Promise<'yes' | 'no' | 'skip'> {
+	const list = await gh(['api', `repos/${nwo}/rulesets`])
+	if (!list.ok) return 'skip'
+	let rulesets: Array<{ id?: number; target?: string; enforcement?: string }>
+	try {
+		rulesets = JSON.parse(list.stdout)
+	} catch {
+		return 'skip'
+	}
+	if (!Array.isArray(rulesets)) return 'skip'
+	const active = rulesets.filter(
+		(r) => r.target === 'branch' && r.enforcement === 'active' && typeof r.id === 'number'
+	)
+	for (const rs of active) {
+		const detail = await gh(['api', `repos/${nwo}/rulesets/${rs.id}`])
+		if (!detail.ok) continue
+		let full: { rules?: Array<{ type?: string }>; conditions?: Record<string, any> }
+		try {
+			full = JSON.parse(detail.stdout)
+		} catch {
+			continue
+		}
+		const enforcesCodeScanning = (full.rules ?? []).some((r) => r.type === 'code_scanning')
+		if (enforcesCodeScanning && rulesetTargetsBranch(full.conditions, branch)) return 'yes'
+	}
+	return 'no'
+}
+
+/**
+ * The #269 gap: CodeQL results are advisory by default — a High alert still
+ * merges unless a branch ruleset requires the code-scanning check. Only
+ * meaningful where CodeQL is actually on, so it no-ops otherwise.
+ */
+async function checkCodeScanningRuleset(
+	gh: GhExec,
+	nwo: string,
+	branch: string,
+	dir: string
+): Promise<CheckResult> {
+	const check = CODE_SCANNING_CHECK
+	if (!(await codeqlEnabled(gh, nwo, dir))) {
+		return { check, status: 'ok', detail: 'CodeQL not enabled — no code-scanning gate needed' }
+	}
+	const found = await hasCodeScanningRuleset(gh, nwo, branch)
+	if (found === 'skip') return skip(check, 'could not read rulesets')
+	if (found === 'yes') {
+		return { check, status: 'ok', detail: `active ruleset requires code-scanning on ${branch}` }
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: `CodeQL is on but no active ruleset requires code-scanning on ${branch} (High alerts stay advisory)`,
+		hint: 'Run `npx @rtorcato/js-tooling fix github-settings` to add a code_scanning branch ruleset that blocks merge on High+ CodeQL alerts',
+	}
 }
 
 // --- Fixer side (#138): apply the standard via gh api ---------------------
@@ -359,6 +499,20 @@ export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<s
 		else
 			console.log(chalk.yellow(`   could not apply ${cmd.label}: ${r.stderr.trim() || 'gh error'}`))
 	}
+
+	// Code-scanning ruleset (#269): POST only when CodeQL is on and no active gate
+	// covers the default branch — the check re-read keeps this idempotent.
+	const cs = await checkCodeScanningRuleset(gh, info.nwo, info.branch, dir)
+	if (cs.status === 'drift') {
+		const label = `code-scanning ruleset on ${info.branch}`
+		const r = await gh(
+			['api', '-X', 'POST', `repos/${info.nwo}/rulesets`, '--input', '-'],
+			CODE_SCANNING_RULESET_BODY
+		)
+		if (r.ok) applied.push(label)
+		else console.log(chalk.yellow(`   could not apply ${label}: ${r.stderr.trim() || 'gh error'}`))
+	}
+
 	if (applied.length === 0) console.log(chalk.gray('   already configured — nothing to apply'))
 	return applied
 }

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -79,6 +79,7 @@ describe('fix registry', () => {
 			'Branch protection',
 			'Merge settings',
 			'Workflow permissions',
+			'Code-scanning gate',
 		])
 	})
 

--- a/tests/cli/utils/github-settings.test.ts
+++ b/tests/cli/utils/github-settings.test.ts
@@ -48,28 +48,42 @@ const COMPLIANT_WORKFLOW = JSON.stringify({
 	can_approve_pull_request_reviews: false,
 })
 
+/** default-setup reads `not-configured` unless overridden → CodeQL gate no-ops. */
+const CODEQL_OFF = JSON.stringify({ state: 'not-configured' })
+const CODEQL_ON = JSON.stringify({ state: 'configured' })
+
+interface GhOverrides {
+	repo?: GhResult
+	protection?: GhResult
+	workflow?: GhResult
+	defaultSetup?: GhResult
+	rulesets?: GhResult
+	rulesetDetail?: GhResult
+}
+
 /** Route canned responses by which gh api path is invoked. */
-function fakeGh(
-	overrides: { repo?: GhResult; protection?: GhResult; workflow?: GhResult } = {}
-): GhExec {
+function fakeGh(overrides: GhOverrides = {}): GhExec {
 	return vi.fn(async (args: string[]) => {
-		if (args[1] === 'repos/{owner}/{repo}') return overrides.repo ?? ok(COMPLIANT_REPO)
-		if (args[1]?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
-		if (args[1]?.includes('/actions/permissions/workflow'))
+		const p = args[1]
+		if (p === 'repos/{owner}/{repo}') return overrides.repo ?? ok(COMPLIANT_REPO)
+		if (p?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
+		if (p?.includes('/actions/permissions/workflow'))
 			return overrides.workflow ?? ok(COMPLIANT_WORKFLOW)
+		if (p?.includes('/code-scanning/default-setup')) return overrides.defaultSetup ?? ok(CODEQL_OFF)
+		if (p?.includes('/rulesets/')) return overrides.rulesetDetail ?? ok('{}')
+		if (p?.endsWith('/rulesets')) return overrides.rulesets ?? ok('[]')
 		return fail('unexpected call')
 	})
 }
 
-const byName = (results: { check: string }[], name: string) =>
-	results.find((r) => r.check === name)
+const byName = (results: { check: string }[], name: string) => results.find((r) => r.check === name)
 
 describe('checkGitHubSettings — skip paths', () => {
 	it('never spawns gh outside a git repo', async () => {
 		const exec = fakeGh()
 		const results = await checkGitHubSettings(newTmpDir(), exec)
 		expect(exec).not.toHaveBeenCalled()
-		expect(results).toHaveLength(3)
+		expect(results).toHaveLength(4)
 		expect(results.every((r) => r.status === 'ok' && r.detail.includes('skipped'))).toBe(true)
 	})
 
@@ -90,9 +104,65 @@ describe('checkGitHubSettings — skip paths', () => {
 describe('checkGitHubSettings — compliant repo', () => {
 	it('reports all three ok when settings match the standard', async () => {
 		const results = await checkGitHubSettings(gitRepo(), fakeGh())
-		expect(results).toHaveLength(3)
+		expect(results).toHaveLength(4)
 		expect(results.every((r) => r.status === 'ok')).toBe(true)
 		expect(byName(results, 'Branch protection')?.detail).toContain('protected per standard')
+	})
+})
+
+describe('checkGitHubSettings — code-scanning gate (#269)', () => {
+	const gate = (r: GhResult[] | { check: string }[]) =>
+		byName(r as { check: string }[], 'Code-scanning gate')
+
+	it('no-ops as ok when CodeQL is not enabled', async () => {
+		const g = gate(await checkGitHubSettings(gitRepo(), fakeGh()))
+		expect(g?.status).toBe('ok')
+		expect(g?.detail).toContain('CodeQL not enabled')
+	})
+
+	it('drifts when CodeQL is on but no active ruleset requires code-scanning', async () => {
+		const exec = fakeGh({ defaultSetup: ok(CODEQL_ON), rulesets: ok('[]') })
+		const g = gate(await checkGitHubSettings(gitRepo(), exec))
+		expect(g?.status).toBe('drift')
+		expect(g?.detail).toContain('High alerts stay advisory')
+	})
+
+	it('is ok when an active ruleset enforces code-scanning on the default branch', async () => {
+		const exec = fakeGh({
+			defaultSetup: ok(CODEQL_ON),
+			rulesets: ok(JSON.stringify([{ id: 7, target: 'branch', enforcement: 'active' }])),
+			rulesetDetail: ok(
+				JSON.stringify({
+					rules: [{ type: 'code_scanning' }],
+					conditions: { ref_name: { include: ['~DEFAULT_BRANCH'] } },
+				})
+			),
+		})
+		const g = gate(await checkGitHubSettings(gitRepo(), exec))
+		expect(g?.status).toBe('ok')
+		expect(g?.detail).toContain('requires code-scanning on main')
+	})
+
+	it('ignores an inactive or non-default-branch ruleset (still drift)', async () => {
+		const exec = fakeGh({
+			defaultSetup: ok(CODEQL_ON),
+			// A code_scanning ruleset that targets a different branch → does not count.
+			rulesets: ok(JSON.stringify([{ id: 9, target: 'branch', enforcement: 'active' }])),
+			rulesetDetail: ok(
+				JSON.stringify({
+					rules: [{ type: 'code_scanning' }],
+					conditions: { ref_name: { include: ['refs/heads/release'] } },
+				})
+			),
+		})
+		expect(gate(await checkGitHubSettings(gitRepo(), exec))?.status).toBe('drift')
+	})
+
+	it('skips (ok) when rulesets cannot be read', async () => {
+		const exec = fakeGh({ defaultSetup: ok(CODEQL_ON), rulesets: fail('gh: (HTTP 403)') })
+		const g = gate(await checkGitHubSettings(gitRepo(), exec))
+		expect(g?.status).toBe('ok')
+		expect(g?.detail).toContain('skipped')
 	})
 })
 
@@ -121,7 +191,10 @@ describe('checkGitHubSettings — drift', () => {
 				allow_deletions: { enabled: false },
 			})
 		)
-		const bp = byName(await checkGitHubSettings(gitRepo(), fakeGh({ protection })), 'Branch protection')
+		const bp = byName(
+			await checkGitHubSettings(gitRepo(), fakeGh({ protection })),
+			'Branch protection'
+		)
 		expect(bp?.status).toBe('drift')
 		expect(bp?.detail).toContain('typecheck')
 	})
@@ -148,7 +221,10 @@ describe('checkGitHubSettings — drift', () => {
 				can_approve_pull_request_reviews: false,
 			})
 		)
-		const wp = byName(await checkGitHubSettings(gitRepo(), fakeGh({ workflow })), 'Workflow permissions')
+		const wp = byName(
+			await checkGitHubSettings(gitRepo(), fakeGh({ workflow })),
+			'Workflow permissions'
+		)
 		expect(wp?.status).toBe('drift')
 		expect(wp?.detail).toContain('write')
 	})
@@ -207,17 +283,19 @@ describe('applyGithubSettings', () => {
 	})
 
 	/** Records every gh call; canned responses drive which deltas fire. */
-	function recordingGh(
-		overrides: { repo?: GhResult; protection?: GhResult; workflow?: GhResult } = {}
-	) {
+	function recordingGh(overrides: GhOverrides = {}) {
 		const calls: { args: string[]; stdin?: string }[] = []
 		const exec: GhExec = vi.fn(async (args: string[], stdin?: string) => {
 			calls.push({ args, stdin })
 			if (args[1] === 'repos/{owner}/{repo}') return overrides.repo ?? ok(COMPLIANT_REPO)
-			if (args.includes('--input')) return ok('') // protection PUT
+			if (args.includes('--input')) return ok('') // protection PUT or ruleset POST
 			if (args[1]?.includes('/protection')) return overrides.protection ?? ok(COMPLIANT_PROTECTION)
 			if (args[1]?.includes('/actions/permissions/workflow'))
 				return overrides.workflow ?? ok(COMPLIANT_WORKFLOW)
+			if (args[1]?.includes('/code-scanning/default-setup'))
+				return overrides.defaultSetup ?? ok(CODEQL_OFF)
+			if (args[1]?.includes('/rulesets/')) return overrides.rulesetDetail ?? ok('{}')
+			if (args[1]?.endsWith('/rulesets')) return overrides.rulesets ?? ok('[]')
 			if (args.includes('PATCH')) return ok('') // merge PATCH
 			return ok('')
 		})
@@ -257,9 +335,7 @@ describe('applyGithubSettings', () => {
 			'workflow permissions (read-only)',
 		])
 		// The three mutating calls fire after the read probes, PATCH before the PUTs.
-		const mutations = calls.filter(
-			(c) => c.args.includes('PATCH') || c.args.includes('PUT')
-		)
+		const mutations = calls.filter((c) => c.args.includes('PATCH') || c.args.includes('PUT'))
 		expect(mutations.map((c) => c.args[2])).toEqual(['PATCH', 'PUT', 'PUT'])
 		const protectionPut = mutations.find((c) => c.args.includes('--input'))
 		expect(protectionPut?.stdin).toContain('required_status_checks')
@@ -274,5 +350,21 @@ describe('applyGithubSettings', () => {
 		const { exec, calls } = recordingGh({ repo: fail('gh auth login required') })
 		expect(await applyGithubSettings(gitRepo(), exec)).toEqual([])
 		expect(calls.every((c) => !c.args.includes('PUT') && !c.args.includes('PATCH'))).toBe(true)
+	})
+
+	it('POSTs a code-scanning ruleset when CodeQL is on and none exists (#269)', async () => {
+		const { exec, calls } = recordingGh({ defaultSetup: ok(CODEQL_ON), rulesets: ok('[]') })
+		const labels = await applyGithubSettings(gitRepo(), exec)
+		expect(labels).toContain('code-scanning ruleset on main')
+		const post = calls.find(
+			(c) => c.args.includes('POST') && c.args.some((a) => a.endsWith('/rulesets'))
+		)
+		expect(post?.stdin).toContain('code_scanning')
+	})
+
+	it('does not POST a ruleset on a compliant CodeQL-off repo', async () => {
+		const { exec, calls } = recordingGh()
+		await applyGithubSettings(gitRepo(), exec)
+		expect(calls.some((c) => c.args.includes('POST'))).toBe(false)
 	})
 })


### PR DESCRIPTION
Closes #269

## What

CodeQL results are **advisory by default** — a PR with a High CodeQL alert still merges unless a branch ruleset requires the `code_scanning` check. Every repo with CodeQL enabled has this gap until someone notices.

### Audit
Adds a **Code-scanning gate** check to the GitHub-settings suite (`doctor`). When CodeQL is enabled — detected via an advanced-setup workflow on disk *or* GitHub's default-setup API — it queries `repos/OWNER/REPO/rulesets`, fetches each active branch ruleset by id, and looks for a `code_scanning` rule targeting the default branch. Flags **drift** if none exists; **no-ops** (ok) when CodeQL is off, and self-skips when rulesets can't be read.

### Scaffold
The existing `fix github-settings` fixer now also POSTs the branch ruleset when the gate is drifting — `high_or_higher` / `errors` thresholds (GitHub UI defaults), `~DEFAULT_BRANCH` so it's branch-name-agnostic. Idempotent: the check re-read means a repo already covered is a no-op.

### Roll out
Run `npx @rtorcato/js-tooling fix github-settings` in each `@rtorcato/*` repo with CodeQL on.

## Notes
- Thresholds are module constants (the override surface); no per-repo config until one is actually needed.
- GitHub-only — gated behind the same gh probe as the other repo-settings checks.

## Tests
Full suite green (467). New cases: gate no-ops when CodeQL off, drifts when on without a ruleset, ok with a matching ruleset, ignores inactive/non-default-branch rulesets, skips on read failure, fixer POSTs only when CodeQL is on and none exists.