### PR TITLE
refactor(fix): split language-agnostic fixers into src/base (#303)

### DIFF
--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -1,10 +1,29 @@
 /**
- * The fixer contract, shared by every language module (#286).
+ * The fixer contract plus the language-agnostic fixers (#286, #303).
  *
- * Only the types live here — the fixers themselves belong to their language
- * module. `fix` concatenates the set for the repo's detected language.
+ * These are the fixers for the checks in ./checks.ts — repo hygiene, security
+ * automation, community health, AI agent files, GitHub repo settings. Nothing
+ * here reads a package.json or emits a toolchain-specific step, so every
+ * language module gets them for free; `fix` concatenates them with the module's
+ * own set.
+ *
+ * Not here: `github-actions` / `gitlab-ci` / `lockfile`. Their *content* is
+ * language-shaped (CI steps, recorded tool choices), so each module ships its
+ * own — see src/base/ci.ts for the shell they share.
  */
+import { installAgentRules, installAiSetup } from '../cli/generators/agent-rules.js'
+import { generateCommunityHealth } from '../cli/generators/community-health.js'
+import { generateCodeowners, generateEditorConfig } from '../cli/generators/misc.js'
+import {
+	generateCodeQLWorkflow,
+	generateDependabotConfig,
+	generateRenovateConfig,
+} from '../cli/generators/security.js'
+import { copyPreset } from '../cli/utils/copy-preset.js'
+import { detectLanguage } from '../cli/utils/detect-language.js'
 import type { Lockfile } from '../cli/utils/lockfile.js'
+import { resolveLanguageModule } from '../languages/registry.js'
+import { applyGithubSettings } from './github-settings.js'
 import type { CheckResult } from './types.js'
 
 /** A parsed package.json, or null when the repo has none (any non-JS repo). */
@@ -36,3 +55,180 @@ export interface Fixer {
 	canFixDrift?: boolean
 	run(ctx: FixerContext): Promise<{ filesWritten: string[] }>
 }
+
+/** The repo's language module, resolved from its marker files. */
+async function moduleFor(targetDir: string) {
+	return resolveLanguageModule(await detectLanguage(targetDir))
+}
+
+export const BASE_FIXERS: Fixer[] = [
+	{
+		target: 'editorconfig',
+		description: 'Scaffold .editorconfig (UTF-8, LF, tab indent)',
+		appliesTo: ['EditorConfig'],
+		outputs: ['.editorconfig'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			await generateEditorConfig(targetDir)
+			return { filesWritten: ['.editorconfig'] }
+		},
+	},
+	{
+		target: 'dependabot',
+		description:
+			'Scaffold the canonical .github/dependabot.yml (monthly, grouped: production-minor/dev-minor/major-updates) + the dependabot-automerge workflow',
+		appliesTo: ['Dependabot'],
+		outputs: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const { dependabotEcosystem } = await moduleFor(targetDir)
+			return { filesWritten: await generateDependabotConfig(targetDir, dependabotEcosystem) }
+		},
+	},
+	{
+		target: 'renovate',
+		description: 'Scaffold renovate.json (weekly schedule; alternative to Dependabot)',
+		appliesTo: ['Dependabot'],
+		outputs: ['renovate.json'],
+		riskLevel: 'safe-add',
+		async run({ targetDir }) {
+			await generateRenovateConfig(targetDir)
+			return { filesWritten: ['renovate.json'] }
+		},
+	},
+	{
+		target: 'codeql',
+		description: 'Scaffold .github/workflows/codeql.yml (security scanning)',
+		appliesTo: ['CodeQL'],
+		outputs: ['.github/workflows/codeql.yml'],
+		async run({ targetDir }) {
+			const { codeqlLanguages } = await moduleFor(targetDir)
+			return { filesWritten: await generateCodeQLWorkflow(targetDir, codeqlLanguages) }
+		},
+	},
+	{
+		target: 'github-settings',
+		description:
+			'Apply branch protection + auto-merge + workflow permissions + code-scanning ruleset on GitHub via gh api (mutates the remote repo, not files)',
+		appliesTo: [
+			'Branch protection',
+			'Merge settings',
+			'Workflow permissions',
+			'Code-scanning gate',
+		],
+		outputs: ['GitHub repo settings (remote, via gh api)'],
+		// safe-add is load-bearing: it exempts this fixer from the `--diff` shadow-run
+		// (previewFixer copies to tmp and *executes* run(), which would fire real
+		// `gh api` PUTs during a mere preview).
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await applyGithubSettings(targetDir) }
+		},
+	},
+	{
+		target: 'codeowners',
+		description: 'Scaffold .github/CODEOWNERS with commented examples',
+		appliesTo: ['CODEOWNERS'],
+		outputs: ['.github/CODEOWNERS'],
+		riskLevel: 'safe-add',
+		canFixDrift: false,
+		async run({ targetDir }) {
+			const written = await generateCodeowners(targetDir)
+			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'community-health',
+		description: 'Scaffold CONTRIBUTING.md, SECURITY.md, PR + issue templates',
+		appliesTo: ['Community health'],
+		outputs: [
+			'CONTRIBUTING.md',
+			'SECURITY.md',
+			'.github/PULL_REQUEST_TEMPLATE.md',
+			'.github/ISSUE_TEMPLATE/bug_report.md',
+			'.github/ISSUE_TEMPLATE/feature_request.md',
+		],
+		riskLevel: 'safe-add',
+		canFixDrift: false,
+		async run({ targetDir }) {
+			const filesWritten = await generateCommunityHealth(targetDir)
+			return { filesWritten }
+		},
+	},
+	{
+		target: 'ai',
+		description:
+			'Install all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example)',
+		appliesTo: ['AI setup'],
+		outputs: [
+			'AGENTS.md',
+			'CLAUDE.md',
+			'.cursor/rules/repo-tooling.mdc',
+			'.github/copilot-instructions.md',
+			'.claude/skills/repo-tooling.md',
+			'.mcp.json.example',
+			// Only written when the repo ships its own skills/<name>/SKILL.md.
+			'README.md',
+		],
+		// Every output is a delimited-block upsert or a `.example` file — existing
+		// user content is never clobbered.
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const filesWritten = await installAiSetup(targetDir)
+			return { filesWritten }
+		},
+	},
+	{
+		target: 'claude-skill',
+		description: 'Install the repo-tooling Claude Code skill into .claude/skills/',
+		appliesTo: ['Claude skill'],
+		outputs: ['.claude/skills/repo-tooling.md'],
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('claude-skill', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'cursor-rules',
+		description: 'Install the repo-tooling rules for Cursor (.cursor/rules/repo-tooling.mdc)',
+		appliesTo: ['Cursor rules'],
+		outputs: ['.cursor/rules/repo-tooling.mdc'],
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const written = await installAgentRules(targetDir, 'cursor')
+			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'copilot-instructions',
+		description:
+			'Install the repo-tooling rules for GitHub Copilot (.github/copilot-instructions.md)',
+		appliesTo: ['Copilot instructions'],
+		outputs: ['.github/copilot-instructions.md'],
+		// Upserts a delimited block — never clobbers the consumer's own instructions.
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const written = await installAgentRules(targetDir, 'copilot')
+			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'agents-md',
+		description: 'Install the repo-tooling rules into AGENTS.md (universal agent instructions)',
+		appliesTo: ['AGENTS.md rules'],
+		outputs: ['AGENTS.md'],
+		// Upserts a delimited block — never clobbers existing AGENTS.md content.
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const written = await installAgentRules(targetDir, 'agents-md')
+			return { filesWritten: [written] }
+		},
+	},
+]

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -16,28 +16,23 @@ import type { CheckResult } from './doctor.js'
 import { runDoctor } from './doctor.js'
 import { declinedInLock, lockfilePatchForTarget } from './fix-targets.js'
 import { computeFileList } from './setup-presets.js'
-import type { Fixer, FixRiskLevel, Pkg } from '../../base/fixers.js'
+import { BASE_FIXERS, type Fixer, type FixRiskLevel, type Pkg } from '../../base/fixers.js'
 import { FIXERS, readPackageJson } from '../../languages/js/fixers.js'
 import { SWIFT_FIXERS } from '../../languages/swift/fixers.js'
 import { detectLanguage } from '../utils/detect-language.js'
 
 /**
- * The fixers that apply to a repo, by detected language (#286). Swift repos get
- * the Swift set; everything else (including a bare dir mid-setup) gets JS, the
+ * The fixers that apply to a repo, by detected language (#286, #303): the
+ * language-agnostic base set plus the module's own. Swift repos get the Swift
+ * module; everything else (including a bare dir mid-setup) gets JS, the
  * historical default.
- *
- * ponytail: no base/language split yet. Most of the JS set is *actually*
- * language-agnostic (dependabot, codeql, codeowners, community-health, …), so a
- * Swift repo currently sees those checks from doctor but can't fix them. That
- * move is the fixer sibling of #282 and gets its own issue rather than riding
- * along here.
  */
 function fixersForLanguage(language: string): Fixer[] {
-	return language === 'swift' ? SWIFT_FIXERS : FIXERS
+	return [...BASE_FIXERS, ...(language === 'swift' ? SWIFT_FIXERS : FIXERS)]
 }
 
 /** Every fixer across every language — for `--list` and the unknown-target hint. */
-const ALL_FIXERS: Fixer[] = [...FIXERS, ...SWIFT_FIXERS]
+const ALL_FIXERS: Fixer[] = [...BASE_FIXERS, ...FIXERS, ...SWIFT_FIXERS]
 
 export interface FixOptions {
 	directory?: string

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -3,10 +3,18 @@ import fs from 'fs-extra'
 import { renderCodeQLWorkflow } from '../../base/ci.js'
 import { LANGUAGES } from '../../languages/registry.js'
 
-/** The canonical dependency-update standard shared by every @rtorcato repo. */
-export const DEPENDABOT_CONFIG = `version: 2
-updates:
-  - package-ecosystem: npm
+/**
+ * The canonical dependency-update standard shared by every @rtorcato repo.
+ *
+ * `ecosystem` is the language's Dependabot `package-ecosystem` (#303) — null
+ * for a language Dependabot doesn't support, which drops the manifest block and
+ * leaves only the github-actions one.
+ */
+export function dependabotConfig(ecosystem: string | null): string {
+	const manifest =
+		ecosystem === null
+			? ''
+			: `  - package-ecosystem: ${ecosystem}
     directory: /
     schedule:
       interval: monthly
@@ -41,7 +49,11 @@ updates:
         update-types:
           - major
 
-  - package-ecosystem: github-actions
+`
+
+	return `version: 2
+updates:
+${manifest}  - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
@@ -49,6 +61,11 @@ updates:
       prefix: ci
       include: scope
 `
+}
+
+/** The JS flavour — the historical default, kept for the generators that don't
+ * resolve a language module. */
+export const DEPENDABOT_CONFIG = dependabotConfig('npm')
 
 /**
  * Auto-merges patch + minor Dependabot PRs once CI is green. Requires branch
@@ -97,9 +114,12 @@ export const DEPENDABOT_FILES = [
  * into a safe tier and a major tier, and the workflow merges the safe tier on
  * green. See \`apps/docs/docs/guides/dependabot-strategy.md\`.
  */
-export async function generateDependabotConfig(targetDir: string) {
+export async function generateDependabotConfig(
+	targetDir: string,
+	ecosystem: string | null = 'npm'
+) {
 	await fs.ensureDir(path.join(targetDir, '.github', 'workflows'))
-	await fs.writeFile(path.join(targetDir, '.github', 'dependabot.yml'), DEPENDABOT_CONFIG)
+	await fs.writeFile(path.join(targetDir, '.github', 'dependabot.yml'), dependabotConfig(ecosystem))
 	await fs.writeFile(
 		path.join(targetDir, '.github', 'workflows', 'dependabot-automerge.yml'),
 		DEPENDABOT_AUTOMERGE_WORKFLOW

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
-import { installAgentRules, installAiSetup } from '../../cli/generators/agent-rules.js'
 import { buildBadgeBlock, parseRepository, upsertBadges } from '../../cli/generators/badges.js'
 import {
 	generateReleasePleaseConfig,
@@ -9,7 +8,6 @@ import {
 	generateRollupConfig,
 	generateSemanticReleaseConfig,
 } from '../../cli/generators/build.js'
-import { generateCommunityHealth } from '../../cli/generators/community-health.js'
 import {
 	generateCommitlintConfig,
 	generateHuskyConfig,
@@ -22,8 +20,6 @@ import { generateESLintConfig, generatePrettierConfig } from '../../cli/generato
 import {
 	alignNodeVersion,
 	ensureEnginesNode,
-	generateCodeowners,
-	generateEditorConfig,
 	generateKnipConfig,
 	generateNvmrc,
 	generateSizeLimitConfig,
@@ -31,11 +27,6 @@ import {
 } from '../../cli/generators/misc.js'
 import { composeVerifyScriptFromPkg } from '../../cli/generators/package-json.js'
 import { generatePostcss } from '../../cli/generators/postcss.js'
-import {
-	generateCodeQLWorkflow,
-	generateDependabotConfig,
-	generateRenovateConfig,
-} from '../../cli/generators/security.js'
 import { generateCypressConfig, generateVitestConfig } from '../../cli/generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../../cli/generators/treeshake.js'
 import { generateTailwind } from '../../cli/generators/tailwind.js'
@@ -45,10 +36,8 @@ import { generateBun } from '../../cli/generators/bun.js'
 import { generateDocsSite } from '../../cli/generators/docs-site.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../../cli/generators/typedoc.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
-import { applyGithubSettings } from '../../base/github-settings.js'
 import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
 import type { ProjectConfig } from '../../cli/commands/setup.js'
-import { LANGUAGES } from '../registry.js'
 
 // The fixer contract moved to src/base/fixers.ts when Swift became the second
 // module (#286) — import it from there.
@@ -365,89 +354,6 @@ export const FIXERS: Fixer[] = [
 		},
 	},
 	{
-		target: 'dependabot',
-		description:
-			'Scaffold the canonical .github/dependabot.yml (monthly, grouped: production-minor/dev-minor/major-updates) + the dependabot-automerge workflow',
-		appliesTo: ['Dependabot'],
-		outputs: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
-		canFixDrift: true,
-		async run({ targetDir }) {
-			const filesWritten = await generateDependabotConfig(targetDir)
-			return { filesWritten }
-		},
-	},
-	{
-		target: 'renovate',
-		description: 'Scaffold renovate.json (weekly schedule; alternative to Dependabot)',
-		appliesTo: ['Dependabot'],
-		outputs: ['renovate.json'],
-		riskLevel: 'safe-add',
-		async run({ targetDir }) {
-			await generateRenovateConfig(targetDir)
-			return { filesWritten: ['renovate.json'] }
-		},
-	},
-	{
-		target: 'codeql',
-		description: 'Scaffold .github/workflows/codeql.yml (security scanning)',
-		appliesTo: ['CodeQL'],
-		outputs: ['.github/workflows/codeql.yml'],
-		async run({ targetDir }) {
-			const filesWritten = await generateCodeQLWorkflow(targetDir, LANGUAGES.js.codeqlLanguages)
-			return { filesWritten }
-		},
-	},
-	{
-		target: 'github-settings',
-		description:
-			'Apply branch protection + auto-merge + workflow permissions + code-scanning ruleset on GitHub via gh api (mutates the remote repo, not files)',
-		appliesTo: [
-			'Branch protection',
-			'Merge settings',
-			'Workflow permissions',
-			'Code-scanning gate',
-		],
-		outputs: ['GitHub repo settings (remote, via gh api)'],
-		// safe-add is load-bearing: it exempts this fixer from the `--diff` shadow-run
-		// (previewFixer copies to tmp and *executes* run(), which would fire real
-		// `gh api` PUTs during a mere preview).
-		riskLevel: 'safe-add',
-		canFixDrift: true,
-		async run({ targetDir }) {
-			return { filesWritten: await applyGithubSettings(targetDir) }
-		},
-	},
-	{
-		target: 'codeowners',
-		description: 'Scaffold .github/CODEOWNERS with commented examples',
-		appliesTo: ['CODEOWNERS'],
-		outputs: ['.github/CODEOWNERS'],
-		riskLevel: 'safe-add',
-		canFixDrift: false,
-		async run({ targetDir }) {
-			const written = await generateCodeowners(targetDir)
-			return { filesWritten: [written] }
-		},
-	},
-	{
-		target: 'community-health',
-		description: 'Scaffold CONTRIBUTING.md, SECURITY.md, PR + issue templates',
-		appliesTo: ['Community health'],
-		outputs: [
-			'CONTRIBUTING.md',
-			'SECURITY.md',
-			'.github/PULL_REQUEST_TEMPLATE.md',
-			'.github/ISSUE_TEMPLATE/bug_report.md',
-			'.github/ISSUE_TEMPLATE/feature_request.md',
-		],
-		riskLevel: 'safe-add',
-		canFixDrift: false,
-		async run({ targetDir }) {
-			const filesWritten = await generateCommunityHealth(targetDir)
-			return { filesWritten }
-		},
-	},
-	{
 		target: 'gitlab-ci',
 		description: 'Scaffold .gitlab-ci.yml (lint/typecheck/test/build mirrored from GitHub Actions)',
 		appliesTo: ['GitLab CI'],
@@ -506,17 +412,6 @@ export const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const written = await generatePostcss(targetDir)
 			return { filesWritten: written }
-		},
-	},
-	{
-		target: 'editorconfig',
-		description: 'Scaffold .editorconfig (UTF-8, LF, tab indent)',
-		appliesTo: ['EditorConfig'],
-		outputs: ['.editorconfig'],
-		canFixDrift: true,
-		async run({ targetDir }) {
-			await generateEditorConfig(targetDir)
-			return { filesWritten: ['.editorconfig'] }
 		},
 	},
 	{
@@ -835,81 +730,6 @@ export const FIXERS: Fixer[] = [
 				: `# ${name ?? 'project'}\n`
 			await fs.writeFile(readmePath, upsertBadges(existing, block))
 			return { filesWritten: ['README.md'] }
-		},
-	},
-	{
-		target: 'ai',
-		description:
-			'Install all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example)',
-		appliesTo: ['AI setup'],
-		outputs: [
-			'AGENTS.md',
-			'CLAUDE.md',
-			'.cursor/rules/repo-tooling.mdc',
-			'.github/copilot-instructions.md',
-			'.claude/skills/repo-tooling.md',
-			'.mcp.json.example',
-			// Only written when the repo ships its own skills/<name>/SKILL.md.
-			'README.md',
-		],
-		// Every output is a delimited-block upsert or a `.example` file — existing
-		// user content is never clobbered.
-		riskLevel: 'safe-merge',
-		canFixDrift: true,
-		async run({ targetDir }) {
-			const filesWritten = await installAiSetup(targetDir)
-			return { filesWritten }
-		},
-	},
-	{
-		target: 'claude-skill',
-		description: 'Install the repo-tooling Claude Code skill into .claude/skills/',
-		appliesTo: ['Claude skill'],
-		outputs: ['.claude/skills/repo-tooling.md'],
-		riskLevel: 'safe-add',
-		canFixDrift: true,
-		async run({ targetDir }) {
-			const result = await copyPreset('claude-skill', targetDir)
-			return { filesWritten: [result.target] }
-		},
-	},
-	{
-		target: 'cursor-rules',
-		description: 'Install the repo-tooling rules for Cursor (.cursor/rules/repo-tooling.mdc)',
-		appliesTo: ['Cursor rules'],
-		outputs: ['.cursor/rules/repo-tooling.mdc'],
-		riskLevel: 'safe-add',
-		canFixDrift: true,
-		async run({ targetDir }) {
-			const written = await installAgentRules(targetDir, 'cursor')
-			return { filesWritten: [written] }
-		},
-	},
-	{
-		target: 'copilot-instructions',
-		description:
-			'Install the repo-tooling rules for GitHub Copilot (.github/copilot-instructions.md)',
-		appliesTo: ['Copilot instructions'],
-		outputs: ['.github/copilot-instructions.md'],
-		// Upserts a delimited block — never clobbers the consumer's own instructions.
-		riskLevel: 'safe-merge',
-		canFixDrift: true,
-		async run({ targetDir }) {
-			const written = await installAgentRules(targetDir, 'copilot')
-			return { filesWritten: [written] }
-		},
-	},
-	{
-		target: 'agents-md',
-		description: 'Install the repo-tooling rules into AGENTS.md (universal agent instructions)',
-		appliesTo: ['AGENTS.md rules'],
-		outputs: ['AGENTS.md'],
-		// Upserts a delimited block — never clobbers existing AGENTS.md content.
-		riskLevel: 'safe-merge',
-		canFixDrift: true,
-		async run({ targetDir }) {
-			const written = await installAgentRules(targetDir, 'agents-md')
-			return { filesWritten: [written] }
 		},
 	},
 	{

--- a/src/languages/registry.ts
+++ b/src/languages/registry.ts
@@ -17,6 +17,12 @@ export interface LanguageModule {
 	/** CodeQL language identifiers for this language's code-scanning matrix (#287). */
 	codeqlLanguages: readonly string[]
 	/**
+	 * Dependabot `package-ecosystem` for this language's manifests, or null when
+	 * Dependabot has no support for it (Perl/CPAN). Null still gets the
+	 * github-actions update block — that one applies to any repo with workflows.
+	 */
+	dependabotEcosystem: string | null
+	/**
 	 * Whether repo-tooling's doctor/fix suite covers this language yet. Only JS
 	 * today; Swift/Python/Perl flip to `true` as their modules land (#286/#290/#289).
 	 * The coarse doctor gate keys off this until per-module dispatch (#285).
@@ -29,11 +35,30 @@ export const LANGUAGES: Record<LanguageModule['id'], LanguageModule> = {
 		id: 'js',
 		label: 'JavaScript/TypeScript',
 		codeqlLanguages: ['javascript-typescript'],
+		dependabotEcosystem: 'npm',
 		supported: true,
 	},
-	swift: { id: 'swift', label: 'Swift', codeqlLanguages: ['swift'], supported: true },
-	python: { id: 'python', label: 'Python', codeqlLanguages: ['python'], supported: false },
-	perl: { id: 'perl', label: 'Perl', codeqlLanguages: [], supported: false },
+	swift: {
+		id: 'swift',
+		label: 'Swift',
+		codeqlLanguages: ['swift'],
+		dependabotEcosystem: 'swift',
+		supported: true,
+	},
+	python: {
+		id: 'python',
+		label: 'Python',
+		codeqlLanguages: ['python'],
+		dependabotEcosystem: 'pip',
+		supported: false,
+	},
+	perl: {
+		id: 'perl',
+		label: 'Perl',
+		codeqlLanguages: [],
+		dependabotEcosystem: null,
+		supported: false,
+	},
 }
 
 /**

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -4,51 +4,11 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import type { Fixer } from '../../base/fixers.js'
-import { generateCodeQLWorkflow } from '../../cli/generators/security.js'
+import { buildPresetConfig } from '../../cli/commands/setup-presets.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
-import { LANGUAGES } from '../registry.js'
+import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
 import { readSwiftPackage, renderSwiftGitLabCI, renderSwiftWorkflow } from './ci.js'
-
-/**
- * The Swift build artefacts that must stay out of git. Appended to an existing
- * .gitignore rather than replacing it — a Swift repo's ignore file usually
- * carries project-specific entries worth keeping.
- */
-const SWIFT_GITIGNORE_BLOCK = `# Swift / SwiftPM
-.DS_Store
-/.build
-/Packages
-/*.xcodeproj
-xcuserdata/
-DerivedData/
-.swiftpm/config/registries.json
-.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
-.netrc
-`
-
-/** Entries whose presence means the block (or an equivalent) is already there. */
-const SENTINELS = ['.build', 'DerivedData', 'xcuserdata']
-
-export async function ensureSwiftGitignore(targetDir: string): Promise<string[]> {
-	const filepath = path.join(targetDir, '.gitignore')
-	if (!(await fs.pathExists(filepath))) {
-		await fs.writeFile(filepath, SWIFT_GITIGNORE_BLOCK)
-		return ['.gitignore']
-	}
-
-	const existing = await fs.readFile(filepath, 'utf-8')
-	const missing = SENTINELS.filter((entry) => !existing.includes(entry))
-	if (missing.length === 0) return []
-
-	// Append only what's absent, so a repo that already ignores .build doesn't
-	// get a duplicate entry for it.
-	const additions = SWIFT_GITIGNORE_BLOCK.split('\n').filter(
-		(line) => line.length > 0 && !existing.includes(line)
-	)
-	const separator = existing.endsWith('\n') ? '' : '\n'
-	await fs.writeFile(filepath, `${existing}${separator}\n${additions.join('\n')}\n`)
-	return ['.gitignore']
-}
+import { ensureSwiftGitignore } from './gitignore.js'
 
 export const SWIFT_FIXERS: Fixer[] = [
 	{
@@ -113,13 +73,18 @@ export const SWIFT_FIXERS: Fixer[] = [
 		},
 	},
 	{
-		target: 'swift-codeql',
-		description: 'Scaffold .github/workflows/codeql.yml with `language: swift`',
-		appliesTo: ['CodeQL'],
-		outputs: ['.github/workflows/codeql.yml'],
+		target: 'swift-lockfile',
+		description: `Scaffold ${LOCKFILE_NAME} recording the Swift tool choices`,
+		appliesTo: ['lockfile'],
+		outputs: [LOCKFILE_NAME],
+		riskLevel: 'safe-add',
+		canFixDrift: false,
 		async run({ targetDir }) {
-			const filesWritten = await generateCodeQLWorkflow(targetDir, LANGUAGES.swift.codeqlLanguages)
-			return { filesWritten }
+			// A Swift repo has no package.json to infer from, so record what `setup
+			// --preset swift-library` would have written — the same config, minus the
+			// scaffolding.
+			await writeLockfile(targetDir, buildPresetConfig('swift-library', path.basename(targetDir)))
+			return { filesWritten: [LOCKFILE_NAME] }
 		},
 	},
 ]

--- a/src/languages/swift/gitignore.ts
+++ b/src/languages/swift/gitignore.ts
@@ -1,0 +1,49 @@
+/**
+ * The Swift .gitignore block, shared by the `swift-gitignore` fixer and the
+ * scaffolder. Its own module so `scaffold.ts` doesn't have to import from
+ * `fixers.ts` — that edge closed an import cycle once `fixers.ts` started
+ * reading the lockfile (lockfile → setup-presets → scaffold → fixers → lockfile).
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * The Swift build artefacts that must stay out of git. Appended to an existing
+ * .gitignore rather than replacing it — a Swift repo's ignore file usually
+ * carries project-specific entries worth keeping.
+ */
+const SWIFT_GITIGNORE_BLOCK = `# Swift / SwiftPM
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc
+`
+
+/** Entries whose presence means the block (or an equivalent) is already there. */
+const SENTINELS = ['.build', 'DerivedData', 'xcuserdata']
+
+export async function ensureSwiftGitignore(targetDir: string): Promise<string[]> {
+	const filepath = path.join(targetDir, '.gitignore')
+	if (!(await fs.pathExists(filepath))) {
+		await fs.writeFile(filepath, SWIFT_GITIGNORE_BLOCK)
+		return ['.gitignore']
+	}
+
+	const existing = await fs.readFile(filepath, 'utf-8')
+	const missing = SENTINELS.filter((entry) => !existing.includes(entry))
+	if (missing.length === 0) return []
+
+	// Append only what's absent, so a repo that already ignores .build doesn't
+	// get a duplicate entry for it.
+	const additions = SWIFT_GITIGNORE_BLOCK.split('\n').filter(
+		(line) => line.length > 0 && !existing.includes(line)
+	)
+	const separator = existing.endsWith('\n') ? '' : '\n'
+	await fs.writeFile(filepath, `${existing}${separator}\n${additions.join('\n')}\n`)
+	return ['.gitignore']
+}

--- a/src/languages/swift/scaffold.ts
+++ b/src/languages/swift/scaffold.ts
@@ -20,7 +20,7 @@ import { generateCodeQLWorkflow, generateDependabotConfig } from '../../cli/gene
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LANGUAGES } from '../registry.js'
 import { readSwiftPackage, renderSwiftWorkflow } from './ci.js'
-import { ensureSwiftGitignore } from './fixers.js'
+import { ensureSwiftGitignore } from './gitignore.js'
 
 /**
  * Turn a repo name into a Swift module name: `my-swift-lib` → `MySwiftLib`.
@@ -245,7 +245,7 @@ export async function generateSwiftProject(config: ProjectConfig, targetDir: str
 	)
 
 	if (config.securityAutomation) {
-		await generateDependabotConfig(targetDir)
+		await generateDependabotConfig(targetDir, LANGUAGES.swift.dependabotEcosystem)
 		await generateCodeQLWorkflow(targetDir, LANGUAGES.swift.codeqlLanguages)
 	}
 

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -2,9 +2,11 @@ import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { BASE_FIXERS } from '../../../src/base/fixers.js'
 import { FIXERS } from '../../../src/languages/js/fixers.js'
 import { checkSwiftGitignore } from '../../../src/languages/swift/checks.js'
-import { SWIFT_FIXERS, ensureSwiftGitignore } from '../../../src/languages/swift/fixers.js'
+import { SWIFT_FIXERS } from '../../../src/languages/swift/fixers.js'
+import { ensureSwiftGitignore } from '../../../src/languages/swift/gitignore.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -37,10 +39,26 @@ describe('swift fixers', () => {
 		}
 	})
 
-	it('uses target names that do not collide with the JS fixer set', () => {
+	it('uses target names that do not collide with the JS or base fixer sets', () => {
 		// `fix --list` shows every language's fixers in one list.
-		const jsTargets = new Set(FIXERS.map((f) => f.target))
-		for (const f of SWIFT_FIXERS) expect(jsTargets).not.toContain(f.target)
+		const taken = new Set([...FIXERS, ...BASE_FIXERS].map((f) => f.target))
+		for (const f of SWIFT_FIXERS) expect(taken).not.toContain(f.target)
+	})
+
+	// The bug behind #303: doctor reported the base findings on a Swift repo but
+	// `fix` returned `unsupported` for every one of them, because only the Swift
+	// module's fixers were in play.
+	it('base + Swift fixers cover every check doctor emits for a Swift repo', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version: 5.9\n')
+		const fixable = new Set([...BASE_FIXERS, ...SWIFT_FIXERS].flatMap((f) => f.appliesTo))
+		const uncovered = (await runDoctor(dir))
+			.map((r) => r.check)
+			.filter((check) => !fixable.has(check))
+		// `language` and `Package.swift` are informational (scaffolding a manifest
+		// is `setup`'s job); `Coverage upload` is a base check only the JS CI
+		// generator satisfies, so Swift has nothing to apply for it.
+		expect(uncovered).toEqual(['language', 'Coverage upload', 'Package.swift'])
 	})
 
 	it('swiftlint writes a config the SwiftLint check accepts', async () => {


### PR DESCRIPTION
#282 moved the language-agnostic checks into src/base/; the fixers
never followed, so on a Swift repo `doctor` reported the base findings
and `fix` returned `unsupported` for every one of them.

Move the 12 fixers whose output has nothing JS-specific in it
(editorconfig, dependabot, renovate, codeql, github-settings,
codeowners, community-health, ai, claude-skill, cursor-rules,
copilot-instructions, agents-md) into BASE_FIXERS, and have
fixersForLanguage() return [...BASE_FIXERS, ...languageFixers].

Two are now language-aware rather than JS-hardcoded, resolving the
module from the repo's marker files:

- dependabot writes the language's `package-ecosystem` (npm/swift/pip;
  null for Perl drops the manifest block, leaving github-actions)
- codeql uses the module's codeqlLanguages, which makes swift-codeql
  redundant — dropped

github-actions/gitlab-ci/lockfile stay per-module: their content is
language-shaped. Swift gains a swift-lockfile fixer recording the
swift-library preset config, having no package.json to infer from.

Swift .gitignore generation moves to languages/swift/gitignore.ts —
scaffold.ts importing it from fixers.ts closed an import cycle
(lockfile -> setup-presets -> scaffold -> fixers -> lockfile) once the
fixers read the lockfile, which crashed the built CLI at startup.

Closes #303