### PR TITLE
test(setup): drop unsafe optional chaining in the language-prompt tests

### DIFF
--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -300,6 +300,12 @@ describe('setup language prompt', () => {
 		return spy
 	}
 
+	/** The language question, as it was actually handed to inquirer. */
+	function languageQuestion(spy: ReturnType<typeof mockPrompt>): Record<string, unknown> {
+		const [questions] = spy.mock.calls[0] as [Array<Record<string, unknown>>]
+		return questions[0]
+	}
+
 	const JS_ANSWERS = {
 		projectName: 'demo',
 		projectType: 'library',
@@ -327,7 +333,7 @@ describe('setup language prompt', () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await setupProject({ directory: dir, skipInstall: true })
-			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
+			const question = languageQuestion(spy)
 			expect(question.name).toBe('language')
 			expect(question.default).toBe('swift')
 		} finally {
@@ -341,7 +347,7 @@ describe('setup language prompt', () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await setupProject({ directory: dir, skipInstall: true })
-			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
+			const question = languageQuestion(spy)
 			expect(question.default).toBe('js')
 		} finally {
 			logSpy.mockRestore()
@@ -354,7 +360,7 @@ describe('setup language prompt', () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await setupProject({ directory: dir, skipInstall: true })
-			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
+			const question = languageQuestion(spy)
 			const choices = question.choices as Array<{ name: string; value: string }>
 			expect(choices.map((c) => c.value)).toEqual(['js', 'swift', 'python', 'perl'])
 			expect(choices.find((c) => c.value === 'js')?.name).not.toMatch(/lands with/)


### PR DESCRIPTION
## Summary

Follow-up to #301 (landed just after it merged). The language-prompt tests did:

```ts
const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
```

That indexes into the result of an optional chain — if the spy was never called, it throws a `TypeError: Cannot read properties of undefined` instead of failing the assertion with a useful message. Biome flags it as `noUnsafeOptionalChaining`.

Pulled into one `languageQuestion(spy)` helper that destructures instead.

Note: the repo's `pnpm check` only lints `src scripts`, so this never failed CI — it showed up as an editor diagnostic.

## Type of change

- [x] Refactor / cleanup

## Test plan

- [x] `pnpm test` — 27 setup tests pass, 497 total
- [x] `pnpm exec biome check tests/cli/commands/setup.test.ts` clean

## Checklist

- [x] No behaviour change — test-only