### PR TITLE
feat(setup): prompt for the repo language (#284)

### DIFF
--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -36,6 +36,7 @@ $ npx @rtorcato/repo-tooling setup
 
 Setting up tooling in: /home/user/my-lib
 
+? 🗣️  What is the primary language of this repo? JavaScript/TypeScript
 ? 📦 What is your project name? my-lib
 ? 🏗️  What type of project are you building? 📚 Library/Package
 ? 📘 Do you want to use TypeScript? Yes
@@ -67,6 +68,7 @@ Running `setup` (or its alias `init`) launches an interactive wizard:
 
 | Prompt | Options |
 |---|---|
+| Primary language | `js` (default), `swift`, `python`, `perl` — defaults to whatever the directory looks like |
 | Project name | defaults to directory name |
 | Project type | `library`, `web-app`, `node-api`, `nextjs-app`, `react-app` |
 | TypeScript? | yes/no |
@@ -82,6 +84,10 @@ Running `setup` (or its alias `init`) launches an interactive wizard:
 | Bundler | `tsup`, `esbuild`, `vite` *(web apps)*, `none` |
 
 A universal baseline (`.editorconfig`, `.nvmrc`, `engines.node`, `knip.json`, `.vscode/extensions.json`) is scaffolded automatically — no prompt — because these are safe defaults for every project.
+
+:::note Non-JS languages
+Only JavaScript/TypeScript has scaffolding today. Picking Swift, Python or Perl writes nothing and points you at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). Presets for the other languages land with their language modules — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
+:::
 
 ## Non-interactive setup (CI / scripts)
 

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -2,7 +2,9 @@ import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
+import { LANGUAGES, type LanguageModule } from '../../languages/registry.js'
 import { generateConfigs } from '../generators/index.js'
+import { detectLanguage } from '../utils/detect-language.js'
 import { formatGeneratedFiles } from '../utils/format.js'
 import { installDependencies } from '../utils/install.js'
 import { LOCKFILE_NAME, writeLockfile } from '../utils/lockfile.js'
@@ -79,7 +81,8 @@ export interface SetupOptions {
 	configSchema?: boolean
 }
 
-async function resolveConfig(options: SetupOptions): Promise<ProjectConfig> {
+/** `null` means the run was declined, not that it failed — see promptForConfig. */
+async function resolveConfig(options: SetupOptions): Promise<ProjectConfig | null> {
 	if (options.config && options.preset) {
 		console.warn(chalk.yellow('⚠️  Both --config and --preset given; --config wins.\n'))
 	}
@@ -131,6 +134,10 @@ export async function setupProject(options: SetupOptions) {
 	try {
 		await fs.ensureDir(targetDir)
 		const config = await resolveConfig(options)
+		// The language picker bails out for a language whose module hasn't landed
+		// yet. It has already explained why — scaffolding a JS project into a Swift
+		// repo would be worse than doing nothing.
+		if (config === null) return
 
 		if (dryRun) {
 			const files = computeFileList(config)
@@ -163,7 +170,60 @@ export async function setupProject(options: SetupOptions) {
 	}
 }
 
-async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
+/**
+ * Ask which language this repo is, defaulting to whatever the target dir looks
+ * like. Languages without a module yet are still offered — hiding them reads as
+ * "repo-tooling is JS-only" when the honest answer is "not yet" (#139).
+ */
+async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
+	const detected = await detectLanguage(targetDir)
+	const { language } = await inquirer.prompt([
+		{
+			type: 'list',
+			name: 'language',
+			message: '🗣️  What is the primary language of this repo?',
+			choices: Object.values(LANGUAGES).map((module) => ({
+				name: module.supported ? module.label : `${module.label} (setup lands with its module)`,
+				value: module.id,
+			})),
+			// 'unknown' is a bare dir mid-setup — JS is the historical default.
+			default: detected === 'unknown' ? 'js' : detected,
+		},
+	])
+	return LANGUAGES[language as LanguageModule['id']]
+}
+
+function explainUnsupported(module: LanguageModule) {
+	console.log(chalk.yellow(`\n⚠️  ${module.label} scaffolding isn't available yet.\n`))
+	console.log(
+		chalk.gray(
+			`   doctor and fix already cover ${module.label} repos with the language-agnostic\n` +
+				'   checks (CI, CodeQL, Dependabot, GitHub repo settings):\n'
+		)
+	)
+	console.log(chalk.gray('     npx @rtorcato/repo-tooling doctor\n'))
+	console.log(
+		chalk.gray(
+			`   ${module.label} presets land with its language module — track the work at\n` +
+				'   https://github.com/rtorcato/repo-tooling/issues/139\n'
+		)
+	)
+}
+
+/** `null` when the chosen language has no scaffolding yet; nothing is written. */
+async function promptForConfig(targetDir: string): Promise<ProjectConfig | null> {
+	const language = await promptForLanguage(targetDir)
+
+	// An allowlist, not a `module.supported` check: `supported` flips when Swift's
+	// doctor/fix module lands (#286), which is earlier than its *scaffolding*
+	// (#288). Keying off it would fall through to the JS question list and write
+	// a package.json into a Swift repo. Bailing out is the safe default; #288
+	// adds the swift branch here deliberately.
+	if (language.id !== 'js') {
+		explainUnsupported(language)
+		return null
+	}
+
 	// Turborepo only makes sense in a pnpm-workspace monorepo, so the prompt is
 	// only offered when one is already present in the target dir.
 	const hasWorkspace = await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))
@@ -393,9 +453,9 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig> {
 
 	return {
 		projectName: answers.projectName,
-		// v1 of the setup wizard scaffolds JS/TS repos only; the field exists so
-		// doctor/fix can gate by language (#139). No prompt yet — always 'js'.
-		language: 'js',
+		// The real answer from the language question above, not a hardcoded 'js'
+		// (#284) — the lockfile is what doctor/fix gate on later.
+		language: language.id,
 		projectType: answers.projectType,
 		typescript: {
 			enabled: answers.useTypeScript || false,

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import fs from 'fs-extra'
+import inquirer from 'inquirer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { setupProject } from '../../../src/cli/commands/setup.js'
 import {
@@ -285,5 +286,109 @@ describe('setup --config', () => {
 			exitSpy.mockRestore()
 			errSpy.mockRestore()
 		}
+	})
+})
+
+// The interactive path (#284). `prompt` is called once for the language, then
+// once for the JS question list — queue an answer per call.
+describe('setup language prompt', () => {
+	function mockPrompt(...answers: Array<Record<string, unknown>>) {
+		const spy = vi.spyOn(inquirer, 'prompt')
+		for (const answer of answers) {
+			spy.mockImplementationOnce((async () => answer) as never)
+		}
+		return spy
+	}
+
+	const JS_ANSWERS = {
+		projectName: 'demo',
+		projectType: 'library',
+		useTypeScript: true,
+		tsConfig: 'base',
+		lintingTool: 'biome',
+		testingFramework: 'vitest',
+		gitHooks: false,
+		commitLint: false,
+		releaseTool: 'none',
+		securityAutomation: false,
+		aiSetup: false,
+		badges: false,
+		bundler: 'none',
+	}
+
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('defaults to the language detected in the target directory', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version:6.0\n')
+		const spy = mockPrompt({ language: 'swift' })
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
+			expect(question.name).toBe('language')
+			expect(question.default).toBe('swift')
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
+	it('falls back to js for a directory with no language marker', async () => {
+		const dir = newTmpDir()
+		const spy = mockPrompt({ language: 'perl' })
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
+			expect(question.default).toBe('js')
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
+	it('offers every registered language, flagging the ones without a module', async () => {
+		const dir = newTmpDir()
+		const spy = mockPrompt({ language: 'js' }, JS_ANSWERS)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
+			const choices = question.choices as Array<{ name: string; value: string }>
+			expect(choices.map((c) => c.value)).toEqual(['js', 'swift', 'python', 'perl'])
+			expect(choices.find((c) => c.value === 'js')?.name).not.toMatch(/lands with/)
+			expect(choices.find((c) => c.value === 'swift')?.name).toMatch(/lands with its module/)
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
+	it('writes nothing and points at doctor when the language has no module yet', async () => {
+		const dir = newTmpDir()
+		mockPrompt({ language: 'swift' })
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+			const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+			expect(output).toMatch(/Swift scaffolding isn't available yet/)
+			expect(output).toMatch(/doctor/)
+		} finally {
+			logSpy.mockRestore()
+		}
+		expect(await fs.readdir(dir)).toEqual([])
+	})
+
+	it('records the chosen language in the lockfile instead of a hardcoded js', async () => {
+		const dir = newTmpDir()
+		mockPrompt({ language: 'js' }, JS_ANSWERS)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+		}
+		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(lock.config.language).toBe('js')
 	})
 })


### PR DESCRIPTION
## Summary

- `setup` hardcoded `language: 'js'` into every config it wrote, so a Swift or Python repo got a lockfile claiming to be JavaScript — the one field `doctor`/`fix` gate on since #285. It now asks.
- The question is first, and defaults to whatever `detectLanguage()` finds in the target dir (`Package.swift`, `cpanfile`, `pyproject.toml`). A bare dir still defaults to `js`.
- Every registered language is offered, not just the supported one — hiding the rest reads as "repo-tooling is JS-only" when the honest answer is "not yet".
- Picking a language with no scaffolding **writes nothing** and points at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). Half-scaffolding a JS project into a Swift repo would be worse than doing nothing.

Last issue in the *Multi-language: core architecture* milestone.

## Design notes

**The gate is an explicit allowlist, not a `module.supported` check.** `supported` flips when Swift's doctor/fix module lands (#286), which is *earlier* than its scaffolding (#288). Keying off it would fall through to the JS question list and write a `package.json` into a Swift repo. #288 adds the swift branch deliberately.

**`resolveConfig()` now returns `null`** for the declined case, so setup exits quietly instead of raising a `❌ Setup failed` — the user didn't do anything wrong.

**`--preset` / `--config` are untouched.** Presets already carry `language: 'js'` via `BASE`, and `CONFIG_SCHEMA` already accepts the field, so a future `swift-library` preset is purely additive. No `--language` flag: the preset name is the language selector, so a flag would have nothing to do until #288.

## Type of change

- [x] New feature

## Test plan

- [x] Existing tests pass (`pnpm test`) — 497 passing
- [x] New tests added — 5 cases covering the detected-language default, the bare-dir fallback, the choice list (including the "lands with its module" labels), the write-nothing bail-out, and the real language reaching the lockfile
- [x] `pnpm verify` clean (biome + typecheck + tests + build)
- [x] `pnpm dogfood` clean (45 checks)
- [x] `pnpm knip` at parity with `main`
- [x] Docs updated — `getting-started.mdx` sample transcript, wizard prompt table, and a note on non-JS languages

## Checklist

- [x] No `console.log` left in production code (the new output is user-facing wizard text)
- [x] No breaking changes — non-interactive paths behave identically
- [x] `pnpm check` (Biome) passes

Closes #284