### PR TITLE
feat(swift): CI generation (GHA + GitLab) + CodeQL language: swift (#287)

### DIFF
--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -94,7 +94,34 @@ DerivedData/
 
 `.build` and `DerivedData` are the ones that matter — a single stray commit of either adds hundreds of megabytes to the repo's history.
 
+## CI
+
+```bash
+npx @rtorcato/repo-tooling fix swift-ci          # .github/workflows/ci.yml
+npx @rtorcato/repo-tooling fix swift-codeql      # .github/workflows/codeql.yml
+npx @rtorcato/repo-tooling fix swift-gitlab-ci   # .gitlab-ci.yml
+```
+
+The workflow is derived from `Package.swift` — there's no config object to fill in.
+
+| Job | Runner | What it does |
+|---|---|---|
+| `build-test` | `macos-latest` | `swift build` + `swift test`, with a SwiftPM cache keyed on `Package.resolved` |
+| `lint` | `macos-latest` | `swiftlint lint --strict` |
+| `dead-code` | `macos-latest` | `periphery scan --strict`, `continue-on-error` |
+| `platforms` | `macos-latest` | `xcodebuild` per declared platform |
+
+The `platforms` matrix is emitted only when the manifest declares both a `platforms:` clause and a library product (the product name becomes the xcodebuild scheme). A server-side or CLI package with neither gets `build-test` + `lint` + `dead-code` and nothing else — `xcodebuild` against a package with no deployment targets has nothing to build.
+
+`dead-code` is emitted unconditionally and always as `continue-on-error`. An established codebase almost always has unused declarations on day one, and a permanently red job trains people to ignore CI; drop the flag once the repo is clean.
+
+CodeQL uses `language: swift` rather than the JS matrix.
+
+### GitLab
+
+GitLab runs Swift in the official Linux image (`swift:6.0`), which has no Xcode — so `.gitlab-ci.yml` covers the Linux-portable half only, `swift build` then `swift test`. No SwiftLint, no platform matrix.
+
 ## What isn't covered yet
 
-- **CI generation.** `.github/workflows/ci.yml` for Swift (plus `language: swift` in the CodeQL matrix) lands in [#287](https://github.com/rtorcato/repo-tooling/issues/287).
-- **Language-agnostic fixers.** `doctor` reports base findings (Dependabot, CodeQL, CODEOWNERS, community health) on a Swift repo, but `fix` reports them as `unsupported` — those fixers still live in the JS module and haven't been split out yet.
+- **Language-agnostic fixers.** `doctor` reports base findings (Dependabot, CODEOWNERS, community health) on a Swift repo, but `fix` reports them as `unsupported` — those fixers still live in the JS module and haven't been split out. Tracked in [#303](https://github.com/rtorcato/repo-tooling/issues/303).
+- **Dependabot.** The generated config uses `package-ecosystem: npm`; a Swift repo wants `swift`. Part of #303.

--- a/src/base/ci.ts
+++ b/src/base/ci.ts
@@ -18,6 +18,8 @@ const SKIP_GUARD = "needs.check-skip.outputs.should-skip != 'true'"
 export interface CiJob {
 	/** YAML job id (`lint`, `build`, …). */
 	id: string
+	/** Runner label. Swift needs macOS for Xcode; everything else is happy on Linux. */
+	runsOn?: string
 	/** Jobs this one waits on. `check-skip` is appended automatically. */
 	needs?: readonly string[]
 	/** Extra condition ANDed with the skip gate. */
@@ -71,7 +73,7 @@ function renderJob(job: CiJob): string {
 	const condition = job.if ? `${SKIP_GUARD} && ${job.if}` : SKIP_GUARD
 
 	return `  ${job.id}:
-    runs-on: ubuntu-latest
+    runs-on: ${job.runsOn ?? 'ubuntu-latest'}
     needs: ${needsYaml}
     if: ${condition}
 ${job.extra ? `${job.extra}\n` : ''}    steps:

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -23,10 +23,12 @@ export async function generateGitHubActions(config: ProjectConfig, targetDir: st
 	const workflowsDir = path.join(targetDir, '.github', 'workflows')
 	await fs.ensureDir(workflowsDir)
 
-	// ponytail: JS is the only module with CI steps today, so its jobs are
-	// imported directly rather than resolved through the registry. The dispatch
-	// lands with the second implementation (Swift, #287) — one caller behind a
-	// module.githubJobs() seam would be scaffolding for nobody.
+	// This is the JS path specifically. Swift (#287) renders its own workflow
+	// from `src/languages/swift/ci.ts` rather than dispatching through here: it
+	// takes no ProjectConfig at all (its jobs derive from Package.swift), so a
+	// shared entry point would mean inventing a fake config to pass in. Both
+	// paths meet at renderGitHubWorkflow() in src/base/ci.ts, which is the seam
+	// that actually matters.
 	const workflow = renderGitHubWorkflow(githubJobs(config))
 	await fs.writeFile(path.join(workflowsDir, 'ci.yml'), workflow)
 

--- a/src/languages/swift/ci.ts
+++ b/src/languages/swift/ci.ts
@@ -1,0 +1,189 @@
+/**
+ * Swift CI generation (#287), built on the language-agnostic skeleton in
+ * `src/base/ci.ts`. No `setup-node`, no `pnpm` — the Swift path runs on macOS
+ * runners with Xcode, SwiftPM and Homebrew-installed tools.
+ *
+ * Unlike the JS path there's no `ProjectConfig` to read: everything the Swift
+ * workflow needs (products, deployment platforms) is declared in Package.swift,
+ * so the jobs are derived from the repo itself.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+import { type CiJob, type GitLabSpec, renderGitHubWorkflow, renderGitLabCI } from '../../base/ci.js'
+
+/** SwiftPM runs on macOS runners — Xcode isn't available anywhere else. */
+const MACOS = 'macos-latest'
+
+export interface SwiftPackage {
+	/** Library product names. For a SwiftPM package these double as xcodebuild schemes. */
+	products: string[]
+	/** Deployment platforms declared in `platforms:`, as xcodebuild destination names. */
+	platforms: string[]
+}
+
+/**
+ * Pull the two facts CI needs out of a Package.swift. A regex rather than a
+ * SwiftPM invocation: `swift package dump-package` would need a Swift toolchain
+ * on the machine running `repo-tooling`, which is usually a Node environment.
+ */
+export function parsePackageSwift(contents: string): SwiftPackage {
+	const products = [...contents.matchAll(/\.library\(\s*name:\s*"([^"]+)"/g)].map(
+		(m) => m[1] as string
+	)
+
+	// Only the `platforms:` array declares deployment targets — matching
+	// `.iOS(` across the whole manifest would also catch `.iOS` in target
+	// conditionals.
+	const platformsClause = contents.match(/platforms:\s*\[([^\]]*)\]/s)?.[1] ?? ''
+	const platforms = [...platformsClause.matchAll(/\.(iOS|macOS|tvOS|watchOS|visionOS)\s*\(/g)].map(
+		(m) => m[1] as string
+	)
+
+	return { products, platforms: [...new Set(platforms)] }
+}
+
+export async function readSwiftPackage(dir: string): Promise<SwiftPackage> {
+	const filepath = path.join(dir, 'Package.swift')
+	if (!(await fs.pathExists(filepath))) return { products: [], platforms: [] }
+	return parsePackageSwift(await fs.readFile(filepath, 'utf-8'))
+}
+
+/** Checkout + pin Xcode. Every Swift job needs both before it can do anything. */
+const XCODE_SETUP = `      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🛠️  Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable`
+
+/**
+ * SwiftPM's build products and the resolved-dependency clone are both expensive
+ * to rebuild; key on Package.resolved so the cache invalidates with the graph.
+ */
+const SPM_CACHE = `      - name: 📦 Cache SwiftPM
+        uses: actions/cache@v5
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+          key: \${{ runner.os }}-spm-\${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            \${{ runner.os }}-spm-`
+
+export function swiftGithubJobs(pkg: SwiftPackage): CiJob[] {
+	const jobs: CiJob[] = [
+		{
+			id: 'build-test',
+			runsOn: MACOS,
+			steps: `${XCODE_SETUP}
+
+${SPM_CACHE}
+
+      - name: 🏗️  swift build
+        run: swift build
+
+      - name: 🧪 swift test
+        run: swift test`,
+		},
+		{
+			id: 'lint',
+			runsOn: MACOS,
+			steps: `      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Install SwiftLint
+        run: brew install swiftlint
+
+      - name: 🔍 swiftlint --strict
+        run: swiftlint lint --strict --reporter github-actions-logging`,
+		},
+	]
+
+	// Periphery is part of this module's standard (the `periphery` fixer ships
+	// its config alongside), so the job is unconditional. Gating it on
+	// .periphery.yml existing looked tidier but silently lost the job on a fresh
+	// repo: `fix` walks doctor's findings in order, and GitHub Actions comes
+	// before Periphery, so the CI file was written before the config existed.
+	jobs.push({
+		id: 'dead-code',
+		runsOn: MACOS,
+		// Informational: an established codebase almost always has unused
+		// declarations on day one, and a red X there trains people to ignore CI.
+		// Drop continue-on-error once the repo is clean.
+		extra: '    continue-on-error: true',
+		steps: `${XCODE_SETUP}
+
+      - name: 📦 Install Periphery
+        run: brew install periphery
+
+      - name: 🔍 periphery scan
+        run: periphery scan --strict --format github-actions`,
+	})
+
+	// xcodebuild per platform catches deployment-target breaks that `swift build`
+	// (host-platform only) never sees. Needs both a scheme and declared platforms.
+	const scheme = pkg.products[0]
+	if (scheme && pkg.platforms.length > 0) {
+		jobs.push({
+			id: 'platforms',
+			runsOn: MACOS,
+			extra: `    name: xcodebuild \${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+${pkg.platforms.map((p) => `          - ${p}`).join('\n')}`,
+			steps: `${XCODE_SETUP}
+
+      - name: 📦 Cache DerivedData
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: \${{ runner.os }}-derived-\${{ matrix.platform }}-\${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            \${{ runner.os }}-derived-\${{ matrix.platform }}-
+
+      - name: 🏗️  Build for \${{ matrix.platform }}
+        run: |
+          set -o pipefail
+          xcodebuild \\
+            -scheme ${scheme} \\
+            -destination "generic/platform=\${{ matrix.platform }}" \\
+            -skipPackagePluginValidation \\
+            build | xcbeautify --renderer github-actions`,
+		})
+	}
+
+	return jobs
+}
+
+export function renderSwiftWorkflow(pkg: SwiftPackage): string {
+	return renderGitHubWorkflow(swiftGithubJobs(pkg))
+}
+
+/**
+ * GitLab runs Swift in the official Linux image. That rules out Xcode — so no
+ * platform matrix and no SwiftLint (a Homebrew/macOS tool in practice); the
+ * Linux-portable half of the pipeline is `swift build` + `swift test`.
+ */
+function swiftGitlabSpec(): GitLabSpec {
+	return {
+		image: 'swift:6.0',
+		preamble: `cache:
+  key:
+    files:
+      - Package.resolved
+  paths:
+    - .build`,
+		jobs: [
+			{ id: 'build', stage: 'build', script: ['swift build'] },
+			{ id: 'test', stage: 'test', script: ['swift test'] },
+		],
+	}
+}
+
+export function renderSwiftGitLabCI(): string {
+	return renderGitLabCI(swiftGitlabSpec())
+}

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -4,7 +4,10 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import type { Fixer } from '../../base/fixers.js'
+import { generateCodeQLWorkflow } from '../../cli/generators/security.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
+import { LANGUAGES } from '../registry.js'
+import { readSwiftPackage, renderSwiftGitLabCI, renderSwiftWorkflow } from './ci.js'
 
 /**
  * The Swift build artefacts that must stay out of git. Appended to an existing
@@ -81,6 +84,42 @@ export const SWIFT_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			return { filesWritten: await ensureSwiftGitignore(targetDir) }
+		},
+	},
+	{
+		target: 'swift-ci',
+		description:
+			'Scaffold .github/workflows/ci.yml for Swift (macOS runners: swift build/test, SwiftLint, xcodebuild per platform)',
+		appliesTo: ['GitHub Actions'],
+		outputs: ['.github/workflows/ci.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const workflowsDir = path.join(targetDir, '.github', 'workflows')
+			await fs.ensureDir(workflowsDir)
+			const workflow = renderSwiftWorkflow(await readSwiftPackage(targetDir))
+			await fs.writeFile(path.join(workflowsDir, 'ci.yml'), workflow)
+			return { filesWritten: ['.github/workflows/ci.yml'] }
+		},
+	},
+	{
+		target: 'swift-gitlab-ci',
+		description: 'Scaffold .gitlab-ci.yml for Swift (swift build + test on the Linux Swift image)',
+		appliesTo: ['GitLab CI'],
+		outputs: ['.gitlab-ci.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			await fs.writeFile(path.join(targetDir, '.gitlab-ci.yml'), renderSwiftGitLabCI())
+			return { filesWritten: ['.gitlab-ci.yml'] }
+		},
+	},
+	{
+		target: 'swift-codeql',
+		description: 'Scaffold .github/workflows/codeql.yml with `language: swift`',
+		appliesTo: ['CodeQL'],
+		outputs: ['.github/workflows/codeql.yml'],
+		async run({ targetDir }) {
+			const filesWritten = await generateCodeQLWorkflow(targetDir, LANGUAGES.swift.codeqlLanguages)
+			return { filesWritten }
 		},
 	},
 ]

--- a/tests/languages/swift/ci.test.ts
+++ b/tests/languages/swift/ci.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+	parsePackageSwift,
+	renderSwiftGitLabCI,
+	renderSwiftWorkflow,
+	swiftGithubJobs,
+} from '../../../src/languages/swift/ci.js'
+
+const MANIFEST = `// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "MatrixSwiftBase",
+    platforms: [.iOS(.v16), .macOS(.v13), .tvOS(.v16), .watchOS(.v9)],
+    products: [
+        .library(name: "MatrixSwiftBaseCore", targets: ["MatrixSwiftBaseCore"]),
+        .library(name: "MatrixSwiftBaseUI", targets: ["MatrixSwiftBaseUI"])
+    ],
+    targets: [.target(name: "MatrixSwiftBaseCore")]
+)
+`
+
+describe('parsePackageSwift', () => {
+	it('reads products and platforms', () => {
+		const pkg = parsePackageSwift(MANIFEST)
+		expect(pkg.products).toEqual(['MatrixSwiftBaseCore', 'MatrixSwiftBaseUI'])
+		expect(pkg.platforms).toEqual(['iOS', 'macOS', 'tvOS', 'watchOS'])
+	})
+
+	it('returns empties for a manifest with neither', () => {
+		expect(parsePackageSwift('// swift-tools-version: 5.9\n')).toEqual({
+			products: [],
+			platforms: [],
+		})
+	})
+
+	// `.iOS` also appears in target conditionals — only the platforms: clause
+	// declares deployment targets.
+	it('ignores platform references outside the platforms clause', () => {
+		const pkg = parsePackageSwift(
+			`platforms: [.macOS(.v13)],\ntargets: [.target(name: "A", condition: .when(platforms: [.iOS]))]`
+		)
+		expect(pkg.platforms).toEqual(['macOS'])
+	})
+
+	it('de-duplicates a platform listed twice', () => {
+		expect(parsePackageSwift('platforms: [.iOS(.v16), .iOS(.v17)]').platforms).toEqual(['iOS'])
+	})
+})
+
+describe('swiftGithubJobs', () => {
+	const pkg = parsePackageSwift(MANIFEST)
+
+	it('has no Node or pnpm anywhere in the workflow', () => {
+		expect(renderSwiftWorkflow(pkg)).not.toMatch(/setup-node|pnpm|node_modules|\.nvmrc/)
+	})
+
+	it('runs every job on macOS', () => {
+		for (const job of swiftGithubJobs(pkg)) expect(job.runsOn).toBe('macos-latest')
+	})
+
+	it('builds and tests with SwiftPM', () => {
+		const yaml = renderSwiftWorkflow(pkg)
+		expect(yaml).toContain('run: swift build')
+		expect(yaml).toContain('run: swift test')
+		expect(yaml).toContain('swiftlint lint --strict')
+	})
+
+	// Gating this on .periphery.yml existing lost the job on a fresh repo: `fix`
+	// walks doctor's findings in order and writes ci.yml before the periphery
+	// fixer has created its config.
+	it('always emits the Periphery job, informational-only', () => {
+		const yaml = renderSwiftWorkflow(pkg)
+		expect(yaml).toContain('periphery scan')
+		expect(yaml).toContain('continue-on-error: true')
+	})
+
+	it('builds a matrix over the declared platforms using the first product as scheme', () => {
+		const yaml = renderSwiftWorkflow(pkg)
+		expect(yaml).toContain('-scheme MatrixSwiftBaseCore')
+		expect(yaml).toContain('          - iOS\n          - macOS\n          - tvOS\n          - watchOS')
+	})
+
+	it('skips the platform matrix when the manifest declares no platforms', () => {
+		const bare = parsePackageSwift('let package = Package(name: "CLI")')
+		const ids = swiftGithubJobs(bare).map((j) => j.id)
+		expect(ids).toEqual(['build-test', 'lint', 'dead-code'])
+	})
+
+	it('skips the platform matrix when there is no library product to use as a scheme', () => {
+		const noProducts = parsePackageSwift('platforms: [.macOS(.v13)]')
+		expect(swiftGithubJobs(noProducts).map((j) => j.id)).not.toContain('platforms')
+	})
+})
+
+describe('renderSwiftGitLabCI', () => {
+	it('uses the Linux Swift image and stays Xcode-free', () => {
+		const yaml = renderSwiftGitLabCI()
+		expect(yaml).toContain('image: swift:6.0')
+		expect(yaml).not.toMatch(/xcodebuild|setup-xcode|brew/)
+	})
+
+	it('builds before it tests', () => {
+		expect(renderSwiftGitLabCI()).toContain('stages:\n  - build\n  - test\n')
+	})
+})

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -1,6 +1,8 @@
 import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { FIXERS } from '../../../src/languages/js/fixers.js'
 import { checkSwiftGitignore } from '../../../src/languages/swift/checks.js'
 import { SWIFT_FIXERS, ensureSwiftGitignore } from '../../../src/languages/swift/fixers.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -21,11 +23,24 @@ const ctx = (targetDir: string) => ({
 })
 
 describe('swift fixers', () => {
-	it('every fixer resolves a check the Swift module actually emits', () => {
-		const emitted = ['SwiftLint', 'Periphery', 'Swift .gitignore']
+	// A fixer whose appliesTo doesn't match a real check name is dead code: `fix`
+	// looks fixers up by check, so it would simply never run. Derive the valid
+	// names from doctor itself rather than hardcoding them.
+	it('every fixer resolves a check doctor actually emits for a Swift repo', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version: 5.9\n')
+		const emitted = new Set((await runDoctor(dir)).map((r) => r.check))
 		for (const f of SWIFT_FIXERS) {
-			for (const check of f.appliesTo) expect(emitted).toContain(check)
+			for (const check of f.appliesTo) {
+				expect(emitted, `${f.target} → ${check}`).toContain(check)
+			}
 		}
+	})
+
+	it('uses target names that do not collide with the JS fixer set', () => {
+		// `fix --list` shows every language's fixers in one list.
+		const jsTargets = new Set(FIXERS.map((f) => f.target))
+		for (const f of SWIFT_FIXERS) expect(jsTargets).not.toContain(f.target)
 	})
 
 	it('swiftlint writes a config the SwiftLint check accepts', async () => {


### PR DESCRIPTION
## Summary

Swift CI built on the `src/base/ci.ts` skeleton from #283 — the first consumer that isn't JS, and the thing that skeleton existed for.

| Job | Runner | What it does |
|---|---|---|
| `build-test` | `macos-latest` | `swift build` + `swift test`, SwiftPM cache keyed on `Package.resolved` |
| `lint` | `macos-latest` | `swiftlint lint --strict` |
| `dead-code` | `macos-latest` | `periphery scan --strict`, `continue-on-error` |
| `platforms` | `macos-latest` | `xcodebuild` per declared platform |

No `setup-node`, no `pnpm`, and **no `ProjectConfig`** — the jobs derive from `Package.swift` itself. Parsed with a regex rather than `swift package dump-package`, which would need a Swift toolchain on what is usually a Node machine.

`platforms` is emitted only when the manifest declares both a `platforms:` clause and a library product (the product name becomes the scheme). A CLI or server-side package with neither has nothing for `xcodebuild` to build, so it gets the other three.

CodeQL emits `language: swift` through the `languages` parameter added in #283 — the registry's `codeqlLanguages` now drives both language paths.

GitLab gets the Linux-portable half only: `swift:6.0` has no Xcode, so `swift build` + `swift test`, no SwiftLint, no matrix.

## Skeleton change

`CiJob` gains an optional `runsOn`. It was hardcoded to `ubuntu-latest`, which no Swift job can use. JS output is unchanged — the default preserves it and the snapshot still passes.

## A wrong turn I backed out before committing

The Periphery job was initially gated on `.periphery.yml` existing. That looked tidier but **silently lost the job on every fresh repo**: `fix` walks doctor's findings in order, `GitHub Actions` comes before `Periphery`, so `ci.yml` was written before the config existed. Caught in the end-to-end run, not by a test.

It's unconditional now — Periphery is part of this module's standard, ships with its config, and `continue-on-error` means it can't block anyone. Fewer moving parts and no ordering trap. (I looked at gating on `declinedInLock` instead; that's keyed on JS-shaped `ProjectConfig` fields and has no Swift path, so it would have reduced to "always" anyway.)

## Fixer naming

`swift-ci` / `swift-gitlab-ci` / `swift-codeql` rather than reusing `github-actions` / `gitlab-ci` / `codeql`. `fix --list` shows every language's fixers in one list, so colliding target names would render duplicates. There's a test asserting no collisions with the JS set.

## Verified end to end

Fresh SwiftPM repo, built CLI:

```
$ repo-tooling fix --json --yes
applied  swift-ci          GitHub Actions
applied  swift-codeql      CodeQL
applied  swift-gitlab-ci   GitLab CI
...
$ grep -E "^  [a-z-]+:$" .github/workflows/ci.yml
  check-skip:  build-test:  lint:  dead-code:  platforms:
$ grep language: .github/workflows/codeql.yml
        language: [swift]
```

## Type of change

- [x] New feature

## Test plan

- [x] `pnpm test` — 530 passing (14 new in `tests/languages/swift/ci.test.ts`)
- [x] `pnpm verify` clean (biome + typecheck + tests + build)
- [x] `pnpm dogfood` clean (45 checks)
- [x] `pnpm knip` at parity with `main` (16 unused exports, 1 unused type)
- [x] JS workflow snapshot unchanged — `runsOn` default preserves it
- [x] End-to-end against a fresh SwiftPM repo (above)

## Checklist

- [x] No `console.log` left in production code
- [x] No breaking changes
- [x] `pnpm check` (Biome) passes
- [x] Docs: `reference/swift` gains a CI section; the "not covered yet" list now points only at #303

Closes #287