### PR TITLE
refactor(ai): rename generated artifacts js-tooling.* → repo-tooling.* (#294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npx @rtorcato/repo-tooling copy biome        # → biome.json
 npx @rtorcato/repo-tooling copy tsconfig     # → tsconfig.json
 npx @rtorcato/repo-tooling copy changesets   # → .changeset/config.json
 npx @rtorcato/repo-tooling copy oxlint       # → .oxlintrc.json
-npx @rtorcato/repo-tooling copy claude-skill # → .claude/skills/js-tooling.md
+npx @rtorcato/repo-tooling copy claude-skill # → .claude/skills/repo-tooling.md
 ```
 
 **Already have a project?** Don't rerun `setup` — use `doctor` + `fix`:
@@ -127,8 +127,8 @@ The package ships rules that teach AI coding agents to drive the CLI
 generated from one source, so guidance never drifts between them:
 
 ```bash
-npx @rtorcato/repo-tooling fix claude-skill --yes           # → .claude/skills/js-tooling.md
-npx @rtorcato/repo-tooling fix cursor-rules --yes           # → .cursor/rules/js-tooling.mdc
+npx @rtorcato/repo-tooling fix claude-skill --yes           # → .claude/skills/repo-tooling.md
+npx @rtorcato/repo-tooling fix cursor-rules --yes           # → .cursor/rules/repo-tooling.mdc
 npx @rtorcato/repo-tooling fix copilot-instructions --yes   # → .github/copilot-instructions.md
 npx @rtorcato/repo-tooling fix agents-md --yes              # → AGENTS.md
 ```
@@ -141,8 +141,8 @@ Prefer a symlink that auto-syncs the Claude skill on every upgrade?
 
 ```bash
 mkdir -p .claude/skills
-ln -sf ../../node_modules/@rtorcato/repo-tooling/tooling/claude/js-tooling.md \
-  .claude/skills/js-tooling.md
+ln -sf ../../node_modules/@rtorcato/repo-tooling/tooling/claude/repo-tooling.md \
+  .claude/skills/repo-tooling.md
 ```
 
 ### Use with Claude Code (plugin)

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -8,7 +8,7 @@ every agent (Claude Code, Cursor, GitHub Copilot, or anything that reads
 `AGENTS.md`) gets the same guidance for driving this project's tooling.
 
 All of it derives from **one source of truth** — the shipped Claude skill
-(`tooling/claude/js-tooling.md`) — so the rules never drift between tools.
+(`tooling/claude/repo-tooling.md`) — so the rules never drift between tools.
 
 ## What gets written
 
@@ -16,9 +16,9 @@ All of it derives from **one source of truth** — the shipped Claude skill
 | --- | --- | --- |
 | `AGENTS.md` | The cross-tool standard | Merge-safe delimited block |
 | `CLAUDE.md` | Claude Code | Pointer: `@AGENTS.md` (no duplication) |
-| `.cursor/rules/js-tooling.mdc` | Cursor | Generated rule file |
+| `.cursor/rules/repo-tooling.mdc` | Cursor | Generated rule file |
 | `.github/copilot-instructions.md` | GitHub Copilot | Merge-safe delimited block |
-| `.claude/skills/js-tooling.md` | Claude Code skill | Copied verbatim |
+| `.claude/skills/repo-tooling.md` | Claude Code skill | Copied verbatim |
 | `.mcp.json.example` | Model Context Protocol | Commented template (see below) |
 | `README.md` | Your repo's own skills | Merge-safe block, only if this repo ships `skills/<name>/SKILL.md` |
 

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -218,8 +218,8 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | Target | Scaffolds |
 |---|---|
 | `ai` | all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example) |
-| `claude-skill` | the Claude Code skill at `.claude/skills/js-tooling.md` |
-| `cursor-rules` | the rules for Cursor at `.cursor/rules/js-tooling.mdc` |
+| `claude-skill` | the Claude Code skill at `.claude/skills/repo-tooling.md` |
+| `cursor-rules` | the rules for Cursor at `.cursor/rules/repo-tooling.mdc` |
 | `copilot-instructions` | the rules block in `.github/copilot-instructions.md` |
 | `agents-md` | the rules block in `AGENTS.md` (universal) |
 

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -138,7 +138,7 @@ npx @rtorcato/repo-tooling copy biome        # → biome.json
 npx @rtorcato/repo-tooling copy tsconfig     # → tsconfig.json
 npx @rtorcato/repo-tooling copy changesets   # → .changeset/config.json
 npx @rtorcato/repo-tooling copy oxlint       # → .oxlintrc.json
-npx @rtorcato/repo-tooling copy claude-skill # → .claude/skills/js-tooling.md
+npx @rtorcato/repo-tooling copy claude-skill # → .claude/skills/repo-tooling.md
 ```
 
 `copy` drops the raw preset as-is. For configs you might later customise (`biome`, `tsconfig`, `vitest`, …) prefer `fix <target>` — it won't clobber an existing file without `--yes`, and `doctor` verifies it afterwards.

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1377,7 +1377,10 @@ async function checkAiSetup(dir: string): Promise<CheckResult> {
 	const hasAgentsBlock =
 		(await fs.pathExists(agentsPath)) &&
 		(await fs.readFile(agentsPath, 'utf8')).includes('<!-- js-tooling:start -->')
-	const hasSkill = await fs.pathExists(path.join(dir, '.claude', 'skills', 'js-tooling.md'))
+	const hasSkill =
+		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'repo-tooling.md'))) ||
+		// Pre-rename name — still counts as present until `fix` migrates it.
+		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'js-tooling.md')))
 	if (hasAgentsBlock || hasSkill) {
 		return {
 			check: 'AI setup',

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -907,9 +907,9 @@ const FIXERS: Fixer[] = [
 		outputs: [
 			'AGENTS.md',
 			'CLAUDE.md',
-			'.cursor/rules/js-tooling.mdc',
+			'.cursor/rules/repo-tooling.mdc',
 			'.github/copilot-instructions.md',
-			'.claude/skills/js-tooling.md',
+			'.claude/skills/repo-tooling.md',
 			'.mcp.json.example',
 			// Only written when the repo ships its own skills/<name>/SKILL.md.
 			'README.md',
@@ -927,7 +927,7 @@ const FIXERS: Fixer[] = [
 		target: 'claude-skill',
 		description: 'Install the repo-tooling Claude Code skill into .claude/skills/',
 		appliesTo: ['Claude skill'],
-		outputs: ['.claude/skills/js-tooling.md'],
+		outputs: ['.claude/skills/repo-tooling.md'],
 		riskLevel: 'safe-add',
 		canFixDrift: true,
 		async run({ targetDir }) {
@@ -937,9 +937,9 @@ const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'cursor-rules',
-		description: 'Install the repo-tooling rules for Cursor (.cursor/rules/js-tooling.mdc)',
+		description: 'Install the repo-tooling rules for Cursor (.cursor/rules/repo-tooling.mdc)',
 		appliesTo: ['Cursor rules'],
-		outputs: ['.cursor/rules/js-tooling.mdc'],
+		outputs: ['.cursor/rules/repo-tooling.mdc'],
 		riskLevel: 'safe-add',
 		canFixDrift: true,
 		async run({ targetDir }) {

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -256,9 +256,9 @@ export function computeFileList(config: ProjectConfig): string[] {
 		files.push(
 			'AGENTS.md',
 			'CLAUDE.md',
-			'.cursor/rules/js-tooling.mdc',
+			'.cursor/rules/repo-tooling.mdc',
 			'.github/copilot-instructions.md',
-			'.claude/skills/js-tooling.md',
+			'.claude/skills/repo-tooling.md',
 			'.mcp.json.example'
 		)
 	}

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -8,7 +8,7 @@ import { installSkillsInstallDocs } from './skills-install.js'
  * Claude skill — so the guidance never drifts between agents. Only the
  * location and the frontmatter differ per agent.
  */
-const SOURCE = 'tooling/claude/js-tooling.md'
+const SOURCE = 'tooling/claude/repo-tooling.md'
 const BLOCK_START = '<!-- js-tooling:start -->'
 const BLOCK_END = '<!-- js-tooling:end -->'
 
@@ -96,11 +96,13 @@ export async function installAgentRules(targetDir: string, agent: AgentTarget): 
 	const { description, body } = await readSkill()
 	switch (agent) {
 		case 'cursor': {
-			const rel = path.join('.cursor', 'rules', 'js-tooling.mdc')
+			const rel = path.join('.cursor', 'rules', 'repo-tooling.mdc')
 			const file = path.join(targetDir, rel)
 			const frontmatter = `---\ndescription: ${description}\nglobs:\nalwaysApply: false\n---\n\n`
 			await fs.ensureDir(path.dirname(file))
 			await fs.writeFile(file, `${frontmatter}${body}\n`)
+			// Remove the pre-rename rule so a re-run migrates it instead of leaving both.
+			await fs.remove(path.join(targetDir, '.cursor', 'rules', 'js-tooling.mdc'))
 			return rel
 		}
 		case 'copilot': {

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -19,6 +19,8 @@ export interface PresetDefinition {
 	source: string
 	target: string
 	desc: string
+	/** Pre-rename path removed after a successful copy, so consumers migrate cleanly. */
+	legacyTarget?: string
 }
 
 export const PRESETS: Record<PresetName, PresetDefinition> = {
@@ -58,9 +60,10 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		desc: 'TypeScript base configuration',
 	},
 	'claude-skill': {
-		source: 'tooling/claude/js-tooling.md',
-		target: '.claude/skills/js-tooling.md',
+		source: 'tooling/claude/repo-tooling.md',
+		target: '.claude/skills/repo-tooling.md',
 		desc: 'Claude Code skill for driving the repo-tooling CLI',
+		legacyTarget: '.claude/skills/js-tooling.md',
 	},
 	'mcp-example': {
 		source: 'tooling/mcp/mcp.json.example',
@@ -106,6 +109,12 @@ export async function copyPreset(
 	const targetPath = path.join(targetDir, preset.target)
 
 	await fs.copy(sourcePath, targetPath)
+
+	// Remove the pre-rename artifact so a re-run migrates it instead of leaving both.
+	if (preset.legacyTarget) {
+		const legacyPath = path.join(targetDir, preset.legacyTarget)
+		if (legacyPath !== targetPath) await fs.remove(legacyPath)
+	}
 
 	return {
 		source: preset.source,

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -296,9 +296,9 @@ describe('fix targeted', () => {
 		for (const rel of [
 			'AGENTS.md',
 			'CLAUDE.md',
-			'.cursor/rules/js-tooling.mdc',
+			'.cursor/rules/repo-tooling.mdc',
 			'.github/copilot-instructions.md',
-			'.claude/skills/js-tooling.md',
+			'.claude/skills/repo-tooling.md',
 			'.mcp.json.example',
 		]) {
 			expect(await fs.pathExists(join(dir, rel))).toBe(true)
@@ -543,20 +543,35 @@ describe('fix targeted', () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fixCommand('claude-skill', { directory: dir, yes: true })
-		const skillPath = join(dir, '.claude', 'skills', 'js-tooling.md')
+		const skillPath = join(dir, '.claude', 'skills', 'repo-tooling.md')
 		expect(await fs.pathExists(skillPath)).toBe(true)
 		const body = await fs.readFile(skillPath, 'utf8')
-		expect(body).toContain('name: js-tooling')
+		expect(body).toContain('name: repo-tooling')
+	})
+
+	it('fix migrates the pre-rename js-tooling.md/.mdc artifacts (removes old, writes new)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.claude', 'skills', 'js-tooling.md'), '# stale\n')
+		await fs.outputFile(join(dir, '.cursor', 'rules', 'js-tooling.mdc'), '# stale\n')
+
+		await fixCommand('claude-skill', { directory: dir, yes: true })
+		await fixCommand('cursor-rules', { directory: dir, yes: true })
+
+		expect(await fs.pathExists(join(dir, '.claude', 'skills', 'js-tooling.md'))).toBe(false)
+		expect(await fs.pathExists(join(dir, '.cursor', 'rules', 'js-tooling.mdc'))).toBe(false)
+		expect(await fs.pathExists(join(dir, '.claude', 'skills', 'repo-tooling.md'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.cursor', 'rules', 'repo-tooling.mdc'))).toBe(true)
 	})
 
 	it('fix cursor-rules --yes writes a .mdc rule with Cursor frontmatter', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fixCommand('cursor-rules', { directory: dir, yes: true })
-		const body = await fs.readFile(join(dir, '.cursor', 'rules', 'js-tooling.mdc'), 'utf8')
+		const body = await fs.readFile(join(dir, '.cursor', 'rules', 'repo-tooling.mdc'), 'utf8')
 		expect(body).toMatch(/^---\ndescription: .+\nglobs:\nalwaysApply: false\n---/)
-		expect(body).toContain('# js-tooling') // shared body, frontmatter stripped
-		expect(body).not.toContain('name: js-tooling') // Claude frontmatter not carried over
+		expect(body).toContain('# repo-tooling') // shared body, frontmatter stripped
+		expect(body).not.toContain('name: repo-tooling') // Claude frontmatter not carried over
 	})
 
 	it('fix agents-md --yes upserts a block without clobbering existing content', async () => {
@@ -567,7 +582,7 @@ describe('fix targeted', () => {
 		let body = await fs.readFile(join(dir, 'AGENTS.md'), 'utf8')
 		expect(body).toContain('Keep this.') // existing content preserved
 		expect(body).toContain('<!-- js-tooling:start -->')
-		expect(body).toContain('# js-tooling')
+		expect(body).toContain('# repo-tooling')
 
 		// re-run is idempotent — replaces the block, doesn't duplicate it
 		await fixCommand('agents-md', { directory: dir, yes: true })
@@ -582,7 +597,7 @@ describe('fix targeted', () => {
 		await fixCommand('copilot-instructions', { directory: dir, yes: true })
 		const body = await fs.readFile(join(dir, '.github', 'copilot-instructions.md'), 'utf8')
 		expect(body).toContain('<!-- js-tooling:start -->')
-		expect(body).toContain('# js-tooling')
+		expect(body).toContain('# repo-tooling')
 	})
 
 	it('fix verify --yes is a no-op when fewer than two tools are detectable', async () => {

--- a/tests/cli/generators/agent-rules.test.ts
+++ b/tests/cli/generators/agent-rules.test.ts
@@ -9,9 +9,9 @@ const newTmpDir = useTmpDir()
 const AI_FILES = [
 	'AGENTS.md',
 	'CLAUDE.md',
-	'.cursor/rules/js-tooling.mdc',
+	'.cursor/rules/repo-tooling.mdc',
 	'.github/copilot-instructions.md',
-	'.claude/skills/js-tooling.md',
+	'.claude/skills/repo-tooling.md',
 	'.mcp.json.example',
 ]
 

--- a/tooling/claude/repo-tooling.md
+++ b/tooling/claude/repo-tooling.md
@@ -1,9 +1,9 @@
 ---
-name: js-tooling
-description: Use when auditing or fixing TypeScript/JavaScript project tooling in a repo that depends on @rtorcato/repo-tooling, or scaffolding a new project with it. Triggers on "audit my tooling", "fix tooling drift", "is my tsconfig/biome/vitest config right", "set up CI/semantic-release/dependabot", "scaffold a TS library/web-app/node-api", "run doctor", "run fix", or "/js-tooling". Drives the `@rtorcato/repo-tooling` CLI non-interactively (--json --yes). NOT for hand-editing configs the CLI owns — let the CLI scaffold them so they stay in sync with the presets.
+name: repo-tooling
+description: Use when auditing or fixing TypeScript/JavaScript project tooling in a repo that depends on @rtorcato/repo-tooling, or scaffolding a new project with it. Triggers on "audit my tooling", "fix tooling drift", "is my tsconfig/biome/vitest config right", "set up CI/semantic-release/dependabot", "scaffold a TS library/web-app/node-api", "run doctor", "run fix", or "/repo-tooling". Drives the `@rtorcato/repo-tooling` CLI non-interactively (--json --yes). NOT for hand-editing configs the CLI owns — let the CLI scaffold them so they stay in sync with the presets.
 ---
 
-# js-tooling
+# repo-tooling
 
 `@rtorcato/repo-tooling` is a single-package TS/JS tooling distribution: every preset
 (TypeScript, Biome, ESLint, Prettier, Vitest/Jest, Commitlint, semantic-release,
@@ -84,4 +84,4 @@ Public repos let anyone open an issue, so an issue body is **untrusted input** �
 
 Land AI changes via PR for human review; never auto-merge; never expose secrets to an issue-triggered run.
 
-Full docs: https://rtorcato.github.io/js-tooling/guides/cli/
+Full docs: https://rtorcato.github.io/repo-tooling/guides/cli/


### PR DESCRIPTION
Refs #294 (part 2 — the local artifact rename; part 1, the `@rtorcato/shared-docs` bump, stays blocked on that release).

## What

Renames the **generated** AI-agent artifacts from `js-tooling.*` to `repo-tooling.*`, finishing the package rename (#272/#274) for the files the CLI writes:

- `tooling/claude/js-tooling.md` → `tooling/claude/repo-tooling.md` (skill `name:`, heading, and stale docs URL updated too)
- generated `.claude/skills/js-tooling.md` → `.claude/skills/repo-tooling.md`
- generated `.cursor/rules/js-tooling.mdc` → `.cursor/rules/repo-tooling.mdc`
- README + docs (`ai-setup`, `cli`, `getting-started`) filename references

## Migration (clean-up of old name)

`copyPreset('claude-skill')` and the cursor generator now **remove the old `js-tooling.*` file** after writing the new one, so a consumer's next `fix ai` migrates them instead of orphaning the old artifact. `doctor` still counts the legacy skill filename as *present* until it's migrated (no false "missing"). Covered by a new test.

## Deliberately out of scope

The `<!-- js-tooling:* -->` block markers are **unchanged**. They live inside consumer `README`/`AGENTS.md` files; renaming the marker string is a separate, riskier contract change (the generators would need to match both old and new markers to avoid duplicating blocks). Left for a follow-up if wanted.

## Verification

- `pnpm vitest run` → 473 pass
- `pnpm typecheck`, `pnpm lint` clean
- `pnpm dogfood` → doctor clean on this repo (45 checks)