### PR TITLE
refactor(core): move GitHub-settings + repo-hygiene checks into src/base (#282)

### DIFF
--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -47,3 +47,227 @@ export async function checkCommunityHealth(dir: string): Promise<CheckResult> {
 		hint: 'Run `npx @rtorcato/repo-tooling fix community-health` to scaffold them',
 	}
 }
+
+export async function checkGitHubActions(dir: string): Promise<CheckResult> {
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (!(await fs.pathExists(workflowsDir))) {
+		return {
+			check: 'GitHub Actions',
+			status: 'optional-missing',
+			detail: 'no .github/workflows/',
+			hint: 'Run `npx @rtorcato/repo-tooling setup` to scaffold a CI workflow',
+		}
+	}
+
+	try {
+		const files = await fs.readdir(workflowsDir)
+		const workflows = files.filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+		if (workflows.length === 0) {
+			return {
+				check: 'GitHub Actions',
+				status: 'optional-missing',
+				detail: '.github/workflows/ is empty',
+				hint: 'Add a workflow file (e.g. ci.yml) under .github/workflows/',
+			}
+		}
+		return {
+			check: 'GitHub Actions',
+			status: 'ok',
+			detail: `${workflows.length} workflow${workflows.length === 1 ? '' : 's'} in .github/workflows/`,
+		}
+	} catch {
+		return {
+			check: 'GitHub Actions',
+			status: 'optional-missing',
+			detail: 'unable to read .github/workflows/',
+		}
+	}
+}
+
+export async function checkDependabot(dir: string): Promise<CheckResult> {
+	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
+		const candidatePath = path.join(dir, candidate)
+		if (await fs.pathExists(candidatePath)) {
+			// The canonical standard (apps/docs/docs/guides/dependabot-strategy.md) is
+			// the safe-tier + major-tier grouping plus the auto-merge workflow that
+			// depends on it. Flag any config that predates it so `fix dependabot` can
+			// bring the pair up to standard.
+			const content = await fs.readFile(candidatePath, 'utf8')
+			const deltas: string[] = []
+			for (const group of ['production-minor', 'dev-minor', 'major-updates']) {
+				if (!new RegExp(`^\\s*${group}:`, 'm').test(content)) {
+					deltas.push(`missing \`${group}\` group`)
+				}
+			}
+			const automergePath = path.join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+			if (!(await fs.pathExists(automergePath))) {
+				deltas.push('missing dependabot-automerge workflow')
+			}
+			if (deltas.length > 0) {
+				return {
+					check: 'Dependabot',
+					status: 'drift',
+					detail: `${candidate} drifts from canonical (${deltas.join('; ')})`,
+					hint: 'Run `npx @rtorcato/repo-tooling fix dependabot` to apply the canonical grouping + auto-merge workflow',
+				}
+			}
+			return {
+				check: 'Dependabot',
+				status: 'ok',
+				detail: `${candidate} + auto-merge workflow`,
+			}
+		}
+	}
+	for (const candidate of [
+		'renovate.json',
+		'renovate.json5',
+		'.github/renovate.json',
+		'.github/renovate.json5',
+		'.renovaterc',
+		'.renovaterc.json',
+	]) {
+		if (await fs.pathExists(path.join(dir, candidate))) {
+			return {
+				check: 'Dependabot',
+				status: 'ok',
+				detail: `${candidate} found (Renovate)`,
+			}
+		}
+	}
+	return {
+		check: 'Dependabot',
+		status: 'optional-missing',
+		detail: 'no Dependabot or Renovate config',
+		hint: 'Run `npx @rtorcato/repo-tooling fix dependabot` (or `fix renovate`) to scaffold weekly dep updates',
+	}
+}
+
+export async function checkCodeQL(dir: string): Promise<CheckResult> {
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (!(await fs.pathExists(workflowsDir))) {
+		return {
+			check: 'CodeQL',
+			status: 'optional-missing',
+			detail: 'no .github/workflows/',
+			hint: 'Run `npx @rtorcato/repo-tooling fix codeql` to scaffold CodeQL security scanning',
+		}
+	}
+	for (const candidate of ['codeql.yml', 'codeql.yaml']) {
+		if (await fs.pathExists(path.join(workflowsDir, candidate))) {
+			return {
+				check: 'CodeQL',
+				status: 'ok',
+				detail: `.github/workflows/${candidate} found`,
+			}
+		}
+	}
+	try {
+		const files = await fs.readdir(workflowsDir)
+		for (const f of files) {
+			if (!(f.endsWith('.yml') || f.endsWith('.yaml'))) continue
+			const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+			if (/github\/codeql-action/.test(content)) {
+				return {
+					check: 'CodeQL',
+					status: 'ok',
+					detail: `codeql-action referenced in ${f}`,
+				}
+			}
+		}
+	} catch {
+		// fall through to optional-missing
+	}
+	return {
+		check: 'CodeQL',
+		status: 'optional-missing',
+		detail: 'no codeql workflow found',
+		hint: 'Run `npx @rtorcato/repo-tooling fix codeql` to scaffold CodeQL security scanning',
+	}
+}
+
+// A README that advertises a Codecov badge but a CI that never uploads coverage
+// leaves the badge permanently red. Only flags when the badge is actually present
+// (no badge → nothing to back, so it's not applicable).
+export async function checkCoverageUpload(dir: string): Promise<CheckResult> {
+	const readmePath = path.join(dir, 'README.md')
+	const readme = (await fs.pathExists(readmePath)) ? await fs.readFile(readmePath, 'utf8') : ''
+	if (!/codecov\.io/.test(readme)) {
+		return {
+			check: 'Coverage upload',
+			status: 'ok',
+			detail: 'no coverage badge in README (nothing to back)',
+		}
+	}
+
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (await fs.pathExists(workflowsDir)) {
+		try {
+			const files = (await fs.readdir(workflowsDir)).filter(
+				(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+			)
+			for (const f of files) {
+				const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+				if (/codecov\/codecov-action/.test(content)) {
+					return {
+						check: 'Coverage upload',
+						status: 'ok',
+						detail: `coverage badge backed by codecov-action in .github/workflows/${f}`,
+					}
+				}
+			}
+		} catch {
+			// fall through to drift
+		}
+	}
+
+	return {
+		check: 'Coverage upload',
+		status: 'drift',
+		detail: 'README has a Codecov badge but no CI step uploads coverage (badge stays red)',
+		hint: 'Run `npx @rtorcato/repo-tooling fix github-actions` to regenerate ci.yml with a Codecov upload step',
+	}
+}
+
+export async function checkAiSetup(dir: string): Promise<CheckResult> {
+	// Consider AI setup present if AGENTS.md carries the js-tooling block or the
+	// Claude skill is installed — the two primary markers `fix ai` writes.
+	const agentsPath = path.join(dir, 'AGENTS.md')
+	const hasAgentsBlock =
+		(await fs.pathExists(agentsPath)) &&
+		(await fs.readFile(agentsPath, 'utf8')).includes('<!-- js-tooling:start -->')
+	const hasSkill =
+		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'repo-tooling.md'))) ||
+		// Pre-rename name — still counts as present until `fix` migrates it.
+		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'js-tooling.md')))
+	if (hasAgentsBlock || hasSkill) {
+		return {
+			check: 'AI setup',
+			status: 'ok',
+			detail: hasAgentsBlock ? 'AGENTS.md has the js-tooling block' : '.claude skill installed',
+		}
+	}
+	return {
+		check: 'AI setup',
+		status: 'optional-missing',
+		detail: 'no AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill)',
+		hint: 'Run `npx @rtorcato/repo-tooling fix ai` to scaffold agent rules for every AI tool',
+	}
+}
+
+export async function checkGitLabCI(dir: string): Promise<CheckResult> {
+	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
+		if (await fs.pathExists(path.join(dir, candidate))) {
+			return {
+				check: 'GitLab CI',
+				status: 'ok',
+				detail: `${candidate} found`,
+			}
+		}
+	}
+	return {
+		check: 'GitLab CI',
+		status: 'optional-missing',
+		detail: 'no .gitlab-ci.yml',
+		hint: 'Run `npx @rtorcato/repo-tooling fix gitlab-ci` to scaffold a starter GitLab pipeline',
+	}
+}

--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
-import type { CheckResult } from '../commands/doctor.js'
+import type { CheckResult } from './types.js'
 
 /**
  * Machine-checks the GitHub side of the repo-tooling standard — branch

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,10 +3,20 @@ import chalk from 'chalk'
 import fs from 'fs-extra'
 import { resolveLanguageModule } from '../../languages/registry.js'
 import { detectLanguage } from '../utils/detect-language.js'
-import { checkGitHubSettings } from '../utils/github-settings.js'
+import { checkGitHubSettings } from '../../base/github-settings.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
-import { checkCodeowners, checkCommunityHealth, checkEditorConfig } from '../../base/checks.js'
+import {
+	checkAiSetup,
+	checkCodeowners,
+	checkCodeQL,
+	checkCommunityHealth,
+	checkCoverageUpload,
+	checkDependabot,
+	checkEditorConfig,
+	checkGitHubActions,
+	checkGitLabCI,
+} from '../../base/checks.js'
 import type { CheckResult, CheckStatus } from '../../base/types.js'
 import {
 	allDeps,
@@ -47,42 +57,6 @@ export interface DoctorOptions {
 }
 
 const PACKAGE = '@rtorcato/repo-tooling'
-
-async function checkGitHubActions(dir: string): Promise<CheckResult> {
-	const workflowsDir = path.join(dir, '.github', 'workflows')
-	if (!(await fs.pathExists(workflowsDir))) {
-		return {
-			check: 'GitHub Actions',
-			status: 'optional-missing',
-			detail: 'no .github/workflows/',
-			hint: 'Run `npx @rtorcato/repo-tooling setup` to scaffold a CI workflow',
-		}
-	}
-
-	try {
-		const files = await fs.readdir(workflowsDir)
-		const workflows = files.filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
-		if (workflows.length === 0) {
-			return {
-				check: 'GitHub Actions',
-				status: 'optional-missing',
-				detail: '.github/workflows/ is empty',
-				hint: 'Add a workflow file (e.g. ci.yml) under .github/workflows/',
-			}
-		}
-		return {
-			check: 'GitHub Actions',
-			status: 'ok',
-			detail: `${workflows.length} workflow${workflows.length === 1 ? '' : 's'} in .github/workflows/`,
-		}
-	} catch {
-		return {
-			check: 'GitHub Actions',
-			status: 'optional-missing',
-			detail: 'unable to read .github/workflows/',
-		}
-	}
-}
 
 // Detects the broken-release-on-protected-main footgun: a workflow that runs
 // semantic-release but only hands it GITHUB_TOKEN, which can't push the version
@@ -162,150 +136,6 @@ async function checkNpmOidcPublish(dir: string, pkg: Pkg | null): Promise<CheckR
 	}
 }
 
-async function checkDependabot(dir: string): Promise<CheckResult> {
-	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
-		const candidatePath = path.join(dir, candidate)
-		if (await fs.pathExists(candidatePath)) {
-			// The canonical standard (apps/docs/docs/guides/dependabot-strategy.md) is
-			// the safe-tier + major-tier grouping plus the auto-merge workflow that
-			// depends on it. Flag any config that predates it so `fix dependabot` can
-			// bring the pair up to standard.
-			const content = await fs.readFile(candidatePath, 'utf8')
-			const deltas: string[] = []
-			for (const group of ['production-minor', 'dev-minor', 'major-updates']) {
-				if (!new RegExp(`^\\s*${group}:`, 'm').test(content)) {
-					deltas.push(`missing \`${group}\` group`)
-				}
-			}
-			const automergePath = path.join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
-			if (!(await fs.pathExists(automergePath))) {
-				deltas.push('missing dependabot-automerge workflow')
-			}
-			if (deltas.length > 0) {
-				return {
-					check: 'Dependabot',
-					status: 'drift',
-					detail: `${candidate} drifts from canonical (${deltas.join('; ')})`,
-					hint: 'Run `npx @rtorcato/repo-tooling fix dependabot` to apply the canonical grouping + auto-merge workflow',
-				}
-			}
-			return {
-				check: 'Dependabot',
-				status: 'ok',
-				detail: `${candidate} + auto-merge workflow`,
-			}
-		}
-	}
-	for (const candidate of [
-		'renovate.json',
-		'renovate.json5',
-		'.github/renovate.json',
-		'.github/renovate.json5',
-		'.renovaterc',
-		'.renovaterc.json',
-	]) {
-		if (await fs.pathExists(path.join(dir, candidate))) {
-			return {
-				check: 'Dependabot',
-				status: 'ok',
-				detail: `${candidate} found (Renovate)`,
-			}
-		}
-	}
-	return {
-		check: 'Dependabot',
-		status: 'optional-missing',
-		detail: 'no Dependabot or Renovate config',
-		hint: 'Run `npx @rtorcato/repo-tooling fix dependabot` (or `fix renovate`) to scaffold weekly dep updates',
-	}
-}
-
-async function checkCodeQL(dir: string): Promise<CheckResult> {
-	const workflowsDir = path.join(dir, '.github', 'workflows')
-	if (!(await fs.pathExists(workflowsDir))) {
-		return {
-			check: 'CodeQL',
-			status: 'optional-missing',
-			detail: 'no .github/workflows/',
-			hint: 'Run `npx @rtorcato/repo-tooling fix codeql` to scaffold CodeQL security scanning',
-		}
-	}
-	for (const candidate of ['codeql.yml', 'codeql.yaml']) {
-		if (await fs.pathExists(path.join(workflowsDir, candidate))) {
-			return {
-				check: 'CodeQL',
-				status: 'ok',
-				detail: `.github/workflows/${candidate} found`,
-			}
-		}
-	}
-	try {
-		const files = await fs.readdir(workflowsDir)
-		for (const f of files) {
-			if (!(f.endsWith('.yml') || f.endsWith('.yaml'))) continue
-			const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
-			if (/github\/codeql-action/.test(content)) {
-				return {
-					check: 'CodeQL',
-					status: 'ok',
-					detail: `codeql-action referenced in ${f}`,
-				}
-			}
-		}
-	} catch {
-		// fall through to optional-missing
-	}
-	return {
-		check: 'CodeQL',
-		status: 'optional-missing',
-		detail: 'no codeql workflow found',
-		hint: 'Run `npx @rtorcato/repo-tooling fix codeql` to scaffold CodeQL security scanning',
-	}
-}
-
-// A README that advertises a Codecov badge but a CI that never uploads coverage
-// leaves the badge permanently red. Only flags when the badge is actually present
-// (no badge → nothing to back, so it's not applicable).
-async function checkCoverageUpload(dir: string): Promise<CheckResult> {
-	const readmePath = path.join(dir, 'README.md')
-	const readme = (await fs.pathExists(readmePath)) ? await fs.readFile(readmePath, 'utf8') : ''
-	if (!/codecov\.io/.test(readme)) {
-		return {
-			check: 'Coverage upload',
-			status: 'ok',
-			detail: 'no coverage badge in README (nothing to back)',
-		}
-	}
-
-	const workflowsDir = path.join(dir, '.github', 'workflows')
-	if (await fs.pathExists(workflowsDir)) {
-		try {
-			const files = (await fs.readdir(workflowsDir)).filter(
-				(f) => f.endsWith('.yml') || f.endsWith('.yaml')
-			)
-			for (const f of files) {
-				const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
-				if (/codecov\/codecov-action/.test(content)) {
-					return {
-						check: 'Coverage upload',
-						status: 'ok',
-						detail: `coverage badge backed by codecov-action in .github/workflows/${f}`,
-					}
-				}
-			}
-		} catch {
-			// fall through to drift
-		}
-	}
-
-	return {
-		check: 'Coverage upload',
-		status: 'drift',
-		detail: 'README has a Codecov badge but no CI step uploads coverage (badge stays red)',
-		hint: 'Run `npx @rtorcato/repo-tooling fix github-actions` to regenerate ci.yml with a Codecov upload step',
-	}
-}
-
 function checkLockfile(lock: Lockfile | null): CheckResult {
 	if (!lock) {
 		return {
@@ -327,53 +157,6 @@ function checkLockfile(lock: Lockfile | null): CheckResult {
 		check: 'lockfile',
 		status: 'ok',
 		detail: `.repo-tooling.json v${lock.version} (written by ${lock.writtenBy})`,
-	}
-}
-
-async function checkAiSetup(dir: string): Promise<CheckResult> {
-	// Consider AI setup present if AGENTS.md carries the js-tooling block or the
-	// Claude skill is installed — the two primary markers `fix ai` writes.
-	const agentsPath = path.join(dir, 'AGENTS.md')
-	const hasAgentsBlock =
-		(await fs.pathExists(agentsPath)) &&
-		(await fs.readFile(agentsPath, 'utf8')).includes('<!-- js-tooling:start -->')
-	const hasSkill =
-		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'repo-tooling.md'))) ||
-		// Pre-rename name — still counts as present until `fix` migrates it.
-		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'js-tooling.md')))
-	if (hasAgentsBlock || hasSkill) {
-		return {
-			check: 'AI setup',
-			status: 'ok',
-			detail: hasAgentsBlock ? 'AGENTS.md has the js-tooling block' : '.claude skill installed',
-		}
-	}
-	return {
-		check: 'AI setup',
-		status: 'optional-missing',
-		detail: 'no AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill)',
-		hint: 'Run `npx @rtorcato/repo-tooling fix ai` to scaffold agent rules for every AI tool',
-	}
-}
-
-// Only called for pnpm-workspace monorepos (see runDoctor) — a single-package
-// repo has no use for a task orchestrator, so the check would be noise there.
-// Accepts either Turborepo or Nx (no preference); flags a repo running both.
-async function checkGitLabCI(dir: string): Promise<CheckResult> {
-	for (const candidate of ['.gitlab-ci.yml', '.gitlab-ci.yaml']) {
-		if (await fs.pathExists(path.join(dir, candidate))) {
-			return {
-				check: 'GitLab CI',
-				status: 'ok',
-				detail: `${candidate} found`,
-			}
-		}
-	}
-	return {
-		check: 'GitLab CI',
-		status: 'optional-missing',
-		detail: 'no .gitlab-ci.yml',
-		hint: 'Run `npx @rtorcato/repo-tooling fix gitlab-ci` to scaffold a starter GitLab pipeline',
 	}
 }
 

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -46,7 +46,7 @@ import { generateBun } from '../../cli/generators/bun.js'
 import { generateDocsSite } from '../../cli/generators/docs-site.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../../cli/generators/typedoc.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
-import { applyGithubSettings } from '../../cli/utils/github-settings.js'
+import { applyGithubSettings } from '../../base/github-settings.js'
 import { type Lockfile, LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
 import type { ProjectConfig } from '../../cli/commands/setup.js'
 

--- a/tests/base/github-settings.test.ts
+++ b/tests/base/github-settings.test.ts
@@ -7,8 +7,8 @@ import {
 	checkGitHubSettings,
 	type GhExec,
 	type GhResult,
-} from '../../../src/cli/utils/github-settings.js'
-import { useTmpDir } from '../../helpers/tmp-dir.js'
+} from '../../src/base/github-settings.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
 


### PR DESCRIPTION
Follow-up to #280/#281 (PR #296). Moves the language-agnostic checks out of the CLI layer and into `src/base/`, so every future language module (Swift/Python/Perl) inherits them for free.

## What moved
- **`github-settings.ts`** (branch-protection / merge-settings / workflow-permissions — #137/#138) → `src/base/github-settings.ts`. Its `CheckResult` import flips from `../commands/doctor.js` to `./types.js`, removing a base→cli back-reference. Test relocated to `tests/base/`.
- **6 pure-`dir` hygiene checks** → `src/base/checks.ts`: `checkGitHubActions`, `checkCodeQL`, `checkDependabot`, `checkGitLabCI`, `checkCoverageUpload`, `checkAiSetup`.
- Updated the two `github-settings` importers (`doctor.ts`, `languages/js/fixers.ts`).

## What deliberately stayed in `doctor.ts`
- `checkReleaseToken` + `checkNpmOidcPublish` — semantic-release/npm, JS-ecosystem specific.
- `checkLockfile` — its `Lockfile` type is cli-coupled; moving it to base would be a backward layer dependency.

These await per-module dispatch (#285).

## Verification
Pure refactor, zero behaviour change:
- Byte-identical `doctor --json` snapshot over a 43-check fixture (before == after).
- `tsc` clean, biome clean, **480/480 tests** green.

Closes #282