### PR TITLE
feat(setup): single config file — accept lockfile as --config (#271)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ Generate or refresh it from what's currently on disk:
 npx @rtorcato/js-tooling fix lockfile
 ```
 
+**It's the only config file you need.** Don't keep a separate hand-authored
+`.js-tooling.config.json` next to it — the lockfile already embeds the full
+`ProjectConfig` under `config`, and `setup --config` accepts the lockfile
+directly, so you can re-run a non-interactive setup from it:
+
+```bash
+npx @rtorcato/js-tooling setup --config .js-tooling.json
+```
+
 Each `config.*` key mirrors a setup answer — see the
 [schema](https://rtorcato.github.io/js-tooling/schemas/lockfile.json) for the
 full field reference. The keys `doctor` acts on:

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -89,11 +89,19 @@ async function resolveConfig(options: SetupOptions): Promise<ProjectConfig> {
 			throw new Error(`Config file not found: ${configPath}`)
 		}
 		const raw = await fs.readJson(configPath)
-		const { valid, errors } = validateProjectConfig(raw)
+		// Accept the `.js-tooling.json` lockfile itself as the config source, so a
+		// repo needs only one file: the lockfile already embeds the full
+		// ProjectConfig under `config`. Unwrap it here rather than requiring a
+		// separate hand-authored config file (#271).
+		const candidate =
+			typeof raw === 'object' && raw !== null && 'config' in raw && 'version' in raw
+				? (raw as { config: unknown }).config
+				: raw
+		const { valid, errors } = validateProjectConfig(candidate)
 		if (!valid) {
 			throw new Error(`Invalid config:\n  - ${errors.join('\n  - ')}`)
 		}
-		return raw as ProjectConfig
+		return candidate as ProjectConfig
 	}
 	if (options.preset) {
 		if (!(PRESET_NAMES as readonly string[]).includes(options.preset)) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,7 +33,10 @@ program
 	.option('-d, --directory <path>', 'Target directory for setup', process.cwd())
 	.option('--skip-install', 'Skip installing dependencies')
 	.option('--preset <name>', 'Skip prompts; use defaults for a project type')
-	.option('--config <path>', 'Skip prompts; read a JSON ProjectConfig from <path>')
+	.option(
+		'--config <path>',
+		'Skip prompts; read a ProjectConfig or .js-tooling.json lockfile from <path>'
+	)
 	.option('--dry-run', 'Print the resolved config and file list, write nothing')
 	.option('--config-schema', 'Print the JSON Schema for ProjectConfig and exit')
 	.action(setupProject)

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -237,6 +237,31 @@ describe('setup --config', () => {
 		expect(await fs.pathExists(join(dir, 'build.mjs'))).toBe(true)
 	})
 
+	it('accepts a .js-tooling.json lockfile and unwraps its config (#271)', async () => {
+		const dir = newTmpDir()
+		const config = buildPresetConfig('node-api', 'my-api')
+		// A lockfile wraps the config alongside version/writtenBy/etc — those extra
+		// keys would fail validation if not unwrapped.
+		const lockfile = {
+			$schema: 'https://rtorcato.github.io/js-tooling/schemas/lockfile.json',
+			version: 2,
+			config,
+			writtenBy: '@rtorcato/js-tooling@0.0.0',
+			writtenAt: '2026-01-01T00:00:00.000Z',
+		}
+		const configPath = join(dir, '.js-tooling.json')
+		await fs.writeJson(configPath, lockfile)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, config: configPath, dryRun: true, skipInstall: true })
+			const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+			expect(payload.config.projectType).toBe('node-api')
+			expect(payload.config.version).toBeUndefined()
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
 	it('rejects configs with unknown fields', async () => {
 		const dir = newTmpDir()
 		const configPath = join(dir, 'project.json')


### PR DESCRIPTION
Closes #271.

A freshly set-up repo ended up with two near-identically-named files at the root — a hand-authored `.js-tooling.config.json` (setup input) next to the `.js-tooling.json` lockfile. The tool only ever writes the lockfile, and the lockfile already embeds the full ProjectConfig under `config`, so the standalone input file is redundant.

## Change (Option 2 — smallest)
- `setup --config <path>` now unwraps a `.js-tooling.json` lockfile: if the JSON looks like a lockfile (`version` + `config`), it uses `config`; otherwise treated as a bare ProjectConfig as before. The lockfile becomes the single re-usable config file (`setup --config .js-tooling.json`).
- `--config` help text + README lockfile section updated: don't keep a separate `.js-tooling.config.json`.

No destructive migration — the tool never created `.js-tooling.config.json`, so nothing is auto-deleted.

## Test
Added a setup test feeding a full lockfile to `--config`, asserting `config` is unwrapped and lockfile-only keys don't leak. typecheck + setup suite (22) green.

Unblocks #272 and #273.