### PR TITLE
feat(swift): swift-library preset + docs (#288)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Orientation for coding agents working with `@rtorcato/repo-tooling`. Human-reada
 
 A one-package JavaScript / TypeScript tooling distribution. Ships every preset (TypeScript, Biome, ESLint, Prettier, Vitest, Jest, Commitlint, semantic-release, tsup, esbuild, Vite, Playwright) plus a CLI to scaffold and audit projects. Consumers get one install.
 
-`doctor` and `fix` also audit **Swift** repos (detected via `Package.swift`): the language-agnostic checks plus SwiftLint / Periphery / `.gitignore` / `Package.swift`. `setup` remains JS-only. See `src/languages/` — one directory per language module, `src/base/` for what's shared.
+**Swift** repos (detected via `Package.swift`) are covered end to end: `setup --preset swift-library` scaffolds a SwiftPM package, and `doctor`/`fix` run the language-agnostic checks plus SwiftLint / Periphery / `.gitignore` / `Package.swift`. Python and Perl are audit-only for now. See `src/languages/` — one directory per language module, `src/base/` for what's shared.
 
 ## CLI surface (agent-friendly)
 
@@ -14,7 +14,7 @@ Every command supports `--json` and a non-interactive mode. Combine with `--yes`
 
 | Command | Non-interactive | JSON output | Use case |
 |---|---|---|---|
-| `setup --preset <name>` | ✅ | `--dry-run` only | Scaffold a new project. Presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`. |
+| `setup --preset <name>` | ✅ | `--dry-run` only | Scaffold a new project. Presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`. |
 | `setup --config <path>` | ✅ | `--dry-run` only | Scaffold with a full `ProjectConfig` JSON file. See `setup --config-schema`. |
 | `setup --config-schema` | ✅ | ✅ (JSON Schema) | Print the JSON Schema for `ProjectConfig`. Use to validate configs before scaffolding. |
 | `setup --dry-run` | ✅ | ✅ | Print resolved config + file list without writing. Pair with `--preset` or `--config`. |

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ Non-interactive — scaffold from a named preset in one shot (CI-friendly):
 
 ```bash
 npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
-# presets: library | web-app | node-api | nextjs-app | react-app
+# presets: library | web-app | node-api | nextjs-app | react-app | swift-library
 ```
+
+`swift-library` scaffolds a SwiftPM package (manifest, sources, tests, SwiftLint,
+Periphery, macOS CI) instead of an npm one — see the
+[Swift guide](https://rtorcato.github.io/repo-tooling/guides/swift).
 
 Just one config file? Use `copy`:
 

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -13,6 +13,11 @@ npx @rtorcato/repo-tooling setup -d ./my-app  # specific directory
 npx @rtorcato/repo-tooling setup --skip-install  # skip npm/pnpm install
 ```
 
+Add `--preset <name>` to skip the prompts entirely: `library`, `web-app`,
+`node-api`, `nextjs-app`, `react-app`, or `swift-library`. The Swift preset
+scaffolds a SwiftPM package rather than an npm one — see the
+[Swift guide](./swift.md).
+
 ## copy \<name\>
 
 Copies a standalone config file into the current directory without running the full wizard.

--- a/apps/docs/docs/guides/for-ai-agents.md
+++ b/apps/docs/docs/guides/for-ai-agents.md
@@ -29,7 +29,9 @@ npx @rtorcato/repo-tooling setup --config-schema > project-config.schema.json
 npx @rtorcato/repo-tooling setup --preset library --dry-run
 ```
 
-Available presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`.
+Available presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`.
+
+`swift-library` scaffolds a SwiftPM package — no `package.json`, no install step, and the file list is entirely different. See the [Swift guide](./swift.md).
 
 **`--dry-run` output:**
 
@@ -148,7 +150,7 @@ Use this to discover what's available and to map between named tools and the `fi
 
 ```bash
 # 1. Decide the project type (or read from existing pkg deps)
-PRESET=library  # or web-app, node-api, nextjs-app, react-app
+PRESET=library  # or web-app, node-api, nextjs-app, react-app, swift-library
 
 # 2. Preview
 npx @rtorcato/repo-tooling setup --preset $PRESET --dry-run

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -86,7 +86,9 @@ Running `setup` (or its alias `init`) launches an interactive wizard:
 A universal baseline (`.editorconfig`, `.nvmrc`, `engines.node`, `knip.json`, `.vscode/extensions.json`) is scaffolded automatically — no prompt — because these are safe defaults for every project.
 
 :::note Non-JS languages
-Only JavaScript/TypeScript has scaffolding today. Picking Swift, Python or Perl writes nothing and points you at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). [Swift](/reference/swift) additionally has its own checks and fixers (SwiftLint, Periphery, `.gitignore`, `Package.swift`) — it just has no setup preset yet. Presets for the other languages land with their language modules — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
+The table above is the JavaScript/TypeScript question list. Picking **Swift** asks only for a package name and then scaffolds a SwiftPM library — SwiftLint, Periphery and `swift test` are the standard rather than options. See the [Swift guide](./swift.md).
+
+Python and Perl write nothing and point you at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). Their presets land with their language modules — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
 :::
 
 ## Non-interactive setup (CI / scripts)
@@ -97,7 +99,9 @@ Skip the prompts entirely by scaffolding from a named preset:
 npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
 ```
 
-Presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`.
+Presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`.
+
+`swift-library` scaffolds a SwiftPM package instead of an npm one — no `package.json`, no install step. See the [Swift guide](./swift.md) for the full file list.
 
 For full control, drive setup from a `ProjectConfig` JSON file — print the schema, write a config, preview, then scaffold:
 
@@ -122,6 +126,8 @@ npx @rtorcato/repo-tooling setup --config project.json -d ./my-lib --skip-instal
 - `.github/dependabot.yml`, `.github/workflows/codeql.yml` — if security automation chosen
 - `README.md` — project README scaffold
 - `reset.d.ts` — ts-reset type augmentation (if TypeScript)
+
+For a Swift package the list is entirely different (`Package.swift`, `Sources/`, `Tests/`, `.swiftlint.yml`, …) — see the [Swift guide](./swift.md).
 
 ## Existing projects: doctor + fix
 

--- a/apps/docs/docs/guides/swift.md
+++ b/apps/docs/docs/guides/swift.md
@@ -1,0 +1,152 @@
+---
+title: Swift projects
+description: Scaffold, audit, and fix a SwiftPM package with repo-tooling — the swift-library preset, what it writes, and how it differs from the JS path.
+---
+
+Swift is the first non-JavaScript language module. Everything the CLI does for a
+JS repo — scaffold with `setup`, audit with `doctor`, repair with `fix` — it also
+does for a SwiftPM package, using SwiftPM/SwiftLint/Periphery in place of
+pnpm/Biome/Vitest.
+
+The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-common)
+actually runs. For the config file contents and the full check/fix table, see the
+[Swift reference](../reference/swift.md); this guide covers the project lifecycle.
+
+## Scaffold a new package
+
+```bash
+npx @rtorcato/repo-tooling setup --preset swift-library -d ./my-swift-lib
+```
+
+Or run `setup` with no flags and pick **Swift** at the language prompt. Unlike
+the JS wizard there's only one further question — the package name. SwiftLint,
+Periphery and `swift test` aren't options here, they're the standard, and a
+wizard whose every question has one answer is worse than no wizard.
+
+`--skip-install` is accepted but redundant: nothing is installed either way.
+SwiftPM resolves dependencies on the first `swift build`, and there's no
+`node_modules` for the CLI to populate.
+
+### What it writes
+
+| File | Why |
+|---|---|
+| `Package.swift` | SwiftPM manifest — tools version 6.0, `platforms: [.iOS(.v17), .macOS(.v14)]`, one library product |
+| `Sources/<Module>/<Module>.swift` | A placeholder public enum, so `swift build` succeeds |
+| `Tests/<Module>Tests/<Module>Tests.swift` | One XCTest case, so `swift test` succeeds |
+| `.swiftlint.yml` | Lint *and* format config |
+| `.periphery.yml` | Dead-code scan config (`retain_public: true`) |
+| `.gitignore` | `.build`, `DerivedData`, `xcuserdata` and friends |
+| `.editorconfig` | Shared baseline plus a `[*.swift]` 4-space override |
+| `.github/workflows/ci.yml` | Swift CI on macOS runners |
+| `.github/workflows/codeql.yml` | CodeQL with `language: swift` |
+| `.github/dependabot.yml` + auto-merge workflow | Grouped dependency updates |
+| `AGENTS.md`, `CLAUDE.md`, Cursor/Copilot rules, Claude skill, `.mcp.json.example` | AI agent files (language-agnostic) |
+| `README.md` | SwiftPM-flavoured README |
+| `.repo-tooling.json` | Lockfile recording `language: "swift"` |
+
+The module name is derived from the package name: `my-swift-lib` → `MySwiftLib`.
+Swift target names are type identifiers, so hyphens, dots and spaces are stripped
+and a leading digit gets a `Package` prefix.
+
+Preview the list without writing anything:
+
+```bash
+npx @rtorcato/repo-tooling setup --preset swift-library -d ./my-swift-lib --dry-run
+```
+
+### The scaffold passes its own CI
+
+The generated package builds, tests, and lints clean out of the box:
+
+```bash
+cd my-swift-lib
+swift build
+swift test
+swiftlint lint --strict     # the exact command the generated CI runs
+```
+
+That last one is the reason `Package.swift` has no trailing commas in its
+collection literals — the `.swiftlint.yml` written alongside leaves
+`trailing_comma` enabled, so a manifest with them would fail the scaffold's own
+lint job on the first push.
+
+You'll need the tools locally:
+
+```bash
+brew install swiftlint periphery
+```
+
+## How the Swift path differs from JS
+
+`setup` branches on the language before any generator runs, because everything
+in the JS path is rooted in `package.json` — the file a Swift repo is defined by
+not having. Concretely:
+
+| | JavaScript/TypeScript | Swift |
+|---|---|---|
+| Manifest | `package.json` | `Package.swift` |
+| Build | tsup/esbuild/Vite/Rollup | `swift build` |
+| Test | Vitest/Jest/Playwright/Cypress | `swift test` (XCTest) |
+| Lint + format | Biome or ESLint + Prettier | SwiftLint (both jobs) |
+| Dead code | knip | Periphery |
+| Install step | `pnpm install` | none — SwiftPM resolves on build |
+| Git hooks | Husky + lint-staged | none (npm packages) |
+| Release | semantic-release → npm | git tags → SwiftPM |
+| CI runner | `ubuntu-latest` | `macos-latest` (Xcode) |
+| CodeQL | `javascript-typescript` | `swift` |
+
+The lockfile's JS-shaped fields (`linting.tool`, `testing.framework`, `bundler`)
+are all recorded as `none` for a Swift package. That means "no *JS* tool", not
+"no tooling" — SwiftLint and `swift test` are wired unconditionally, and the
+Swift checks `doctor` runs never consult those fields.
+
+## CI
+
+The workflow is derived from `Package.swift` rather than from a config object,
+which is why `setup` writes the manifest first and reads it back:
+
+| Job | What it does |
+|---|---|
+| `build-test` | `swift build` + `swift test`, SwiftPM cache keyed on `Package.resolved` |
+| `lint` | `swiftlint lint --strict` |
+| `dead-code` | `periphery scan --strict`, `continue-on-error` |
+| `platforms` | `xcodebuild` once per platform in the manifest's `platforms:` clause |
+
+Every job runs on `macos-latest` — SwiftPM needs Xcode, and there's no
+`setup-node` or `pnpm` anywhere in the file. The `platforms` matrix appears only
+when the manifest declares both a `platforms:` clause and a library product (the
+product name becomes the xcodebuild scheme); the `swift-library` preset emits
+both, so a fresh scaffold gets iOS and macOS.
+
+GitLab is available via `fix swift-gitlab-ci`, but covers the Linux-portable
+half only — the official `swift:6.0` image has no Xcode, so no SwiftLint job and
+no platform matrix.
+
+## Existing packages: doctor + fix
+
+Don't rerun `setup` on a repo that already exists — it's a fresh-project
+scaffolder and would overwrite your manifest. Use `doctor` and `fix` instead:
+
+```bash
+npx @rtorcato/repo-tooling doctor              # audit
+npx @rtorcato/repo-tooling fix swiftlint       # .swiftlint.yml
+npx @rtorcato/repo-tooling fix periphery       # .periphery.yml
+npx @rtorcato/repo-tooling fix swift-gitignore # append build artefacts
+npx @rtorcato/repo-tooling fix swift-ci        # .github/workflows/ci.yml
+npx @rtorcato/repo-tooling fix swift-codeql    # .github/workflows/codeql.yml
+npx @rtorcato/repo-tooling fix swift-gitlab-ci # .gitlab-ci.yml
+```
+
+`doctor` detects Swift from `Package.swift` and runs the language-agnostic
+checks (CI, CodeQL, Dependabot, GitHub repo settings) plus the Swift ones. There
+is deliberately no fixer for `Package.swift` — rewriting someone's manifest isn't
+safe, so `doctor` reports and you edit.
+
+:::note Not covered yet
+`doctor` reports the language-agnostic findings (Dependabot, CODEOWNERS,
+community health) on a Swift repo, but `fix` reports them as `unsupported` —
+those fixers still live in the JS module. The generated `dependabot.yml` also
+uses `package-ecosystem: npm` where a Swift repo wants `swift`. Both are tracked
+in [#303](https://github.com/rtorcato/repo-tooling/issues/303).
+:::

--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -7,8 +7,8 @@ Swift is the first non-JavaScript language module. `doctor` and `fix` detect a S
 
 The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-common) actually runs — SwiftLint for lint *and* formatting, Periphery for dead code.
 
-:::note No setup preset yet
-`setup` can't scaffold a Swift project — it audits and fixes an existing one. Picking Swift in the setup wizard points you at `doctor` instead. The `swift-library` preset is tracked in [#288](https://github.com/rtorcato/repo-tooling/issues/288).
+:::tip Scaffolding a new package
+`setup --preset swift-library` scaffolds a SwiftPM package end to end (manifest, sources, tests, configs, CI). This page is the config + check reference; the [Swift guide](../guides/swift.md) covers the project lifecycle.
 :::
 
 ## Checks
@@ -120,6 +120,10 @@ CodeQL uses `language: swift` rather than the JS matrix.
 ### GitLab
 
 GitLab runs Swift in the official Linux image (`swift:6.0`), which has no Xcode — so `.gitlab-ci.yml` covers the Linux-portable half only, `swift build` then `swift test`. No SwiftLint, no platform matrix.
+
+## Scaffolding
+
+`setup --preset swift-library` writes all of the above plus `Package.swift`, a `Sources/`/`Tests/` pair that builds and tests green, and the CI workflows. See the [Swift guide](../guides/swift.md) for the full file list and the JS-vs-Swift comparison.
 
 ## What isn't covered yet
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
         'guides/for-ai-agents',
         'guides/ai-setup',
         'guides/library-style',
+        'guides/swift',
         'guides/dependabot-strategy',
         'guides/git-flow',
         'guides/public-repo-issue-safety',

--- a/skills/repo-tooling/SKILL.md
+++ b/skills/repo-tooling/SKILL.md
@@ -47,7 +47,7 @@ npx @rtorcato/repo-tooling fix <target> --diff           # unified diff before c
 ## Scaffolding a new project
 
 ```bash
-# Quick: from a named preset (library | web-app | node-api | nextjs-app | react-app)
+# Quick: from a named preset (library | web-app | node-api | nextjs-app | react-app | swift-library)
 npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
 
 # Full control: validate a config against the schema, preview, then write

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -1,6 +1,13 @@
+import { swiftFileList } from '../../languages/swift/scaffold.js'
 import type { ProjectConfig } from './setup.js'
 
-export type PresetName = 'library' | 'web-app' | 'node-api' | 'nextjs-app' | 'react-app'
+export type PresetName =
+	| 'library'
+	| 'web-app'
+	| 'node-api'
+	| 'nextjs-app'
+	| 'react-app'
+	| 'swift-library'
 
 export const PRESET_NAMES: readonly PresetName[] = [
 	'library',
@@ -8,6 +15,7 @@ export const PRESET_NAMES: readonly PresetName[] = [
 	'node-api',
 	'nextjs-app',
 	'react-app',
+	'swift-library',
 ] as const
 
 const BASE: Omit<ProjectConfig, 'projectName' | 'projectType' | 'typescript' | 'bundler'> = {
@@ -70,6 +78,35 @@ export function buildPresetConfig(name: PresetName, projectName: string): Projec
 				typescript: { enabled: true, config: 'react' },
 				testing: { framework: 'vitest', environment: 'browser' },
 				bundler: 'vite',
+			}
+		// A SwiftPM library (#288). Deliberately not spread from BASE: every one
+		// of its tool choices names a JS tool. The JS-shaped fields below are all
+		// "no JS tool", which is not the same as "no tooling" — SwiftLint,
+		// Periphery and `swift test` are wired unconditionally by the Swift
+		// scaffolder, because unlike the JS path there's nothing to choose
+		// between. They're set explicitly because ProjectConfig requires them and
+		// the lockfile records them.
+		case 'swift-library':
+			return {
+				projectName,
+				language: 'swift',
+				projectType: 'library',
+				typescript: { enabled: false, config: 'base' },
+				linting: { tool: 'none' },
+				formatting: { tool: 'none' },
+				testing: { framework: 'none' },
+				// Husky and commitlint are npm packages; a Swift repo has no
+				// node_modules to install them into.
+				gitHooks: false,
+				commitLint: false,
+				// semantic-release publishes to npm. SwiftPM consumes git tags.
+				semanticRelease: false,
+				securityAutomation: true,
+				bundler: 'none',
+				// Every badge URL is derived from package.json (name + repository),
+				// so on a Swift repo the block would always render empty.
+				badges: false,
+				aiSetup: true,
 			}
 	}
 }
@@ -179,6 +216,11 @@ export function validateProjectConfig(input: unknown): ConfigValidationResult {
 }
 
 export function computeFileList(config: ProjectConfig): string[] {
+	// Swift shares the language-agnostic files but none of the package.json-rooted
+	// ones, so its list is built by the Swift scaffolder rather than filtered out
+	// of this one condition by condition.
+	if (config.language === 'swift') return swiftFileList(config)
+
 	const files: string[] = ['package.json', '.repo-tooling.json']
 	files.push('.editorconfig', '.nvmrc', 'knip.json', '.vscode/extensions.json')
 	if (config.typescript.enabled) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -146,14 +146,19 @@ export async function setupProject(options: SetupOptions) {
 		}
 
 		if (!interactive) {
-			console.log(chalk.cyan(`\n🛠️  Scaffolding ${config.projectType} in ${targetDir}\n`))
+			const shape = config.language === 'swift' ? `Swift ${config.projectType}` : config.projectType
+			console.log(chalk.cyan(`\n🛠️  Scaffolding ${shape} in ${targetDir}\n`))
 		}
 		console.log(chalk.cyan('\n📝 Generating configuration files...\n'))
 
 		await generateConfigs(config, targetDir)
 		await writeLockfile(targetDir, config)
 
-		if (!options.skipInstall) {
+		// Both steps shell out to pnpm. A Swift package has no dependencies to
+		// install and no Biome to format with — SwiftPM resolves on first build,
+		// and `swiftlint --fix` is the formatter (it needs a Swift toolchain we
+		// can't assume is present).
+		if (!options.skipInstall && config.language !== 'swift') {
 			console.log(chalk.cyan('\n📦 Installing dependencies...\n'))
 			await installDependencies(config, targetDir)
 			// Format now that the linter/formatter is installed, so the scaffold
@@ -172,12 +177,11 @@ export async function setupProject(options: SetupOptions) {
 
 /**
  * Languages `setup` can scaffold. Deliberately separate from the registry's
- * `supported` flag, which means "has doctor/fix checks" — Swift's module landed
- * in #286 but its presets land in #288, so it can be audited without being
- * scaffoldable. Both the picker label and the gate below read from here, so the
- * two can't drift apart.
+ * `supported` flag, which means "has doctor/fix checks" — a language can be
+ * auditable before it's scaffoldable (Swift was, between #286 and #288). Both
+ * the picker label and the gate below read from here, so the two can't drift.
  */
-const SCAFFOLDABLE: ReadonlyArray<LanguageModule['id']> = ['js']
+const SCAFFOLDABLE: ReadonlyArray<LanguageModule['id']> = ['js', 'swift']
 
 /**
  * Ask which language this repo is, defaulting to whatever the target dir looks
@@ -236,6 +240,24 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 		explainNotScaffoldable(language)
 		return null
 	}
+
+	// Swift has exactly one shape to scaffold, so there is nothing to ask beyond
+	// the name: SwiftLint, Periphery and `swift test` are the standard, not
+	// options (see the `swift-library` preset). A wizard whose every question has
+	// one answer is worse than no wizard.
+	if (language.id === 'swift') {
+		const { projectName } = await inquirer.prompt([
+			{
+				type: 'input',
+				name: 'projectName',
+				message: '📦 What is your package name?',
+				default: path.basename(targetDir),
+				validate: (input: string) => input.trim().length > 0 || 'Package name is required',
+			},
+		])
+		return buildPresetConfig('swift-library', projectName)
+	}
+
 	// Narrowing for the question list below, which is JS-shaped throughout.
 	if (language.id !== 'js') return null
 
@@ -516,22 +538,35 @@ function showNextSteps(config: ProjectConfig, _targetDir: string) {
 
 	const steps = []
 
-	if (config.typescript.enabled) {
-		steps.push('🔧 Customize your tsconfig.json as needed')
-	}
-
-	if (config.linting.tool !== 'none') {
+	// Every step in the else-branch names a pnpm script. Swift's equivalents are
+	// SwiftPM and SwiftLint commands — and neither tool ships with the scaffold,
+	// so the last line is how to get them.
+	if (config.language === 'swift') {
 		steps.push(
-			`🔍 Run linting with: ${config.linting.tool === 'biome' ? 'pnpm biome check .' : 'pnpm eslint .'}`
+			'🏗️  Build with: swift build',
+			'🧪 Run tests with: swift test',
+			'🔍 Lint and format with: swiftlint --fix (CI runs swiftlint lint --strict)',
+			'🧹 Find dead code with: periphery scan',
+			'📦 Install both tools with: brew install swiftlint periphery'
 		)
-	}
+	} else {
+		if (config.typescript.enabled) {
+			steps.push('🔧 Customize your tsconfig.json as needed')
+		}
 
-	if (config.testing.framework !== 'none') {
-		steps.push(`🧪 Run tests with: pnpm ${config.testing.framework}`)
-	}
+		if (config.linting.tool !== 'none') {
+			steps.push(
+				`🔍 Run linting with: ${config.linting.tool === 'biome' ? 'pnpm biome check .' : 'pnpm eslint .'}`
+			)
+		}
 
-	if (config.gitHooks) {
-		steps.push('🪝 Commit your changes to test the git hooks')
+		if (config.testing.framework !== 'none') {
+			steps.push(`🧪 Run tests with: pnpm ${config.testing.framework}`)
+		}
+
+		if (config.gitHooks) {
+			steps.push('🪝 Commit your changes to test the git hooks')
+		}
 	}
 
 	steps.push(
@@ -559,6 +594,12 @@ function showNextSteps(config: ProjectConfig, _targetDir: string) {
 
 function collectSkippedFixSuggestions(config: ProjectConfig): string[] {
 	const suggestions: string[] = []
+	// Every suggestion below is a JS fix target (husky, biome, vitest…). On a
+	// Swift repo they'd all be wrong — `fix` doesn't even offer them there — so
+	// the Swift scaffold gets only the doctor line at the end.
+	if (config.language === 'swift') {
+		return ['Run `npx @rtorcato/repo-tooling doctor` any time to audit drift']
+	}
 	if (!config.gitHooks) {
 		suggestions.push('Run `npx @rtorcato/repo-tooling fix husky` to add git hooks later')
 	}

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { generateSwiftProject } from '../../languages/swift/scaffold.js'
 import type { ProjectConfig } from '../commands/setup.js'
 import { installAiSetup } from './agent-rules.js'
 import { ensureBuildApprovals, generateBuildConfigs } from './build.js'
@@ -23,6 +24,13 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export async function generateConfigs(config: ProjectConfig, targetDir: string) {
+	// Swift takes its own path (#288) rather than opting out of each step below.
+	// Everything from here down is rooted in package.json — the file a Swift repo
+	// is defined by not having.
+	if (config.language === 'swift') {
+		return generateSwiftProject(config, targetDir)
+	}
+
 	// Generate package.json (must run before generateMiscBaseline,
 	// which sets engines.node on the resulting file)
 	await generatePackageJson(config, targetDir)

--- a/src/languages/swift/scaffold.ts
+++ b/src/languages/swift/scaffold.ts
@@ -1,0 +1,257 @@
+/**
+ * Swift project scaffolding (#288) — what `setup --preset swift-library` writes.
+ *
+ * The JS generators in `src/cli/generators/` are all package.json-rooted, so a
+ * Swift repo shares almost none of them: no package.json, no tsconfig, no
+ * bundler, no pnpm. What it *does* share is the language-agnostic half —
+ * .editorconfig, Dependabot, CodeQL, the AI agent files — which is imported
+ * from there rather than re-templated here.
+ *
+ * The CI workflow comes from ./ci.ts (#287), which derives its jobs from
+ * Package.swift. That's why the manifest is written before the workflow: the
+ * platform matrix reads the `platforms:` clause we just emitted.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+import type { ProjectConfig } from '../../cli/commands/setup.js'
+import { installAiSetup } from '../../cli/generators/agent-rules.js'
+import { generateEditorConfig } from '../../cli/generators/misc.js'
+import { generateCodeQLWorkflow, generateDependabotConfig } from '../../cli/generators/security.js'
+import { copyPreset } from '../../cli/utils/copy-preset.js'
+import { LANGUAGES } from '../registry.js'
+import { readSwiftPackage, renderSwiftWorkflow } from './ci.js'
+import { ensureSwiftGitignore } from './fixers.js'
+
+/**
+ * Turn a repo name into a Swift module name: `my-swift-lib` → `MySwiftLib`.
+ * SwiftPM target names are type identifiers, so hyphens, dots and spaces have
+ * to go, and a leading digit has to be prefixed. Falls back to `Package` when
+ * nothing usable survives (e.g. a directory named `123`).
+ */
+export function swiftModuleName(projectName: string): string {
+	const upperCamel = projectName
+		.split(/[^A-Za-z0-9]+/)
+		.filter(Boolean)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join('')
+	if (upperCamel.length === 0) return 'Package'
+	return /^\d/.test(upperCamel) ? `Package${upperCamel}` : upperCamel
+}
+
+/**
+ * Deployment targets baked into the manifest. `doctor` requires *some*
+ * `platforms:` clause (without one SwiftPM silently assumes its oldest
+ * supported target), and these also become the xcodebuild matrix in CI.
+ *
+ * No trailing commas in the collection literals: the .swiftlint.yml written
+ * alongside leaves `trailing_comma` enabled, so a manifest with them fails the
+ * `swiftlint lint --strict` job in the CI this same scaffold generates.
+ */
+function packageSwift(module: string): string {
+	return `// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "${module}",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14)
+    ],
+    products: [
+        .library(name: "${module}", targets: ["${module}"])
+    ],
+    targets: [
+        .target(name: "${module}"),
+        .testTarget(name: "${module}Tests", dependencies: ["${module}"])
+    ]
+)
+`
+}
+
+/**
+ * A real (if tiny) source + test pair, not an empty directory. `swift build`
+ * fails outright on a package whose target directory doesn't exist, so a
+ * scaffold without these produces a repo whose own CI is red on the first push.
+ */
+function sourceFile(module: string): string {
+	return `/// The public surface of ${module}.
+public enum ${module} {
+    /// Current version of the package. Replace this enum with your own API.
+    public static let version = "0.1.0"
+}
+`
+}
+
+/** XCTest rather than Swift Testing: it works on every toolchain, Linux included. */
+function testFile(module: string): string {
+	return `import XCTest
+
+@testable import ${module}
+
+final class ${module}Tests: XCTestCase {
+    func testVersionIsNotEmpty() {
+        XCTAssertFalse(${module}.version.isEmpty)
+    }
+}
+`
+}
+
+/**
+ * Swift is 4-space by convention while the shared .editorconfig is tab-first,
+ * so the baseline gets a Swift override appended rather than a separate file.
+ */
+const SWIFT_EDITORCONFIG_SECTION = `
+[*.swift]
+indent_style = space
+indent_size = 4
+`
+
+function readme(config: ProjectConfig, module: string): string {
+	return `# ${config.projectName}
+
+> Generated with [@rtorcato/repo-tooling](https://www.npmjs.com/package/@rtorcato/repo-tooling)
+
+## Description
+
+Your package description here.
+
+## Installation
+
+Add the package to your \`Package.swift\`:
+
+\`\`\`swift
+dependencies: [
+    .package(url: "https://github.com/OWNER/${config.projectName}.git", from: "0.1.0"),
+]
+\`\`\`
+
+Then add \`${module}\` to your target's dependencies.
+
+## Development
+
+\`\`\`bash
+swift build            # Build the package
+swift test             # Run the test suite
+swiftlint --fix        # Format and autocorrect
+swiftlint lint --strict # Lint the way CI does
+periphery scan         # Report unused declarations
+\`\`\`
+
+SwiftLint is the formatter *and* the linter here — SwiftFormat is deliberately
+not part of the standard, because a second formatter fights the first.
+
+## Project Structure
+
+\`\`\`
+${config.projectName}/
+├── Sources/${module}/          # Library source
+├── Tests/${module}Tests/       # XCTest suite
+├── Package.swift               # SwiftPM manifest
+├── .swiftlint.yml              # SwiftLint configuration
+├── .periphery.yml              # Dead-code scan configuration
+└── README.md
+\`\`\`
+
+## Tooling
+
+- **SwiftPM** — build, test, and dependency resolution
+- **SwiftLint** — linting and formatting
+- **Periphery** — dead-code detection
+- **GitHub Actions** — \`swift build\`/\`swift test\` on macOS, plus \`xcodebuild\` per declared platform
+
+Run \`npx @rtorcato/repo-tooling doctor\` any time to audit this repo against the standard.
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (\`git checkout -b feature/amazing-feature\`)
+3. Commit your changes (\`git commit -m 'feat: add amazing feature'\`)
+4. Push to the branch (\`git push origin feature/amazing-feature\`)
+5. Open a Pull Request
+
+## License
+
+[Add your license here]
+`
+}
+
+/**
+ * Relative paths `setup --dry-run` reports for a Swift config, in write order.
+ * Kept beside the writer so the two can't drift.
+ */
+export function swiftFileList(config: ProjectConfig): string[] {
+	const module = swiftModuleName(config.projectName)
+	const files = [
+		'.repo-tooling.json',
+		'Package.swift',
+		`Sources/${module}/${module}.swift`,
+		`Tests/${module}Tests/${module}Tests.swift`,
+		'.swiftlint.yml',
+		'.periphery.yml',
+		'.gitignore',
+		'.editorconfig',
+		'.github/workflows/ci.yml',
+	]
+	if (config.securityAutomation) {
+		files.push(
+			'.github/dependabot.yml',
+			'.github/workflows/dependabot-automerge.yml',
+			'.github/workflows/codeql.yml'
+		)
+	}
+	if (config.aiSetup) {
+		files.push(
+			'AGENTS.md',
+			'CLAUDE.md',
+			'.cursor/rules/repo-tooling.mdc',
+			'.github/copilot-instructions.md',
+			'.claude/skills/repo-tooling.md',
+			'.mcp.json.example'
+		)
+	}
+	files.push('README.md')
+	return files
+}
+
+/** Scaffold a SwiftPM library. The Swift arm of `generateConfigs`. */
+export async function generateSwiftProject(config: ProjectConfig, targetDir: string) {
+	const module = swiftModuleName(config.projectName)
+
+	await fs.writeFile(path.join(targetDir, 'Package.swift'), packageSwift(module))
+	await fs.outputFile(
+		path.join(targetDir, 'Sources', module, `${module}.swift`),
+		sourceFile(module)
+	)
+	await fs.outputFile(
+		path.join(targetDir, 'Tests', `${module}Tests`, `${module}Tests.swift`),
+		testFile(module)
+	)
+
+	await copyPreset('swiftlint', targetDir)
+	await copyPreset('periphery', targetDir)
+	await ensureSwiftGitignore(targetDir)
+
+	await generateEditorConfig(targetDir)
+	await fs.appendFile(path.join(targetDir, '.editorconfig'), SWIFT_EDITORCONFIG_SECTION)
+
+	// After Package.swift: the workflow's platform matrix is read back off the
+	// manifest written above.
+	const workflowsDir = path.join(targetDir, '.github', 'workflows')
+	await fs.ensureDir(workflowsDir)
+	await fs.writeFile(
+		path.join(workflowsDir, 'ci.yml'),
+		renderSwiftWorkflow(await readSwiftPackage(targetDir))
+	)
+
+	if (config.securityAutomation) {
+		await generateDependabotConfig(targetDir)
+		await generateCodeQLWorkflow(targetDir, LANGUAGES.swift.codeqlLanguages)
+	}
+
+	if (config.aiSetup) {
+		await installAiSetup(targetDir)
+	}
+
+	await fs.writeFile(path.join(targetDir, 'README.md'), readme(config, module))
+}

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -57,6 +57,23 @@ describe('setup-presets', () => {
 		expect(files).not.toContain('AGENTS.md')
 		expect(files).not.toContain('.mcp.json.example')
 	})
+
+	it('swift-library preset records the language and picks no JS tools (#288)', () => {
+		const config = buildPresetConfig('swift-library', 'demo')
+		expect(config.language).toBe('swift')
+		expect(config.projectType).toBe('library')
+		expect(config.typescript.enabled).toBe(false)
+		expect(config.bundler).toBe('none')
+		// Husky/commitlint/semantic-release are all npm packages, and every badge
+		// URL is derived from a package.json this repo doesn't have.
+		expect(config.gitHooks).toBe(false)
+		expect(config.commitLint).toBe(false)
+		expect(config.semanticRelease).toBe(false)
+		expect(config.badges).toBe(false)
+		// Security automation and the AI agent files are language-agnostic.
+		expect(config.securityAutomation).toBe(true)
+		expect(config.aiSetup).toBe(true)
+	})
 })
 
 describe('validateProjectConfig', () => {
@@ -108,6 +125,16 @@ describe('computeFileList', () => {
 		const files = computeFileList(buildPresetConfig('react-app', 'demo'))
 		expect(files).toContain('vite.config.ts')
 		expect(files).not.toContain('tsup.config.ts')
+	})
+
+	it('lists Swift files and no package.json for swift-library (#288)', () => {
+		const files = computeFileList(buildPresetConfig('swift-library', 'my-swift-lib'))
+		expect(files).toContain('Package.swift')
+		expect(files).toContain('Sources/MySwiftLib/MySwiftLib.swift')
+		expect(files).toContain('.swiftlint.yml')
+		expect(files).toContain('.github/workflows/ci.yml')
+		expect(files).not.toContain('package.json')
+		expect(files).not.toContain('tsconfig.json')
 	})
 
 	it('lists bunfig.toml when targeting Bun (#225)', () => {
@@ -195,6 +222,23 @@ describe('setup --preset', () => {
 		expect(await fs.pathExists(join(dir, 'tsup.config.ts'))).toBe(true)
 		expect(await fs.pathExists(join(dir, '.editorconfig'))).toBe(true)
 		expect(await fs.pathExists(join(dir, '.github', 'dependabot.yml'))).toBe(true)
+	})
+
+	it('scaffolds a Swift package and records the language in the lockfile (#288)', async () => {
+		const dir = newTmpDir()
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'swift-library', skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+		}
+		expect(await fs.pathExists(join(dir, 'Package.swift'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.swiftlint.yml'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.github', 'workflows', 'ci.yml'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'package.json'))).toBe(false)
+
+		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(lock.config.language).toBe('swift')
 	})
 
 	it('rejects unknown preset names', async () => {
@@ -329,7 +373,7 @@ describe('setup language prompt', () => {
 	it('defaults to the language detected in the target directory', async () => {
 		const dir = newTmpDir()
 		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version:6.0\n')
-		const spy = mockPrompt({ language: 'swift' })
+		const spy = mockPrompt({ language: 'swift' }, { projectName: 'demo' })
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await setupProject({ directory: dir, skipInstall: true })
@@ -364,9 +408,8 @@ describe('setup language prompt', () => {
 			const choices = question.choices as Array<{ name: string; value: string }>
 			expect(choices.map((c) => c.value)).toEqual(['js', 'swift', 'python', 'perl'])
 			expect(choices.find((c) => c.value === 'js')?.name).toBe('JavaScript/TypeScript')
-			// Swift has doctor/fix checks (#286) but no setup preset yet (#288) — the
-			// label has to say so rather than reading as fully supported.
-			expect(choices.find((c) => c.value === 'swift')?.name).toMatch(/no setup preset yet/)
+			// Swift is fully scaffoldable since #288, so it gets a bare label like JS.
+			expect(choices.find((c) => c.value === 'swift')?.name).toBe('Swift')
 			expect(choices.find((c) => c.value === 'perl')?.name).toMatch(/lands with its module/)
 		} finally {
 			logSpy.mockRestore()
@@ -375,17 +418,37 @@ describe('setup language prompt', () => {
 
 	it('writes nothing and points at doctor when the language has no module yet', async () => {
 		const dir = newTmpDir()
-		mockPrompt({ language: 'swift' })
+		mockPrompt({ language: 'python' })
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 		try {
 			await setupProject({ directory: dir, skipInstall: true })
 			const output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
-			expect(output).toMatch(/Swift scaffolding isn't available yet/)
+			expect(output).toMatch(/Python scaffolding isn't available yet/)
 			expect(output).toMatch(/doctor/)
 		} finally {
 			logSpy.mockRestore()
 		}
 		expect(await fs.readdir(dir)).toEqual([])
+	})
+
+	// Swift's only real choice is the package name — SwiftLint, Periphery and
+	// `swift test` are the standard, not options (#288).
+	it('asks Swift only for a name, then scaffolds the swift-library preset', async () => {
+		const dir = newTmpDir()
+		const spy = mockPrompt({ language: 'swift' }, { projectName: 'my-swift-lib' })
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+		}
+		expect(spy).toHaveBeenCalledTimes(2)
+		const [swiftQuestions] = spy.mock.calls[1] as [Array<Record<string, unknown>>]
+		expect(swiftQuestions.map((q) => q.name)).toEqual(['projectName'])
+
+		expect(await fs.pathExists(join(dir, 'Sources/MySwiftLib/MySwiftLib.swift'))).toBe(true)
+		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(lock.config.language).toBe('swift')
 	})
 
 	it('records the chosen language in the lockfile instead of a hardcoded js', async () => {

--- a/tests/languages/swift/scaffold.test.ts
+++ b/tests/languages/swift/scaffold.test.ts
@@ -1,0 +1,169 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { buildPresetConfig } from '../../../src/cli/commands/setup-presets.js'
+import {
+	generateSwiftProject,
+	swiftFileList,
+	swiftModuleName,
+} from '../../../src/languages/swift/scaffold.js'
+import { runSwiftChecks } from '../../../src/languages/swift/checks.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+/** Scaffold the swift-library preset into a fresh dir and return it. */
+async function scaffold(projectName = 'my-swift-lib') {
+	const dir = newTmpDir()
+	await generateSwiftProject(buildPresetConfig('swift-library', projectName), dir)
+	return dir
+}
+
+describe('swiftModuleName', () => {
+	it('upper-camels a hyphenated repo name', () => {
+		expect(swiftModuleName('my-swift-lib')).toBe('MySwiftLib')
+	})
+
+	it('strips dots, spaces and underscores', () => {
+		expect(swiftModuleName('swift.common_utils kit')).toBe('SwiftCommonUtilsKit')
+	})
+
+	it('leaves an already-camel name alone', () => {
+		expect(swiftModuleName('SwiftCommon')).toBe('SwiftCommon')
+	})
+
+	// Swift target names are type identifiers, so neither of these can be used raw.
+	it('prefixes a leading digit', () => {
+		expect(swiftModuleName('2fa-kit')).toBe('Package2faKit')
+	})
+
+	it('falls back to Package when nothing usable survives', () => {
+		expect(swiftModuleName('---')).toBe('Package')
+	})
+})
+
+describe('generateSwiftProject', () => {
+	it('writes a manifest, source and test named after the module', async () => {
+		const dir = await scaffold()
+		expect(await fs.pathExists(join(dir, 'Package.swift'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'Sources/MySwiftLib/MySwiftLib.swift'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'Tests/MySwiftLibTests/MySwiftLibTests.swift'))).toBe(true)
+	})
+
+	// The whole point of the Swift arm: none of the package.json-rooted generators run.
+	it('writes no JS artefacts', async () => {
+		const dir = await scaffold()
+		for (const file of ['package.json', 'tsconfig.json', 'biome.jsonc', 'vitest.config.ts']) {
+			expect(await fs.pathExists(join(dir, file)), file).toBe(false)
+		}
+	})
+
+	it('produces a manifest that passes the Package.swift check', async () => {
+		const dir = await scaffold()
+		const manifest = await fs.readFile(join(dir, 'Package.swift'), 'utf-8')
+		expect(manifest).toMatch(/^\/\/ swift-tools-version:/)
+		expect(manifest).toContain('platforms: [')
+		expect(manifest).toContain('.library(name: "MySwiftLib", targets: ["MySwiftLib"])')
+	})
+
+	// Regression: the .swiftlint.yml written alongside leaves `trailing_comma`
+	// enabled, so a manifest with them fails the `swiftlint lint --strict` job
+	// this same scaffold generates.
+	it('emits no trailing commas in the manifest collection literals', async () => {
+		const dir = await scaffold()
+		const manifest = await fs.readFile(join(dir, 'Package.swift'), 'utf-8')
+		expect(manifest).not.toMatch(/,\s*\n\s*\]/)
+	})
+
+	it('leaves the whole Swift doctor suite green', async () => {
+		const dir = await scaffold()
+		const results = await runSwiftChecks(dir)
+		expect(results.map((r) => `${r.check}: ${r.status}`)).toEqual([
+			'Package.swift: ok',
+			'SwiftLint: ok',
+			'Periphery: ok',
+			'Swift .gitignore: ok',
+		])
+	})
+
+	it('renders Swift CI on macOS with no Node in sight', async () => {
+		const dir = await scaffold()
+		const workflow = await fs.readFile(join(dir, '.github/workflows/ci.yml'), 'utf-8')
+		expect(workflow).toContain('runs-on: macos-latest')
+		expect(workflow).toContain('swift build')
+		expect(workflow).toContain('swift test')
+		expect(workflow).not.toContain('setup-node')
+		expect(workflow).not.toContain('pnpm')
+	})
+
+	// Package.swift declares platforms and a library product, so the workflow read
+	// back off it must carry the matrix — this is what the write-order guarantees.
+	it('derives the xcodebuild matrix from the manifest it just wrote', async () => {
+		const dir = await scaffold()
+		const workflow = await fs.readFile(join(dir, '.github/workflows/ci.yml'), 'utf-8')
+		expect(workflow).toContain('-scheme MySwiftLib')
+		expect(workflow).toContain('- iOS')
+		expect(workflow).toContain('- macOS')
+	})
+
+	it('scans Swift, not JavaScript, in CodeQL', async () => {
+		const dir = await scaffold()
+		const codeql = await fs.readFile(join(dir, '.github/workflows/codeql.yml'), 'utf-8')
+		expect(codeql).toContain('language: [swift]')
+		expect(codeql).not.toContain('javascript-typescript')
+	})
+
+	it('overrides the tab-first editorconfig baseline for .swift files', async () => {
+		const dir = await scaffold()
+		const editorconfig = await fs.readFile(join(dir, '.editorconfig'), 'utf-8')
+		expect(editorconfig).toContain('[*.swift]')
+		expect(editorconfig).toMatch(/\[\*\.swift\][\s\S]*indent_style = space/)
+	})
+
+	it('omits security workflows when securityAutomation is off', async () => {
+		const dir = newTmpDir()
+		await generateSwiftProject(
+			{ ...buildPresetConfig('swift-library', 'demo'), securityAutomation: false },
+			dir
+		)
+		expect(await fs.pathExists(join(dir, '.github/dependabot.yml'))).toBe(false)
+		expect(await fs.pathExists(join(dir, '.github/workflows/codeql.yml'))).toBe(false)
+		// CI is not part of security automation and stays either way.
+		expect(await fs.pathExists(join(dir, '.github/workflows/ci.yml'))).toBe(true)
+	})
+})
+
+describe('swiftFileList', () => {
+	// The list drives `setup --dry-run`; if it drifts from the writer, the preview
+	// lies about what setup is going to do.
+	it('matches what generateSwiftProject actually writes', async () => {
+		const config = buildPresetConfig('swift-library', 'my-swift-lib')
+		const dir = newTmpDir()
+		await generateSwiftProject(config, dir)
+
+		const written = (await listFilesRecursive(dir)).sort()
+		// The lockfile is written by setupProject after the generator, so it's
+		// declared but never on disk at this point.
+		const declared = swiftFileList(config)
+			.filter((f) => f !== '.repo-tooling.json')
+			.sort()
+		expect(written).toEqual(declared)
+	})
+
+	it('drops the AI files when aiSetup is off', () => {
+		const config = { ...buildPresetConfig('swift-library', 'demo'), aiSetup: false }
+		expect(swiftFileList(config)).not.toContain('AGENTS.md')
+		expect(swiftFileList(config)).toContain('Package.swift')
+	})
+})
+
+async function listFilesRecursive(dir: string, prefix = ''): Promise<string[]> {
+	const entries = await fs.readdir(join(dir, prefix), { withFileTypes: true })
+	const files: string[] = []
+	for (const entry of entries) {
+		const rel = prefix ? `${prefix}/${entry.name}` : entry.name
+		if (entry.isDirectory()) files.push(...(await listFilesRecursive(dir, rel)))
+		else files.push(rel)
+	}
+	return files
+}

--- a/tooling/claude/repo-tooling.md
+++ b/tooling/claude/repo-tooling.md
@@ -51,7 +51,7 @@ npx @rtorcato/repo-tooling fix <target> --diff           # unified diff before c
 ## Scaffolding a new project
 
 ```bash
-# Quick: from a named preset (library | web-app | node-api | nextjs-app | react-app)
+# Quick: from a named preset (library | web-app | node-api | nextjs-app | react-app | swift-library)
 npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
 
 # Full control: validate a config against the schema, preview, then write


### PR DESCRIPTION
Closes #288. Stacked on #287 (merged as #305) — rebased onto `main`.

## What

`setup --preset swift-library` — and picking **Swift** in the interactive
wizard — now scaffolds a SwiftPM package end to end, instead of writing nothing
and pointing at `doctor`.

```bash
npx @rtorcato/repo-tooling setup --preset swift-library -d ./my-swift-lib
```

## How

The Swift arm branches at the top of `generateConfigs` rather than opting out of
each generator one condition at a time. Everything on the JS path is rooted in
`package.json` — the file a Swift repo is defined by not having — so there was
no shared middle to factor out.

`src/languages/swift/scaffold.ts` writes:

| File | Why |
|---|---|
| `Package.swift` | tools 6.0, `platforms: [.iOS(.v17), .macOS(.v14)]`, one library product |
| `Sources/<Module>/<Module>.swift` | placeholder public enum, so `swift build` succeeds |
| `Tests/<Module>Tests/<Module>Tests.swift` | one XCTest case, so `swift test` succeeds |
| `.swiftlint.yml`, `.periphery.yml`, `.gitignore` | reused from the #286 fixers/presets |
| `.editorconfig` | shared baseline + a `[*.swift]` 4-space override |
| `.github/workflows/ci.yml` | the Swift CI from #287 |
| `codeql.yml`, `dependabot.yml` + auto-merge | language-agnostic security automation |
| AI agent files, `README.md` | language-agnostic / SwiftPM-flavoured |

The manifest is written **before** the workflow on purpose: #287 derives the
`xcodebuild` platform matrix from `Package.swift`, so it reads back what was
just emitted.

`my-swift-lib` → module `MySwiftLib`. Swift target names are type identifiers,
so hyphens/dots/spaces are stripped and a leading digit gets a `Package` prefix.

## The preset's JS fields are all `none`

That means "no *JS* tool", not "no tooling" — SwiftLint, Periphery and
`swift test` are the standard rather than options. Same reason the interactive
Swift path asks only for a package name: a wizard whose every question has one
answer is worse than no wizard. Husky/commitlint/semantic-release are off
because they're npm packages, and `badges` is off because every badge URL is
derived from a `package.json` that doesn't exist here.

None of this confuses `doctor` — the Biome/Vitest/TypeScript checks those fields
gate never run on the Swift path.

## One real bug caught while verifying

The first generated `Package.swift` **failed the scaffold's own CI**: the
`.swiftlint.yml` written alongside it leaves `trailing_comma` enabled, so the
manifest's trailing commas tripped the `swiftlint lint --strict` job this same
scaffold generates. Fixed, with a regression test.

## Verification

Against a real Swift 6.3 toolchain, on a freshly scaffolded package:

```
swift build              → Build complete!
swift test               → Executed 1 test, with 0 failures
swiftlint lint --strict  → Found 0 violations, 0 serious in 3 files
repo-tooling doctor      → 16 ok, 0 drift, 0 missing, 3 not configured
```

`--dry-run`'s file list was diffed against the actual scaffold output: exact match.

- `pnpm verify` — 551 tests pass; check/typecheck/build clean
- `pnpm docs:build` — clean, no broken links
- 17 new tests in `tests/languages/swift/scaffold.test.ts`, plus preset/lockfile/prompt tests in `setup.test.ts`

Two existing language-prompt tests changed: Swift's picker label no longer says
"no setup preset yet", and the "no module yet" case moved from Swift to Python.

## Docs

- **New:** `guides/swift.md` — lifecycle guide (scaffold, file list, JS-vs-Swift
  comparison table, CI, doctor/fix). `reference/swift.md` stays the config +
  check reference.
- Preset lists updated in `README.md`, `AGENTS.md`, the Claude skill,
  `guides/cli.md`, `guides/getting-started.mdx`, `guides/for-ai-agents.md`.

## Deliberately out of scope

The generated `dependabot.yml` still uses `package-ecosystem: npm` where a Swift
repo wants `swift` — already tracked as part of #303, and noted in both docs pages.