### PR TITLE
feat(swift): src/languages/swift module — checks + fixers (#286)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Orientation for coding agents working with `@rtorcato/repo-tooling`. Human-reada
 
 A one-package JavaScript / TypeScript tooling distribution. Ships every preset (TypeScript, Biome, ESLint, Prettier, Vitest, Jest, Commitlint, semantic-release, tsup, esbuild, Vite, Playwright) plus a CLI to scaffold and audit projects. Consumers get one install.
 
+`doctor` and `fix` also audit **Swift** repos (detected via `Package.swift`): the language-agnostic checks plus SwiftLint / Periphery / `.gitignore` / `Package.swift`. `setup` remains JS-only. See `src/languages/` — one directory per language module, `src/base/` for what's shared.
+
 ## CLI surface (agent-friendly)
 
 Every command supports `--json` and a non-interactive mode. Combine with `--yes` for fully autonomous use.

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -86,7 +86,7 @@ Running `setup` (or its alias `init`) launches an interactive wizard:
 A universal baseline (`.editorconfig`, `.nvmrc`, `engines.node`, `knip.json`, `.vscode/extensions.json`) is scaffolded automatically — no prompt — because these are safe defaults for every project.
 
 :::note Non-JS languages
-Only JavaScript/TypeScript has scaffolding today. Picking Swift, Python or Perl writes nothing and points you at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). Presets for the other languages land with their language modules — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
+Only JavaScript/TypeScript has scaffolding today. Picking Swift, Python or Perl writes nothing and points you at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). [Swift](/reference/swift) additionally has its own checks and fixers (SwiftLint, Periphery, `.gitignore`, `Package.swift`) — it just has no setup preset yet. Presets for the other languages land with their language modules — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
 :::
 
 ## Non-interactive setup (CI / scripts)

--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -1,0 +1,100 @@
+---
+title: Swift
+description: SwiftLint and Periphery configs, plus the Swift checks doctor runs on a SwiftPM repo.
+---
+
+Swift is the first non-JavaScript language module. `doctor` and `fix` detect a Swift repo from `Package.swift` and layer Swift-specific checks on top of the language-agnostic ones (CI, CodeQL, Dependabot, GitHub repo settings).
+
+The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-common) actually runs — SwiftLint for lint *and* formatting, Periphery for dead code.
+
+:::note No setup preset yet
+`setup` can't scaffold a Swift project — it audits and fixes an existing one. Picking Swift in the setup wizard points you at `doctor` instead. The `swift-library` preset is tracked in [#288](https://github.com/rtorcato/repo-tooling/issues/288).
+:::
+
+## Checks
+
+| Check | Status when absent | Fix target |
+|---|---|---|
+| `Package.swift` | `missing` | — (run `swift package init`) |
+| SwiftLint | `missing` | `swiftlint` |
+| Periphery | `optional-missing` | `periphery` |
+| Swift `.gitignore` | `missing` | `swift-gitignore` |
+
+`Package.swift` is checked for two things SwiftPM will not infer: a `// swift-tools-version:` comment (without it the manifest doesn't parse) and an explicit `platforms:` clause (without it SwiftPM assumes its oldest supported deployment target, which rejects modern APIs at build time). There's no fixer — rewriting someone's manifest isn't safe, so `doctor` reports and you edit.
+
+## Configs
+
+```bash
+npx @rtorcato/repo-tooling fix swiftlint    # .swiftlint.yml
+npx @rtorcato/repo-tooling fix periphery    # .periphery.yml
+npx @rtorcato/repo-tooling fix swift-gitignore
+```
+
+`swiftlint` and `periphery` are also available via `copy`:
+
+```bash
+npx @rtorcato/repo-tooling copy swiftlint
+```
+
+### SwiftLint
+
+Formatting is SwiftLint's job here — `swiftlint --fix` in a pre-commit hook, `swiftlint lint --strict` in CI. **SwiftFormat is deliberately not part of the standard**; a second formatter would fight the first.
+
+```yaml
+disabled_rules:
+  - weak_delegate
+  - cyclomatic_complexity
+  - force_unwrapping
+  - function_body_length
+  - type_name
+  - line_length
+  - identifier_name
+  - trailing_whitespace
+
+excluded:
+  - .build
+  - .swiftpm
+  - DerivedData
+
+file_length:
+  warning: 500
+  error: 1200
+
+nesting:
+  type_level:
+    warning: 3
+    error: 6
+```
+
+### Periphery
+
+`retain_public: true` keeps a library's public API from being reported as unused — for a SwiftPM package the public surface *is* the product.
+
+```yaml
+retain_public: true
+```
+
+Periphery is best run as an informational CI job (`continue-on-error: true`) until a codebase is clean, then promoted to blocking.
+
+### `.gitignore`
+
+The `swift-gitignore` fixer **appends** the Swift build artefacts rather than replacing the file, so project-specific entries survive. It adds only what's absent:
+
+```gitignore
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+```
+
+`.build` and `DerivedData` are the ones that matter — a single stray commit of either adds hundreds of megabytes to the repo's history.
+
+## What isn't covered yet
+
+- **CI generation.** `.github/workflows/ci.yml` for Swift (plus `language: swift` in the CodeQL matrix) lands in [#287](https://github.com/rtorcato/repo-tooling/issues/287).
+- **Language-agnostic fixers.** `doctor` reports base findings (Dependabot, CodeQL, CODEOWNERS, community health) on a Swift repo, but `fix` reports them as `unsupported` — those fixers still live in the JS module and haven't been split out yet.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -64,6 +64,7 @@ const sidebars: SidebarsConfig = {
         'reference/rolldown',
         'reference/rollup',
         'reference/semantic-release',
+        'reference/swift',
         'reference/tailwind',
         'reference/tsup',
         'reference/turborepo',

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"tooling/semantic-release/*.d.mts",
 		"tooling/claude/*.md",
 		"tooling/mcp/mcp.json.example",
+		"tooling/swift/*.yml",
 		"tooling/github-actions/workflows/*.yml",
 		"README.md",
 		"AGENTS.md"

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -2,6 +2,50 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import type { CheckResult } from './types.js'
 
+/**
+ * "Is one of these files present, and does it look like ours?" — the shape most
+ * config checks take, in any language. Lives in base so the JS and Swift modules
+ * share one implementation instead of two regex-and-fs loops (#286).
+ */
+export interface FileCheck {
+	check: string
+	candidates: string[]
+	/** Phrased to read after the filename: `.swiftlint.yml ${expected}`. */
+	expected: string
+	matcher: RegExp
+	optional?: boolean
+	hint?: string
+}
+
+export async function checkFile(dir: string, spec: FileCheck): Promise<CheckResult> {
+	for (const candidate of spec.candidates) {
+		const filepath = path.join(dir, candidate)
+		if (!(await fs.pathExists(filepath))) continue
+
+		const contents = await fs.readFile(filepath, 'utf-8')
+		if (spec.matcher.test(contents)) {
+			return {
+				check: spec.check,
+				status: 'ok',
+				detail: `${candidate} ${spec.expected}`,
+			}
+		}
+		return {
+			check: spec.check,
+			status: 'drift',
+			detail: `${candidate} found but does not ${spec.expected}`,
+			hint: spec.hint,
+		}
+	}
+
+	return {
+		check: spec.check,
+		status: spec.optional ? 'optional-missing' : 'missing',
+		detail: `no ${spec.candidates.join(' / ')} found`,
+		hint: spec.hint,
+	}
+}
+
 export async function checkEditorConfig(dir: string): Promise<CheckResult> {
 	const exists = await fs.pathExists(path.join(dir, '.editorconfig'))
 	return {

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -1,0 +1,38 @@
+/**
+ * The fixer contract, shared by every language module (#286).
+ *
+ * Only the types live here — the fixers themselves belong to their language
+ * module. `fix` concatenates the set for the repo's detected language.
+ */
+import type { Lockfile } from '../cli/utils/lockfile.js'
+import type { CheckResult } from './types.js'
+
+/** A parsed package.json, or null when the repo has none (any non-JS repo). */
+export type Pkg = Record<string, unknown> | null
+
+interface FixerContext {
+	targetDir: string
+	/** Always null outside the JS module — kept on the shared context so one
+	 * fixer-runner drives every language. */
+	pkg: Pkg
+	result: CheckResult
+	lock: Lockfile | null
+}
+
+export type FixRiskLevel = 'destructive' | 'safe-merge' | 'safe-add'
+
+export interface Fixer {
+	target: string
+	description: string
+	/** Doctor check names this fixer resolves. */
+	appliesTo: string[]
+	outputs: string[]
+	/**
+	 * - destructive (default): overwrites the target file
+	 * - safe-merge: modifies an existing file without replacing user values
+	 * - safe-add: only writes when the target file doesn't yet exist
+	 */
+	riskLevel?: FixRiskLevel
+	canFixDrift?: boolean
+	run(ctx: FixerContext): Promise<{ filesWritten: string[] }>
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import { resolveLanguageModule } from '../../languages/registry.js'
+import { runSwiftChecks } from '../../languages/swift/checks.js'
 import { detectLanguage } from '../utils/detect-language.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
@@ -14,6 +15,7 @@ import {
 	checkCoverageUpload,
 	checkDependabot,
 	checkEditorConfig,
+	checkFile,
 	checkGitHubActions,
 	checkGitLabCI,
 } from '../../base/checks.js'
@@ -23,7 +25,6 @@ import {
 	checkAreTheTypesWrong,
 	checkDocsSite,
 	checkEnginesNode,
-	checkFile,
 	checkHusky,
 	checkHuskyPrePush,
 	checkKnip,
@@ -221,10 +222,25 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 		return demoteDeclined(results, lock)
 	}
 
-	// JS suite. ponytail: JS is the only module carrying checks today, so its
-	// full (base + JS) suite stays inline here rather than behind a
-	// module.runChecks() seam with a single caller — unify when the second
-	// language module lands.
+	// Swift suite (#286): base checks plus the module's own. Swift repos have no
+	// package.json, so nothing JS-shaped runs.
+	if (languageModule.id === 'swift') {
+		const results: CheckResult[] = [
+			{
+				check: 'language',
+				status: 'ok',
+				detail: 'detected Swift (Package.swift)',
+			},
+			...(await runBaseChecks(targetDir, lock)),
+			...(await runSwiftChecks(targetDir)),
+		]
+		return demoteDeclined(results, lock)
+	}
+
+	// JS suite. Still inline rather than behind a module.runChecks() seam: Swift
+	// above is a base+module concatenation, JS interleaves its own checks with
+	// the base ones in a specific display order, so there's no shared shape to
+	// factor out yet. Revisit when Perl/Python land (#289/#290).
 	const pkg = await readPackageJson(targetDir)
 	const results: CheckResult[] = []
 

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -16,13 +16,28 @@ import type { CheckResult } from './doctor.js'
 import { runDoctor } from './doctor.js'
 import { declinedInLock, lockfilePatchForTarget } from './fix-targets.js'
 import { computeFileList } from './setup-presets.js'
-import {
-	type Fixer,
-	FIXERS,
-	type FixRiskLevel,
-	type Pkg,
-	readPackageJson,
-} from '../../languages/js/fixers.js'
+import type { Fixer, FixRiskLevel, Pkg } from '../../base/fixers.js'
+import { FIXERS, readPackageJson } from '../../languages/js/fixers.js'
+import { SWIFT_FIXERS } from '../../languages/swift/fixers.js'
+import { detectLanguage } from '../utils/detect-language.js'
+
+/**
+ * The fixers that apply to a repo, by detected language (#286). Swift repos get
+ * the Swift set; everything else (including a bare dir mid-setup) gets JS, the
+ * historical default.
+ *
+ * ponytail: no base/language split yet. Most of the JS set is *actually*
+ * language-agnostic (dependabot, codeql, codeowners, community-health, …), so a
+ * Swift repo currently sees those checks from doctor but can't fix them. That
+ * move is the fixer sibling of #282 and gets its own issue rather than riding
+ * along here.
+ */
+function fixersForLanguage(language: string): Fixer[] {
+	return language === 'swift' ? SWIFT_FIXERS : FIXERS
+}
+
+/** Every fixer across every language — for `--list` and the unknown-target hint. */
+const ALL_FIXERS: Fixer[] = [...FIXERS, ...SWIFT_FIXERS]
 
 export interface FixOptions {
 	directory?: string
@@ -52,7 +67,7 @@ export interface FixJsonResult {
 }
 
 export function getFixers(): Fixer[] {
-	return FIXERS
+	return ALL_FIXERS
 }
 
 async function ownOutputsPresent(targetDir: string, fixer: Fixer): Promise<boolean> {
@@ -66,18 +81,18 @@ async function ownOutputsPresent(targetDir: string, fixer: Fixer): Promise<boole
 	return false
 }
 
-function findFixer(target: string): Fixer | undefined {
+function findFixer(fixers: Fixer[], target: string): Fixer | undefined {
 	const normalized = target.toLowerCase()
-	return FIXERS.find((f) => f.target.toLowerCase() === normalized)
+	return fixers.find((f) => f.target.toLowerCase() === normalized)
 }
 
-function findFixerForCheck(checkName: string): Fixer | undefined {
-	return FIXERS.find((f) => f.appliesTo.includes(checkName))
+function findFixerForCheck(fixers: Fixer[], checkName: string): Fixer | undefined {
+	return fixers.find((f) => f.appliesTo.includes(checkName))
 }
 
-function logTargets() {
+function logTargets(fixers: Fixer[]) {
 	console.log(chalk.gray('Available fix targets:'))
-	for (const f of FIXERS) {
+	for (const f of fixers) {
 		console.log(`  ${chalk.green('●')} ${chalk.bold(f.target)}: ${chalk.gray(f.description)}`)
 	}
 }
@@ -92,7 +107,7 @@ export interface FixerSummary {
 }
 
 export function listFixers(): FixerSummary[] {
-	return FIXERS.map((f) => ({
+	return ALL_FIXERS.map((f) => ({
 		target: f.target,
 		description: f.description,
 		appliesTo: f.appliesTo,
@@ -402,6 +417,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 
 	const pkg = await readPackageJson(targetDir)
 	const lock = await readLockfile(targetDir)
+	const fixers = fixersForLanguage(await detectLanguage(targetDir))
 	const results = await runDoctor(targetDir)
 	const actions: FixActionRecord[] = []
 
@@ -424,7 +440,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 	}
 
 	if (target) {
-		const fixer = findFixer(target)
+		const fixer = findFixer(fixers, target)
 		if (!fixer) {
 			if (json) {
 				console.log(
@@ -442,7 +458,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 				process.exit(1)
 			}
 			console.error(chalk.red(`\n❌ Unknown fix target: ${target}\n`))
-			logTargets()
+			logTargets(fixers)
 			console.log()
 			process.exit(1)
 		}
@@ -527,7 +543,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 	let unsupportedCount = 0
 
 	for (const result of fixable) {
-		const fixer = findFixerForCheck(result.check)
+		const fixer = findFixerForCheck(fixers, result.check)
 		if (!fixer) {
 			actions.push(recordFor(null, result.check, result.status, 'unsupported', []))
 			if (!silent) console.log(chalk.gray(`  — ${result.check}: no fixer registered`))

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -171,9 +171,18 @@ export async function setupProject(options: SetupOptions) {
 }
 
 /**
+ * Languages `setup` can scaffold. Deliberately separate from the registry's
+ * `supported` flag, which means "has doctor/fix checks" — Swift's module landed
+ * in #286 but its presets land in #288, so it can be audited without being
+ * scaffoldable. Both the picker label and the gate below read from here, so the
+ * two can't drift apart.
+ */
+const SCAFFOLDABLE: ReadonlyArray<LanguageModule['id']> = ['js']
+
+/**
  * Ask which language this repo is, defaulting to whatever the target dir looks
- * like. Languages without a module yet are still offered — hiding them reads as
- * "repo-tooling is JS-only" when the honest answer is "not yet" (#139).
+ * like. Languages setup can't scaffold yet are still offered — hiding them reads
+ * as "repo-tooling is JS-only" when the honest answer is "not yet" (#139).
  */
 async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
 	const detected = await detectLanguage(targetDir)
@@ -183,7 +192,9 @@ async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
 			name: 'language',
 			message: '🗣️  What is the primary language of this repo?',
 			choices: Object.values(LANGUAGES).map((module) => ({
-				name: module.supported ? module.label : `${module.label} (setup lands with its module)`,
+				name: SCAFFOLDABLE.includes(module.id)
+					? module.label
+					: `${module.label} (${module.supported ? 'doctor/fix only — no setup preset yet' : 'setup lands with its module'})`,
 				value: module.id,
 			})),
 			// 'unknown' is a bare dir mid-setup — JS is the historical default.
@@ -193,18 +204,22 @@ async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
 	return LANGUAGES[language as LanguageModule['id']]
 }
 
-function explainUnsupported(module: LanguageModule) {
+function explainNotScaffoldable(module: LanguageModule) {
 	console.log(chalk.yellow(`\n⚠️  ${module.label} scaffolding isn't available yet.\n`))
 	console.log(
 		chalk.gray(
-			`   doctor and fix already cover ${module.label} repos with the language-agnostic\n` +
-				'   checks (CI, CodeQL, Dependabot, GitHub repo settings):\n'
+			module.supported
+				? `   doctor and fix already audit ${module.label} repos — both the language-agnostic\n` +
+						`   checks (CI, CodeQL, Dependabot, GitHub repo settings) and the ${module.label}-specific\n` +
+						'   ones:\n'
+				: `   doctor and fix already cover ${module.label} repos with the language-agnostic\n` +
+						'   checks (CI, CodeQL, Dependabot, GitHub repo settings):\n'
 		)
 	)
 	console.log(chalk.gray('     npx @rtorcato/repo-tooling doctor\n'))
 	console.log(
 		chalk.gray(
-			`   ${module.label} presets land with its language module — track the work at\n` +
+			`   ${module.label} setup presets are tracked at\n` +
 				'   https://github.com/rtorcato/repo-tooling/issues/139\n'
 		)
 	)
@@ -214,15 +229,15 @@ function explainUnsupported(module: LanguageModule) {
 async function promptForConfig(targetDir: string): Promise<ProjectConfig | null> {
 	const language = await promptForLanguage(targetDir)
 
-	// An allowlist, not a `module.supported` check: `supported` flips when Swift's
-	// doctor/fix module lands (#286), which is earlier than its *scaffolding*
-	// (#288). Keying off it would fall through to the JS question list and write
-	// a package.json into a Swift repo. Bailing out is the safe default; #288
-	// adds the swift branch here deliberately.
-	if (language.id !== 'js') {
-		explainUnsupported(language)
+	// Gate on SCAFFOLDABLE, not `module.supported` — Swift is supported (#286)
+	// but has no preset yet (#288), and falling through here would write a
+	// package.json into a Swift repo.
+	if (!SCAFFOLDABLE.includes(language.id)) {
+		explainNotScaffoldable(language)
 		return null
 	}
+	// Narrowing for the question list below, which is JS-shaped throughout.
+	if (language.id !== 'js') return null
 
 	// Turborepo only makes sense in a pnpm-workspace monorepo, so the prompt is
 	// only offered when one is already present in the target dir.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -256,6 +256,18 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: 'codeql',
 	},
 	{
+		name: 'SwiftLint',
+		description: 'Swift linter configuration (lint + --fix; pairs with `swiftlint --strict` in CI)',
+		exports: [],
+		fixTarget: 'swiftlint',
+	},
+	{
+		name: 'Periphery',
+		description: 'Swift dead-code scanner configuration (retains public API for SwiftPM libraries)',
+		exports: [],
+		fixTarget: 'periphery',
+	},
+	{
 		name: 'AI Agent Setup',
 		description: 'Scaffold AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill, MCP example',
 		exports: [],

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -9,6 +9,8 @@ export type PresetName =
 	| 'release-please'
 	| 'oxlint'
 	| 'tsconfig'
+	| 'swiftlint'
+	| 'periphery'
 	| 'claude-skill'
 	| 'mcp-example'
 	| 'docusaurus-sync-changelog'
@@ -58,6 +60,16 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/typescript/tsconfig.base.json',
 		target: 'tsconfig.json',
 		desc: 'TypeScript base configuration',
+	},
+	swiftlint: {
+		source: 'tooling/swift/swiftlint.yml',
+		target: '.swiftlint.yml',
+		desc: 'SwiftLint configuration (lint + --fix; the standard swift-common runs)',
+	},
+	periphery: {
+		source: 'tooling/swift/periphery.yml',
+		target: '.periphery.yml',
+		desc: 'Periphery dead-code scan configuration (retains public API)',
 	},
 	'claude-skill': {
 		source: 'tooling/claude/repo-tooling.md',

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fs from 'fs-extra'
+import type { FileCheck } from '../../base/checks.js'
 import type { CheckResult } from '../../base/types.js'
 import { BADGE_START, hasPublicOnlyBadges } from '../../cli/generators/badges.js'
 
@@ -48,15 +49,6 @@ export function evaluateNodeVersion(version: string): CheckResult {
 		status: 'ok',
 		detail: display,
 	}
-}
-
-interface FileCheck {
-	check: string
-	candidates: string[]
-	expected: string
-	matcher: RegExp
-	optional?: boolean
-	hint?: string
 }
 
 export const FILE_CHECKS: FileCheck[] = [
@@ -132,35 +124,6 @@ export const FILE_CHECKS: FileCheck[] = [
 		hint: 'Run `npx @rtorcato/repo-tooling fix release-please` to scaffold',
 	},
 ]
-
-export async function checkFile(dir: string, spec: FileCheck): Promise<CheckResult> {
-	for (const candidate of spec.candidates) {
-		const filepath = path.join(dir, candidate)
-		if (!(await fs.pathExists(filepath))) continue
-
-		const contents = await fs.readFile(filepath, 'utf-8')
-		if (spec.matcher.test(contents)) {
-			return {
-				check: spec.check,
-				status: 'ok',
-				detail: `${candidate} ${spec.expected}`,
-			}
-		}
-		return {
-			check: spec.check,
-			status: 'drift',
-			detail: `${candidate} found but does not ${spec.expected}`,
-			hint: spec.hint,
-		}
-	}
-
-	return {
-		check: spec.check,
-		status: spec.optional ? 'optional-missing' : 'missing',
-		detail: `no ${spec.candidates.join(' / ')} found`,
-		hint: spec.hint,
-	}
-}
 
 export type Pkg = Record<string, unknown>
 

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
-import type { CheckResult } from '../../base/types.js'
 import { installAgentRules, installAiSetup } from '../../cli/generators/agent-rules.js'
 import { buildBadgeBlock, parseRepository, upsertBadges } from '../../cli/generators/badges.js'
 import {
@@ -47,35 +46,13 @@ import { generateDocsSite } from '../../cli/generators/docs-site.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../../cli/generators/typedoc.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { applyGithubSettings } from '../../base/github-settings.js'
-import { type Lockfile, LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
+import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
 import type { ProjectConfig } from '../../cli/commands/setup.js'
 import { LANGUAGES } from '../registry.js'
 
-export type Pkg = Record<string, unknown> | null
-
-export interface FixerContext {
-	targetDir: string
-	pkg: Pkg
-	result: CheckResult
-	lock: Lockfile | null
-}
-
-export type FixRiskLevel = 'destructive' | 'safe-merge' | 'safe-add'
-
-export interface Fixer {
-	target: string
-	description: string
-	appliesTo: string[]
-	outputs: string[]
-	/**
-	 * - destructive (default): overwrites the target file
-	 * - safe-merge: modifies an existing file without replacing user values
-	 * - safe-add: only writes when the target file doesn't yet exist
-	 */
-	riskLevel?: FixRiskLevel
-	canFixDrift?: boolean
-	run(ctx: FixerContext): Promise<{ filesWritten: string[] }>
-}
+// The fixer contract moved to src/base/fixers.ts when Swift became the second
+// module (#286) — import it from there.
+import type { Fixer, Pkg } from '../../base/fixers.js'
 
 function inferProjectConfig(pkg: Pkg): ProjectConfig {
 	const deps = {

--- a/src/languages/registry.ts
+++ b/src/languages/registry.ts
@@ -31,7 +31,7 @@ export const LANGUAGES: Record<LanguageModule['id'], LanguageModule> = {
 		codeqlLanguages: ['javascript-typescript'],
 		supported: true,
 	},
-	swift: { id: 'swift', label: 'Swift', codeqlLanguages: ['swift'], supported: false },
+	swift: { id: 'swift', label: 'Swift', codeqlLanguages: ['swift'], supported: true },
 	python: { id: 'python', label: 'Python', codeqlLanguages: ['python'], supported: false },
 	perl: { id: 'perl', label: 'Perl', codeqlLanguages: [], supported: false },
 }

--- a/src/languages/swift/checks.ts
+++ b/src/languages/swift/checks.ts
@@ -1,0 +1,125 @@
+/**
+ * Swift language module — checks (#286).
+ *
+ * The standard encoded here is the one `swift-common` actually runs: SwiftLint
+ * (lint + `--fix` in pre-commit, `--strict` in CI) and Periphery for dead code.
+ * Deliberately *not* checked:
+ *
+ * - SwiftFormat — SwiftLint's `--fix` does the formatting; a second formatter
+ *   would fight it.
+ * - `.swift-version` — the toolchain is pinned in CI (`setup-xcode`) and the
+ *   package declares `// swift-tools-version:`, so a root file would be a third
+ *   place to keep in sync.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+import { type FileCheck, checkFile } from '../../base/checks.js'
+import type { CheckResult } from '../../base/types.js'
+
+const SWIFT_FILE_CHECKS: FileCheck[] = [
+	{
+		check: 'SwiftLint',
+		candidates: ['.swiftlint.yml', '.swiftlint.yaml'],
+		// SwiftLint configs are project-owned — there's no `extends` mechanism to
+		// point at ours, so any file declaring real config counts as ok.
+		expected: 'is a valid SwiftLint configuration',
+		matcher: /^(disabled_rules|opt_in_rules|only_rules|included|excluded|analyzer_rules):/m,
+		hint: 'Run `npx @rtorcato/repo-tooling fix swiftlint` to scaffold',
+	},
+	{
+		check: 'Periphery',
+		candidates: ['.periphery.yml', '.periphery.yaml'],
+		expected: 'is a valid Periphery configuration',
+		matcher: /^(retain_public|project|schemes|targets|index_exclude):/m,
+		optional: true,
+		hint: 'Run `npx @rtorcato/repo-tooling fix periphery` to scaffold a dead-code scan config',
+	},
+]
+
+/**
+ * Build artefacts that must never be committed. `.build` and `DerivedData` are
+ * the expensive ones — a single stray commit of either adds hundreds of MB.
+ */
+const REQUIRED_GITIGNORE_ENTRIES = ['.build', 'DerivedData', 'xcuserdata']
+
+export async function checkSwiftGitignore(dir: string): Promise<CheckResult> {
+	const filepath = path.join(dir, '.gitignore')
+	if (!(await fs.pathExists(filepath))) {
+		return {
+			check: 'Swift .gitignore',
+			status: 'missing',
+			detail: 'no .gitignore',
+			hint: 'Run `npx @rtorcato/repo-tooling fix swift-gitignore` to scaffold the Swift template',
+		}
+	}
+
+	const contents = await fs.readFile(filepath, 'utf-8')
+	const missing = REQUIRED_GITIGNORE_ENTRIES.filter((entry) => !contents.includes(entry))
+	if (missing.length > 0) {
+		return {
+			check: 'Swift .gitignore',
+			status: 'drift',
+			detail: `.gitignore missing Swift build artefacts: ${missing.join(', ')}`,
+			hint: 'Run `npx @rtorcato/repo-tooling fix swift-gitignore` to append the missing entries',
+		}
+	}
+
+	return {
+		check: 'Swift .gitignore',
+		status: 'ok',
+		detail: '.gitignore covers .build, DerivedData and xcuserdata',
+	}
+}
+
+/**
+ * Package.swift hygiene. Both signals are things SwiftPM will not infer for
+ * you: without a tools-version comment the manifest doesn't parse at all, and
+ * without `platforms:` SwiftPM assumes the oldest deployment target it supports,
+ * which silently rejects modern APIs at build time.
+ */
+export async function checkPackageSwift(dir: string): Promise<CheckResult> {
+	const filepath = path.join(dir, 'Package.swift')
+	if (!(await fs.pathExists(filepath))) {
+		return {
+			check: 'Package.swift',
+			status: 'missing',
+			detail: 'no Package.swift',
+			hint: 'Run `swift package init` to create a SwiftPM manifest',
+		}
+	}
+
+	const contents = await fs.readFile(filepath, 'utf-8')
+	const toolsVersion = contents.match(/^\/\/\s*swift-tools-version:\s*([\d.]+)/m)?.[1]
+	if (!toolsVersion) {
+		return {
+			check: 'Package.swift',
+			status: 'drift',
+			detail: 'Package.swift has no `// swift-tools-version:` comment',
+			hint: 'Add `// swift-tools-version: 5.9` as the first line — SwiftPM requires it',
+		}
+	}
+
+	if (!/\bplatforms:\s*\[/.test(contents)) {
+		return {
+			check: 'Package.swift',
+			status: 'drift',
+			detail: `Package.swift (tools ${toolsVersion}) declares no \`platforms:\``,
+			hint: 'Add a `platforms:` clause — without it SwiftPM assumes the oldest supported deployment target',
+		}
+	}
+
+	return {
+		check: 'Package.swift',
+		status: 'ok',
+		detail: `Package.swift declares tools ${toolsVersion} and explicit platforms`,
+	}
+}
+
+/** The Swift module's suite, layered on top of the base checks by doctor. */
+export async function runSwiftChecks(dir: string): Promise<CheckResult[]> {
+	return [
+		await checkPackageSwift(dir),
+		...(await Promise.all(SWIFT_FILE_CHECKS.map((spec) => checkFile(dir, spec)))),
+		await checkSwiftGitignore(dir),
+	]
+}

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -1,0 +1,86 @@
+/**
+ * Swift language module — fixers (#286). One per check in ./checks.ts.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+import type { Fixer } from '../../base/fixers.js'
+import { copyPreset } from '../../cli/utils/copy-preset.js'
+
+/**
+ * The Swift build artefacts that must stay out of git. Appended to an existing
+ * .gitignore rather than replacing it — a Swift repo's ignore file usually
+ * carries project-specific entries worth keeping.
+ */
+const SWIFT_GITIGNORE_BLOCK = `# Swift / SwiftPM
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+`
+
+/** Entries whose presence means the block (or an equivalent) is already there. */
+const SENTINELS = ['.build', 'DerivedData', 'xcuserdata']
+
+export async function ensureSwiftGitignore(targetDir: string): Promise<string[]> {
+	const filepath = path.join(targetDir, '.gitignore')
+	if (!(await fs.pathExists(filepath))) {
+		await fs.writeFile(filepath, SWIFT_GITIGNORE_BLOCK)
+		return ['.gitignore']
+	}
+
+	const existing = await fs.readFile(filepath, 'utf-8')
+	const missing = SENTINELS.filter((entry) => !existing.includes(entry))
+	if (missing.length === 0) return []
+
+	// Append only what's absent, so a repo that already ignores .build doesn't
+	// get a duplicate entry for it.
+	const additions = SWIFT_GITIGNORE_BLOCK.split('\n').filter(
+		(line) => line.length > 0 && !existing.includes(line)
+	)
+	const separator = existing.endsWith('\n') ? '' : '\n'
+	await fs.writeFile(filepath, `${existing}${separator}\n${additions.join('\n')}\n`)
+	return ['.gitignore']
+}
+
+export const SWIFT_FIXERS: Fixer[] = [
+	{
+		target: 'swiftlint',
+		description: 'Scaffold .swiftlint.yml (the SwiftLint config swift-common runs)',
+		appliesTo: ['SwiftLint'],
+		outputs: ['.swiftlint.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('swiftlint', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'periphery',
+		description: 'Scaffold .periphery.yml (dead-code scan config, retains public API)',
+		appliesTo: ['Periphery'],
+		outputs: ['.periphery.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('periphery', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'swift-gitignore',
+		description:
+			'Add the Swift/SwiftPM build artefacts (.build, DerivedData, xcuserdata) to .gitignore',
+		appliesTo: ['Swift .gitignore'],
+		// Appends what's missing; never clobbers a project's own entries.
+		riskLevel: 'safe-merge',
+		outputs: ['.gitignore'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await ensureSwiftGitignore(targetDir) }
+		},
+	},
+]

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -357,8 +357,11 @@ describe('setup language prompt', () => {
 			const question = (spy.mock.calls[0]?.[0] as Array<Record<string, unknown>>)[0]
 			const choices = question.choices as Array<{ name: string; value: string }>
 			expect(choices.map((c) => c.value)).toEqual(['js', 'swift', 'python', 'perl'])
-			expect(choices.find((c) => c.value === 'js')?.name).not.toMatch(/lands with/)
-			expect(choices.find((c) => c.value === 'swift')?.name).toMatch(/lands with its module/)
+			expect(choices.find((c) => c.value === 'js')?.name).toBe('JavaScript/TypeScript')
+			// Swift has doctor/fix checks (#286) but no setup preset yet (#288) — the
+			// label has to say so rather than reading as fully supported.
+			expect(choices.find((c) => c.value === 'swift')?.name).toMatch(/no setup preset yet/)
+			expect(choices.find((c) => c.value === 'perl')?.name).toMatch(/lands with its module/)
 		} finally {
 			logSpy.mockRestore()
 		}

--- a/tests/languages/registry.test.ts
+++ b/tests/languages/registry.test.ts
@@ -10,9 +10,10 @@ describe('resolveLanguageModule', () => {
 		expect(resolveLanguageModule(id).id).toBe(id)
 	})
 
-	it('only JS is supported today; the rest gate out until their modules land', () => {
+	it('JS and Swift carry modules; Python and Perl gate out until theirs land', () => {
 		expect(LANGUAGES.js.supported).toBe(true)
-		expect(LANGUAGES.swift.supported).toBe(false)
+		// Swift flipped with its module (#286).
+		expect(LANGUAGES.swift.supported).toBe(true)
 		expect(LANGUAGES.python.supported).toBe(false)
 		expect(LANGUAGES.perl.supported).toBe(false)
 	})

--- a/tests/languages/swift/checks.test.ts
+++ b/tests/languages/swift/checks.test.ts
@@ -1,0 +1,120 @@
+import fs from 'fs-extra'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+	checkPackageSwift,
+	checkSwiftGitignore,
+	runSwiftChecks,
+} from '../../../src/languages/swift/checks.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const VALID_MANIFEST = `// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "Demo",
+    platforms: [.iOS(.v16), .macOS(.v13)],
+    products: [.library(name: "Demo", targets: ["Demo"])],
+    targets: [.target(name: "Demo")]
+)
+`
+
+describe('checkPackageSwift', () => {
+	it('is missing without a manifest', async () => {
+		const result = await checkPackageSwift(newTmpDir())
+		expect(result.status).toBe('missing')
+	})
+
+	it('passes a manifest with a tools version and explicit platforms', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), VALID_MANIFEST)
+		const result = await checkPackageSwift(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('5.9')
+	})
+
+	it('flags a manifest with no swift-tools-version comment', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), 'import PackageDescription\n')
+		const result = await checkPackageSwift(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toMatch(/swift-tools-version/)
+	})
+
+	it('flags a manifest with no platforms clause', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(
+			join(dir, 'Package.swift'),
+			'// swift-tools-version: 5.9\nlet package = Package(name: "Demo")\n'
+		)
+		const result = await checkPackageSwift(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toMatch(/platforms/)
+	})
+
+	it('accepts the tools-version comment without a space after the colon', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(
+			join(dir, 'Package.swift'),
+			'//swift-tools-version:6.0\nlet package = Package(name: "D", platforms: [.iOS(.v16)])\n'
+		)
+		expect((await checkPackageSwift(dir)).status).toBe('ok')
+	})
+})
+
+describe('checkSwiftGitignore', () => {
+	it('is missing without a .gitignore', async () => {
+		expect((await checkSwiftGitignore(newTmpDir())).status).toBe('missing')
+	})
+
+	it('passes when the build artefacts are covered', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '/.build\nDerivedData/\nxcuserdata/\n')
+		expect((await checkSwiftGitignore(dir)).status).toBe('ok')
+	})
+
+	it('names the entries that are missing', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '/.build\n')
+		const result = await checkSwiftGitignore(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('DerivedData')
+		expect(result.detail).toContain('xcuserdata')
+		expect(result.detail).not.toContain('.build,')
+	})
+})
+
+describe('runSwiftChecks', () => {
+	it('covers Package.swift, SwiftLint, Periphery and the gitignore', async () => {
+		const names = (await runSwiftChecks(newTmpDir())).map((r) => r.check)
+		expect(names).toEqual(['Package.swift', 'SwiftLint', 'Periphery', 'Swift .gitignore'])
+	})
+
+	it('treats Periphery as optional but SwiftLint as required', async () => {
+		const results = await runSwiftChecks(newTmpDir())
+		const byName = Object.fromEntries(results.map((r) => [r.check, r.status]))
+		expect(byName.SwiftLint).toBe('missing')
+		expect(byName.Periphery).toBe('optional-missing')
+	})
+
+	it('accepts the configs the swiftlint/periphery fixers write', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.swiftlint.yml'), 'disabled_rules:\n  - line_length\n')
+		await fs.writeFile(join(dir, '.periphery.yml'), 'retain_public: true\n')
+		const byName = Object.fromEntries(
+			(await runSwiftChecks(dir)).map((r) => [r.check, r.status])
+		)
+		expect(byName.SwiftLint).toBe('ok')
+		expect(byName.Periphery).toBe('ok')
+	})
+
+	it('flags a SwiftLint file that carries no recognisable config', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.swiftlint.yml'), '# TODO: fill this in\n')
+		const results = await runSwiftChecks(dir)
+		expect(results.find((r) => r.check === 'SwiftLint')?.status).toBe('drift')
+	})
+})

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -1,0 +1,77 @@
+import fs from 'fs-extra'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { checkSwiftGitignore } from '../../../src/languages/swift/checks.js'
+import { SWIFT_FIXERS, ensureSwiftGitignore } from '../../../src/languages/swift/fixers.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+function fixer(target: string) {
+	const found = SWIFT_FIXERS.find((f) => f.target === target)
+	if (!found) throw new Error(`no swift fixer: ${target}`)
+	return found
+}
+
+const ctx = (targetDir: string) => ({
+	targetDir,
+	pkg: null,
+	result: { check: 'x', status: 'missing' as const, detail: '' },
+	lock: null,
+})
+
+describe('swift fixers', () => {
+	it('every fixer resolves a check the Swift module actually emits', () => {
+		const emitted = ['SwiftLint', 'Periphery', 'Swift .gitignore']
+		for (const f of SWIFT_FIXERS) {
+			for (const check of f.appliesTo) expect(emitted).toContain(check)
+		}
+	})
+
+	it('swiftlint writes a config the SwiftLint check accepts', async () => {
+		const dir = newTmpDir()
+		const { filesWritten } = await fixer('swiftlint').run(ctx(dir))
+		expect(filesWritten).toEqual(['.swiftlint.yml'])
+		const contents = await fs.readFile(join(dir, '.swiftlint.yml'), 'utf-8')
+		expect(contents).toContain('disabled_rules:')
+		expect(contents).toContain('force_unwrapping')
+	})
+
+	it('periphery writes a config that retains the public API', async () => {
+		const dir = newTmpDir()
+		await fixer('periphery').run(ctx(dir))
+		expect(await fs.readFile(join(dir, '.periphery.yml'), 'utf-8')).toContain('retain_public: true')
+	})
+})
+
+describe('ensureSwiftGitignore', () => {
+	it('creates the file when absent and satisfies the check', async () => {
+		const dir = newTmpDir()
+		expect(await ensureSwiftGitignore(dir)).toEqual(['.gitignore'])
+		expect((await checkSwiftGitignore(dir)).status).toBe('ok')
+	})
+
+	it('appends to an existing .gitignore without dropping its entries', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), 'secrets.env\n')
+		await ensureSwiftGitignore(dir)
+		const contents = await fs.readFile(join(dir, '.gitignore'), 'utf-8')
+		expect(contents).toContain('secrets.env')
+		expect((await checkSwiftGitignore(dir)).status).toBe('ok')
+	})
+
+	it('does not duplicate an entry the repo already ignores', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '/.build\nnotes.md\n')
+		await ensureSwiftGitignore(dir)
+		const contents = await fs.readFile(join(dir, '.gitignore'), 'utf-8')
+		expect(contents.match(/^\/\.build$/gm)).toHaveLength(1)
+		expect((await checkSwiftGitignore(dir)).status).toBe('ok')
+	})
+
+	it('is a no-op when everything is already covered', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '/.build\nDerivedData/\nxcuserdata/\n')
+		expect(await ensureSwiftGitignore(dir)).toEqual([])
+	})
+})

--- a/tooling/swift/periphery.yml
+++ b/tooling/swift/periphery.yml
@@ -1,0 +1,4 @@
+# Periphery dead-code scan. `retain_public: true` keeps a library's public API
+# from being reported as unused — for a SwiftPM package the public surface is
+# the product, not dead code.
+retain_public: true

--- a/tooling/swift/swiftlint.yml
+++ b/tooling/swift/swiftlint.yml
@@ -1,0 +1,23 @@
+disabled_rules:
+  - weak_delegate
+  - cyclomatic_complexity
+  - force_unwrapping
+  - function_body_length
+  - type_name
+  - line_length
+  - identifier_name
+  - trailing_whitespace
+
+excluded:
+  - .build
+  - .swiftpm
+  - DerivedData
+
+file_length:
+  warning: 500
+  error: 1200
+
+nesting:
+  type_level:
+    warning: 3
+    error: 6


### PR DESCRIPTION
## Summary

The first non-JS language module, and the proof that the base/module seams from #280–#285 hold. `doctor`/`fix` detect a Swift repo from `Package.swift` and layer Swift checks on top of the language-agnostic ones.

## The standard encoded here is swift-common's, not the issue's

I checked the stated consumer target, [`swift-common`](https://github.com/rtorcato/swift-common), before writing anything. Two deliberate divergences from the issue's checklist:

| #286 asked for | Shipped | Why |
|---|---|---|
| SwiftFormat config | ❌ | swift-common formats with `swiftlint --fix` in pre-commit. A second formatter would fight the first. |
| `.swift-version` | ❌ | Toolchain is pinned in CI via `setup-xcode`; the manifest carries `// swift-tools-version:`. A root file would be a third place to keep in sync. |
| — | ✅ **Periphery** | Not in the issue, but part of the real standard (`.periphery.yml`, dead-code job in CI). |

Following the issue literally would have made `doctor` fire on swift-common for two things it has deliberately not adopted. Confirmed with you before building.

`tooling/swift/swiftlint.yml` is swift-common's config **byte-for-byte** (verified by diff), so the consumer shows zero drift on adoption.

## Checks

| Check | Absent | Fixer |
|---|---|---|
| `Package.swift` | `missing` | — |
| SwiftLint | `missing` | `swiftlint` |
| Periphery | `optional-missing` | `periphery` |
| Swift `.gitignore` | `missing` | `swift-gitignore` |

`Package.swift` is checked for a tools-version comment and an explicit `platforms:` clause — both things SwiftPM won't infer (no tools-version → the manifest doesn't parse; no `platforms:` → SwiftPM assumes its oldest deployment target and rejects modern APIs at build time). **No fixer**: rewriting someone's manifest isn't safe, so doctor reports and you edit.

`swift-gitignore` *appends* only the missing entries, so project-specific rules survive.

## Wiring

- `registry`: swift → `supported: true`
- `doctor`: a swift branch running base + swift checks
- `fix`: **fixers now resolve by detected language** — the seam #285 deferred until a second module existed
- Shared plumbing moved to base: `checkFile`/`FileCheck` out of the JS module, and the `Fixer` contract into `src/base/fixers.ts`

### One thing #284 predicted, and it fired

`setup`'s language picker labelled choices off `module.supported`. Flipping swift to supported made it read as fully ready while `setup` still bails. Both the label and the gate now read one `SCAFFOLDABLE` list so they can't drift apart. (The `swift-library` preset is #288.)

## Verified end to end

Against a synthetic SwiftPM repo with the built CLI:

```
$ doctor --json     # base findings + 4 swift findings
$ fix --json --yes  # applied: swiftlint, periphery, swift-gitignore
$ doctor --json     # SwiftLint ok, Periphery ok, .gitignore ok
                    # Package.swift drift remains (no fixer, by design)
```

## Known gap — filed as #303

Most of the JS fixer set is *actually* language-agnostic (dependabot, codeql, codeowners, community-health…). A Swift repo sees those findings from `doctor` but gets `unsupported` from `fix`. That's the fixer sibling of #282; I filed **#303** rather than folding a second large refactor into this PR. Documented in the code, the Swift reference page, and the issue.

## Type of change

- [x] New feature

## Test plan

- [x] `pnpm test` — 516 passing (24 new across `tests/languages/swift/`)
- [x] `pnpm verify` clean (biome + typecheck + tests + build)
- [x] `pnpm dogfood` clean (45 checks)
- [x] `pnpm knip` — 16 unused exports (same as `main`), unused exported types **down** from 2 to 1
- [x] End-to-end run against a synthetic SwiftPM repo (above)
- [x] Shipped `.swiftlint.yml` diffed against swift-common's — identical

## Checklist

- [x] No `console.log` left in production code
- [x] No breaking changes — JS repos take the same path as before
- [x] `pnpm check` (Biome) passes
- [x] Docs: new `reference/swift` page, sidebar entry, getting-started note, AGENTS.md

Closes #286