### PR TITLE
refactor(base): move git-hooks, commitlint and badges out of languages/js (#309)

### DIFF
--- a/apps/docs/docs/guides/swift.md
+++ b/apps/docs/docs/guides/swift.md
@@ -37,6 +37,7 @@ SwiftPM resolves dependencies on the first `swift build`, and there's no
 | `.swiftlint.yml` | Lint *and* format config |
 | `.periphery.yml` | Dead-code scan config (`retain_public: true`) |
 | `.gitignore` | `.build`, `DerivedData`, `xcuserdata` and friends |
+| `.githooks/pre-commit` + `pre-push` | Node-free git hooks (SwiftLint, `swift build`/`test`) |
 | `.editorconfig` | Shared baseline plus a `[*.swift]` 4-space override |
 | `.github/workflows/ci.yml` | Swift CI on macOS runners |
 | `.github/workflows/codeql.yml` | CodeQL with `language: swift` |
@@ -91,7 +92,7 @@ not having. Concretely:
 | Lint + format | Biome or ESLint + Prettier | SwiftLint (both jobs) |
 | Dead code | knip | Periphery |
 | Install step | `pnpm install` | none — SwiftPM resolves on build |
-| Git hooks | Husky + lint-staged | none (npm packages) |
+| Git hooks | Husky + lint-staged (`.husky/`) | committed `.githooks/` + `core.hooksPath` |
 | Release | semantic-release → npm | git tags → SwiftPM |
 | CI runner | `ubuntu-latest` | `macos-latest` (Xcode) |
 | CodeQL | `javascript-typescript` | `swift` |
@@ -132,21 +133,21 @@ scaffolder and would overwrite your manifest. Use `doctor` and `fix` instead:
 npx @rtorcato/repo-tooling doctor              # audit
 npx @rtorcato/repo-tooling fix swiftlint       # .swiftlint.yml
 npx @rtorcato/repo-tooling fix periphery       # .periphery.yml
-npx @rtorcato/repo-tooling fix swift-gitignore # append build artefacts
-npx @rtorcato/repo-tooling fix swift-ci        # .github/workflows/ci.yml
-npx @rtorcato/repo-tooling fix swift-codeql    # .github/workflows/codeql.yml
-npx @rtorcato/repo-tooling fix swift-gitlab-ci # .gitlab-ci.yml
+npx @rtorcato/repo-tooling fix swift-gitignore  # append build artefacts
+npx @rtorcato/repo-tooling fix swift-git-hooks  # .githooks/ + core.hooksPath
+npx @rtorcato/repo-tooling fix swift-ci         # .github/workflows/ci.yml
+npx @rtorcato/repo-tooling fix swift-codeql     # .github/workflows/codeql.yml
+npx @rtorcato/repo-tooling fix swift-gitlab-ci  # .gitlab-ci.yml
 ```
 
 `doctor` detects Swift from `Package.swift` and runs the language-agnostic
-checks (CI, CodeQL, Dependabot, GitHub repo settings) plus the Swift ones. There
-is deliberately no fixer for `Package.swift` — rewriting someone's manifest isn't
-safe, so `doctor` reports and you edit.
+checks (git hooks, commit linting, README badges, CI, CodeQL, Dependabot, GitHub
+repo settings) plus the Swift ones. There is deliberately no fixer for
+`Package.swift` — rewriting someone's manifest isn't safe, so `doctor` reports
+and you edit.
 
 :::note Not covered yet
-`doctor` reports the language-agnostic findings (Dependabot, CODEOWNERS,
-community health) on a Swift repo, but `fix` reports them as `unsupported` —
-those fixers still live in the JS module. The generated `dependabot.yml` also
-uses `package-ecosystem: npm` where a Swift repo wants `swift`. Both are tracked
-in [#303](https://github.com/rtorcato/repo-tooling/issues/303).
+The `README badges` check runs on a Swift repo but has no fixer — `fix badges`
+derives every badge URL from a package.json `name` + `repository`, which a
+SwiftPM repo hasn't got. `doctor` reports; you add the badges by hand.
 :::

--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -19,8 +19,37 @@ The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-
 | SwiftLint | `missing` | `swiftlint` |
 | Periphery | `optional-missing` | `periphery` |
 | Swift `.gitignore` | `missing` | `swift-gitignore` |
+| Git hooks | `optional-missing` | `swift-git-hooks` |
+| Pre-push hook | `optional-missing` | `swift-git-hooks` |
 
 `Package.swift` is checked for two things SwiftPM will not infer: a `// swift-tools-version:` comment (without it the manifest doesn't parse) and an explicit `platforms:` clause (without it SwiftPM assumes its oldest supported deployment target, which rejects modern APIs at build time). There's no fixer — rewriting someone's manifest isn't safe, so `doctor` reports and you edit.
+
+`Git hooks` and `Pre-push hook` are language-agnostic checks (they run on a JS repo too, against `.husky/`); the Swift module only supplies the shape — `.githooks/` and `swift test`.
+
+## Git hooks
+
+Husky is an npm package, so a SwiftPM repo can't use it without dragging node into a toolchain that otherwise has none. The node-free equivalent is a committed hooks directory:
+
+```bash
+npx @rtorcato/repo-tooling fix swift-git-hooks
+```
+
+That writes two executable hooks and points git at them:
+
+| Hook | Runs |
+|---|---|
+| `.githooks/pre-commit` | `swiftlint --fix` then `swiftlint lint` |
+| `.githooks/pre-push` | `swift build`, `swift test`, `swiftlint lint --strict` — the same gate as CI |
+
+The hooks run the tools directly rather than through a `verify` indirection. SwiftPM has no scripts field, and a `Makefile` target would be a third place to keep the CI commands in sync (they already live in `.github/workflows/ci.yml` and `.swiftlint.yml`).
+
+`core.hooksPath` is per-clone local git config, not a committed file, so `doctor` never reports its absence as drift — a fresh CI checkout isn't broken. Each clone needs it once:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+There's no `commit-msg` hook: commitlint is an npm package and needs node on `PATH`. The `Commitlint` check still runs (Conventional Commits is language-agnostic) and stays `optional-missing` on a Swift repo unless you opt in.
 
 ## Configs
 
@@ -127,5 +156,6 @@ GitLab runs Swift in the official Linux image (`swift:6.0`), which has no Xcode 
 
 ## What isn't covered yet
 
-- **Language-agnostic fixers.** `doctor` reports base findings (Dependabot, CODEOWNERS, community health) on a Swift repo, but `fix` reports them as `unsupported` — those fixers still live in the JS module and haven't been split out. Tracked in [#303](https://github.com/rtorcato/repo-tooling/issues/303).
-- **Dependabot.** The generated config uses `package-ecosystem: npm`; a Swift repo wants `swift`. Part of #303.
+- **README badges.** The `README badges` check runs on a Swift repo, but there's no fixer: `fix badges` derives every badge URL from a package.json `name` + `repository`, which a SwiftPM repo hasn't got. `doctor` reports; you add the badges by hand.
+- **Release automation.** SwiftPM consumes git tags, so there's no `semantic-release` equivalent wired up. Tracked in [#310](https://github.com/rtorcato/repo-tooling/issues/310).
+- **DocC, swift-format and test configuration.** Tracked in [#311](https://github.com/rtorcato/repo-tooling/issues/311).

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fs from 'fs-extra'
+import { BADGE_START, hasPublicOnlyBadges } from '../cli/generators/badges.js'
 import type { CheckResult } from './types.js'
 
 /**
@@ -296,6 +297,169 @@ export async function checkAiSetup(dir: string): Promise<CheckResult> {
 		detail: 'no AI agent files (AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill)',
 		hint: 'Run `npx @rtorcato/repo-tooling fix ai` to scaffold agent rules for every AI tool',
 	}
+}
+
+/**
+ * Conventional Commits is a repo convention, not a JavaScript one — the config
+ * file is the same in any repo that has node available to run commitlint, so
+ * the spec lives here rather than in the JS module's FILE_CHECKS (#309).
+ */
+export const COMMITLINT_FILE_CHECK: FileCheck = {
+	check: 'Commitlint',
+	candidates: ['commitlint.config.js', 'commitlint.config.mjs', 'commitlint.config.cjs'],
+	expected: 'exports "@rtorcato/repo-tooling/commitlint/config"',
+	matcher: /@rtorcato\/(?:js|repo)-tooling\/commitlint\/config/,
+	optional: true,
+}
+
+/**
+ * How one language wires git hooks (#309). Hooks and a pre-push gate are repo
+ * concerns — the *evidence* differs per language, the requirement doesn't — so
+ * the check bodies live here and each module supplies the shape.
+ */
+export interface GitHooksProfile {
+	/** Committed hooks directory this language's tooling installs into. */
+	dir: string
+	/**
+	 * Committed wiring that makes git run the hooks on a fresh clone, or null
+	 * when the language has none. Swift points git at `.githooks` with
+	 * `core.hooksPath` — per-clone local config, not repo drift — so it passes
+	 * null rather than making doctor fail CI on an unconfigured checkout.
+	 */
+	install: { present: boolean; label: string } | null
+	/** The gate a pre-push hook must run — and what the check greps for. */
+	verifyCommand: string
+	/** `fix` target that scaffolds/aligns the hooks. */
+	fixTarget: string
+}
+
+/**
+ * True when a shell hook has an uncommented line matching `pattern`. A
+ * commented-out line (e.g. `# pnpm verify`) doesn't count — the command never
+ * runs, so it isn't real wiring.
+ */
+export function hookHasUncommented(contents: string, pattern: RegExp): boolean {
+	return contents.split('\n').some((line) => {
+		const trimmed = line.trim()
+		return trimmed.length > 0 && !trimmed.startsWith('#') && pattern.test(trimmed)
+	})
+}
+
+/** `swift test` → /\bswift\s+test\b/, so extra whitespace in a hook still matches. */
+function commandMatcher(command: string): RegExp {
+	const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+')
+	return new RegExp(`\\b${escaped}\\b`)
+}
+
+export async function checkGitHooks(dir: string, p: GitHooksProfile): Promise<CheckResult> {
+	const check = 'Git hooks'
+	const hint = `Run \`npx @rtorcato/repo-tooling fix ${p.fixTarget}\` to enable git hooks`
+	const hooksDir = await fs.pathExists(path.join(dir, p.dir))
+	// With no committed install signal, the hooks directory itself is the whole
+	// answer — there's no second half that can drift out of sync with it.
+	const installed = p.install === null ? hooksDir : p.install.present
+
+	if (hooksDir && installed) {
+		return {
+			check,
+			status: 'ok',
+			detail: p.install ? `${p.dir}/ and ${p.install.label} configured` : `${p.dir}/ found`,
+		}
+	}
+	if (hooksDir || installed) {
+		return {
+			check,
+			status: 'drift',
+			detail: hooksDir
+				? `${p.dir}/ exists but no ${p.install?.label}`
+				: `${p.install?.label} set but no ${p.dir}/ directory`,
+			hint: `${hint} (scaffolds both halves)`,
+		}
+	}
+	return { check, status: 'optional-missing', detail: 'git hooks not configured', hint }
+}
+
+/**
+ * The pre-push gate. Only asserts that the hook runs the language's verify
+ * command — whether that command itself is well-formed is the language module's
+ * business (JS keeps a `verify script` check for exactly that).
+ */
+export async function checkPrePushHook(dir: string, p: GitHooksProfile): Promise<CheckResult> {
+	const check = 'Pre-push hook'
+	if (!(await fs.pathExists(path.join(dir, p.dir)))) {
+		return {
+			check,
+			status: 'optional-missing',
+			detail: 'git hooks not configured',
+			hint: `Run \`npx @rtorcato/repo-tooling fix ${p.fixTarget}\` to enable git hooks (includes pre-push)`,
+		}
+	}
+	const hookPath = path.join(dir, p.dir, 'pre-push')
+	if (!(await fs.pathExists(hookPath))) {
+		return {
+			check,
+			status: 'optional-missing',
+			detail: `no ${p.dir}/pre-push`,
+			hint: `Run \`npx @rtorcato/repo-tooling fix ${p.fixTarget}\` to scaffold a pre-push hook that runs \`${p.verifyCommand}\``,
+		}
+	}
+	const contents = await fs.readFile(hookPath, 'utf-8')
+	if (hookHasUncommented(contents, commandMatcher(p.verifyCommand))) {
+		return { check, status: 'ok', detail: `${p.dir}/pre-push runs \`${p.verifyCommand}\`` }
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: `${p.dir}/pre-push exists but does not run \`${p.verifyCommand}\``,
+		hint: `Run \`npx @rtorcato/repo-tooling fix ${p.fixTarget}\` to align the hook with \`${p.verifyCommand}\``,
+	}
+}
+
+/**
+ * Who the README's badges are for. The language module decides: a private npm
+ * package and a SwiftPM library disagree on whether npm/coverage badges would
+ * 404, but "does the README carry status badges" is the same question either way.
+ */
+export type BadgeAudience = 'public' | 'private' | 'not-applicable'
+
+export async function checkReadmeBadges(
+	dir: string,
+	audience: BadgeAudience,
+	/** `fix` target that rebuilds the badge block, or null when the language has none. */
+	fixTarget: string | null
+): Promise<CheckResult> {
+	const check = 'README badges'
+	const hint = fixTarget
+		? `Run \`npx @rtorcato/repo-tooling fix ${fixTarget}\` to add CI/npm/coverage/license badges`
+		: 'Add CI and license badges to README.md'
+	const readmePath = path.join(dir, 'README.md')
+	const readme = (await fs.pathExists(readmePath)) ? await fs.readFile(readmePath, 'utf8') : ''
+
+	if (audience === 'private') {
+		// Only a problem if a private/app repo carries badges that would 404.
+		if (readme && hasPublicOnlyBadges(readme)) {
+			return {
+				check,
+				status: 'drift',
+				detail: 'README has npm/coverage badges but the package is private (they 404)',
+				hint: fixTarget
+					? `Run \`npx @rtorcato/repo-tooling fix ${fixTarget}\` to rebuild badges for a private repo`
+					: 'Remove the npm/coverage badges — they 404 for a private package',
+			}
+		}
+		return { check, status: 'ok', detail: 'not applicable (private package)' }
+	}
+	if (audience === 'not-applicable') {
+		return { check, status: 'ok', detail: 'not applicable (no published exports)' }
+	}
+
+	const hasBadges =
+		readme.includes(BADGE_START) ||
+		/img\.shields\.io|badge\.svg|badge\.fury\.io|codecov\.io/.test(readme)
+	if (hasBadges) {
+		return { check, status: 'ok', detail: 'README carries status badges' }
+	}
+	return { check, status: 'optional-missing', detail: 'no status badges in README', hint }
 }
 
 export async function checkGitLabCI(dir: string): Promise<CheckResult> {

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -13,6 +13,7 @@
  */
 import { installAgentRules, installAiSetup } from '../cli/generators/agent-rules.js'
 import { generateCommunityHealth } from '../cli/generators/community-health.js'
+import { generateCommitlintConfig } from '../cli/generators/git.js'
 import { generateCodeowners, generateEditorConfig } from '../cli/generators/misc.js'
 import {
 	generateCodeQLWorkflow,
@@ -71,6 +72,20 @@ export const BASE_FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			await generateEditorConfig(targetDir)
 			return { filesWritten: ['.editorconfig'] }
+		},
+	},
+	{
+		target: 'commitlint',
+		description: 'Scaffold commitlint.config.mjs exporting the preset',
+		// Conventional Commits is a repo convention, not a JS one (#309) — the
+		// config is identical in any repo. Running commitlint still needs node on
+		// PATH, which is why the Swift hooks don't wire a commit-msg hook.
+		appliesTo: ['Commitlint'],
+		outputs: ['commitlint.config.mjs'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			await generateCommitlintConfig(targetDir)
+			return { filesWritten: ['commitlint.config.mjs'] }
 		},
 	},
 	{

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,12 +2,13 @@ import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import { resolveLanguageModule } from '../../languages/registry.js'
-import { runSwiftChecks } from '../../languages/swift/checks.js'
+import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../languages/swift/checks.js'
 import { detectLanguage } from '../utils/detect-language.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
 import {
+	type BadgeAudience,
 	checkAiSetup,
 	checkCodeowners,
 	checkCodeQL,
@@ -16,8 +17,13 @@ import {
 	checkDependabot,
 	checkEditorConfig,
 	checkFile,
+	checkGitHooks,
 	checkGitHubActions,
 	checkGitLabCI,
+	checkPrePushHook,
+	checkReadmeBadges,
+	COMMITLINT_FILE_CHECK,
+	type GitHooksProfile,
 } from '../../base/checks.js'
 import type { CheckResult, CheckStatus } from '../../base/types.js'
 import {
@@ -25,15 +31,12 @@ import {
 	checkAreTheTypesWrong,
 	checkDocsSite,
 	checkEnginesNode,
-	checkHusky,
-	checkHuskyPrePush,
 	checkKnip,
 	checkLintStaged,
 	checkNodeVersionConsistency,
 	checkNodeVersionPin,
 	checkPackageJson,
 	checkPublint,
-	checkReadmeBadges,
 	checkSemanticRelease,
 	checkSizeLimit,
 	checkTailwind,
@@ -45,6 +48,8 @@ import {
 	evaluateNodeVersion,
 	FILE_CHECKS,
 	findDocsAppDir,
+	jsBadgeAudience,
+	jsGitHooksProfile,
 	type Pkg,
 	readPackageJson,
 } from '../../languages/js/checks.js'
@@ -176,13 +181,34 @@ function demoteDeclined(results: CheckResult[], lock: Lockfile | null): CheckRes
 	})
 }
 
-// The language-agnostic checks (src/base): repo hygiene, CI, security, and
-// GitHub repo-settings that apply to any repo regardless of language. Run for
-// every project; a supported language module layers its own checks on top.
-async function runBaseChecks(dir: string, lock: Lockfile | null): Promise<CheckResult[]> {
+/**
+ * The per-language inputs the base suite needs. Git hooks, commit linting and
+ * README badges are repo concerns whose *evidence* is language-shaped (#309), so
+ * the module hands the shape in rather than forking the check.
+ */
+interface BaseCheckOptions {
+	/** Null for a language whose hook convention isn't encoded yet (Python/Perl). */
+	hooks: GitHooksProfile | null
+	badges: { audience: BadgeAudience; fixTarget: string | null }
+}
+
+// The language-agnostic checks (src/base): repo hygiene, git hooks, CI,
+// security, and GitHub repo-settings that apply to any repo regardless of
+// language. Declared once and run for every project — a language module layers
+// its own checks on top rather than re-listing these.
+async function runBaseChecks(
+	dir: string,
+	lock: Lockfile | null,
+	opts: BaseCheckOptions
+): Promise<CheckResult[]> {
 	const results: CheckResult[] = []
 	results.push(checkLockfile(lock))
 	results.push(await checkEditorConfig(dir))
+	results.push(await checkFile(dir, COMMITLINT_FILE_CHECK))
+	if (opts.hooks) {
+		results.push(await checkGitHooks(dir, opts.hooks))
+		results.push(await checkPrePushHook(dir, opts.hooks))
+	}
 	results.push(await checkGitHubActions(dir))
 	results.push(await checkDependabot(dir))
 	results.push(await checkCodeQL(dir))
@@ -193,6 +219,7 @@ async function runBaseChecks(dir: string, lock: Lockfile | null): Promise<CheckR
 	results.push(await checkCodeowners(dir))
 	results.push(await checkCommunityHealth(dir))
 	results.push(await checkAiSetup(dir))
+	results.push(await checkReadmeBadges(dir, opts.badges.audience, opts.badges.fixTarget))
 	results.push(await checkCoverageUpload(dir))
 	return results
 }
@@ -217,7 +244,13 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				status: 'ok',
 				detail: `detected ${languageModule.label} — running language-agnostic checks; ${languageModule.label}-specific checks land with its module (#139)`,
 			},
-			...(await runBaseChecks(targetDir, lock)),
+			// hooks: null — nothing here encodes a Python/Perl hook convention yet,
+			// and guessing one would nag every repo with a fix target that doesn't
+			// exist. #289/#290 fill it in.
+			...(await runBaseChecks(targetDir, lock, {
+				hooks: null,
+				badges: { audience: 'public', fixTarget: null },
+			})),
 		]
 		return demoteDeclined(results, lock)
 	}
@@ -231,54 +264,43 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				status: 'ok',
 				detail: 'detected Swift (Package.swift)',
 			},
-			...(await runBaseChecks(targetDir, lock)),
+			...(await runBaseChecks(targetDir, lock, {
+				hooks: SWIFT_GIT_HOOKS,
+				// A SwiftPM package is distributed as public source over git tags, so
+				// badges always apply. No fixer: `fix badges` derives the block from
+				// package.json name/repository, which a Swift repo hasn't got.
+				badges: { audience: 'public', fixTarget: null },
+			})),
 			...(await runSwiftChecks(targetDir)),
 		]
 		return demoteDeclined(results, lock)
 	}
 
-	// JS suite. Still inline rather than behind a module.runChecks() seam: Swift
-	// above is a base+module concatenation, JS interleaves its own checks with
-	// the base ones in a specific display order, so there's no shared shape to
-	// factor out yet. Revisit when Perl/Python land (#289/#290).
+	// JS suite: the module's own checks, then the shared base ones. Only the
+	// JS-shaped checks are listed here — re-listing the base suite is what made
+	// any new base check silently skip JS repos (#309).
 	const pkg = await readPackageJson(targetDir)
 	const results: CheckResult[] = []
 
 	results.push(evaluateNodeVersion(process.version))
 	results.push(checkPackageJson(pkg))
-	results.push(checkLockfile(lock))
 	results.push(checkEnginesNode(pkg))
-	results.push(await checkEditorConfig(targetDir))
 	results.push(await checkVscodeExtensions(targetDir))
 	results.push(await checkNodeVersionPin(targetDir))
 	results.push(await checkNodeVersionConsistency(targetDir, pkg))
 	for (const spec of FILE_CHECKS) {
 		results.push(await checkFile(targetDir, spec))
 	}
-	results.push(await checkHusky(targetDir, pkg))
 	results.push(await checkLintStaged(targetDir, pkg))
 	results.push(await checkVerifyScript(targetDir, pkg))
-	results.push(await checkHuskyPrePush(targetDir, pkg))
 	results.push(await checkSemanticRelease(targetDir, pkg))
 	results.push(await checkKnip(targetDir, pkg))
 	results.push(await checkSizeLimit(targetDir, pkg))
-	results.push(await checkGitHubActions(targetDir))
 	results.push(await checkReleaseToken(targetDir))
 	results.push(await checkNpmOidcPublish(targetDir, pkg))
-	results.push(await checkDependabot(targetDir))
-	results.push(await checkCodeQL(targetDir))
-	// GitHub repo-settings drift (branch protection, merge settings, workflow
-	// permissions). Read-only; self-skips as `ok` outside a live GitHub repo.
-	results.push(...(await checkGitHubSettings(targetDir)))
-	results.push(await checkGitLabCI(targetDir))
-	results.push(await checkCodeowners(targetDir))
-	results.push(await checkCommunityHealth(targetDir))
-	results.push(await checkAiSetup(targetDir))
 	results.push(await checkTypedoc(targetDir, pkg))
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkPublint(targetDir, pkg))
-	results.push(await checkReadmeBadges(targetDir, pkg))
-	results.push(await checkCoverageUpload(targetDir))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 	// Turborepo is monorepo-only — only surface the check when a workspace exists.
 	if (await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))) {
@@ -293,6 +315,13 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	if ('tailwindcss' in allDeps(pkg)) {
 		results.push(await checkTailwind(targetDir, pkg))
 	}
+
+	results.push(
+		...(await runBaseChecks(targetDir, lock, {
+			hooks: jsGitHooksProfile(pkg),
+			badges: { audience: jsBadgeAudience(pkg), fixTarget: 'badges' },
+		}))
+	)
 
 	return demoteDeclined(results, lock)
 }
@@ -319,14 +348,14 @@ function statusLabel(status: CheckStatus): string {
 
 const MAX_NEXT_STEP_SUGGESTIONS = 8
 
-export function nextStepSuggestions(results: CheckResult[]): string[] {
+export function nextStepSuggestions(results: CheckResult[], language?: string): string[] {
 	const fixable = results.filter(
 		(r) => r.status === 'drift' || r.status === 'missing' || r.status === 'optional-missing'
 	)
 	const lines: string[] = []
 	let overflow = 0
 	for (const r of fixable) {
-		const target = getFixTargetForCheck(r.check)
+		const target = getFixTargetForCheck(r.check, language)
 		if (!target) continue
 		if (lines.length >= MAX_NEXT_STEP_SUGGESTIONS) {
 			overflow++
@@ -379,7 +408,7 @@ export async function doctorCommand(options: DoctorOptions = {}) {
 		console.log(
 			`  Summary: ${chalk.green(`${summary.ok} ok`)}, ${chalk.yellow(`${summary.drift} drift`)}, ${chalk.red(`${summary.missing} missing`)}, ${chalk.gray(`${summary.optionalMissing} not configured`)}\n`
 		)
-		const suggestions = nextStepSuggestions(results)
+		const suggestions = nextStepSuggestions(results, await detectLanguage(dir))
 		if (suggestions.length > 0) {
 			console.log(chalk.bold('  Next steps:'))
 			for (const s of suggestions) {

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -14,9 +14,9 @@ export const FIX_TARGETS: Record<string, string> = {
 	Prettier: 'prettier',
 	Vitest: 'vitest',
 	Commitlint: 'commitlint',
-	Husky: 'husky',
+	'Git hooks': 'husky',
 	'lint-staged': 'husky',
-	'Husky pre-push': 'husky',
+	'Pre-push hook': 'husky',
 	'verify script': 'verify',
 	'semantic-release': 'semantic-release',
 	knip: 'knip',
@@ -46,7 +46,26 @@ export const FIX_TARGETS: Record<string, string> = {
 	'AI setup': 'ai',
 }
 
-export function getFixTargetForCheck(checkName: string): string | null {
+/**
+ * Where the Swift module's fixers shadow (or extend) the JS-named defaults
+ * above. Without this, `doctor` on a Swift repo suggests `fix husky` and
+ * `fix github-actions` — targets its fixer set doesn't contain.
+ */
+const SWIFT_FIX_TARGETS: Record<string, string> = {
+	'Git hooks': 'swift-git-hooks',
+	'Pre-push hook': 'swift-git-hooks',
+	'GitHub Actions': 'swift-ci',
+	'GitLab CI': 'swift-gitlab-ci',
+	lockfile: 'swift-lockfile',
+	SwiftLint: 'swiftlint',
+	Periphery: 'periphery',
+	'Swift .gitignore': 'swift-gitignore',
+}
+
+export function getFixTargetForCheck(checkName: string, language?: string): string | null {
+	if (language === 'swift' && SWIFT_FIX_TARGETS[checkName]) {
+		return SWIFT_FIX_TARGETS[checkName]
+	}
 	return FIX_TARGETS[checkName] ?? null
 }
 
@@ -72,9 +91,9 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 			return c.testing?.framework !== 'vitest'
 		case 'Commitlint':
 			return c.commitLint === false
-		case 'Husky':
+		case 'Git hooks':
 		case 'lint-staged':
-		case 'Husky pre-push':
+		case 'Pre-push hook':
 			return c.gitHooks === false
 		case 'verify script':
 			// Verify is derived from other tools; only "declined" if none of typecheck/lint/test are enabled.
@@ -144,6 +163,7 @@ export function lockfilePatchForTarget(
 		case 'commitlint':
 			return c.commitLint ? null : { commitLint: true }
 		case 'husky':
+		case 'swift-git-hooks':
 			return c.gitHooks ? null : { gitHooks: true }
 		case 'semantic-release':
 			return c.semanticRelease ? null : { semanticRelease: true }

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -95,9 +95,11 @@ export function buildPresetConfig(name: PresetName, projectName: string): Projec
 				linting: { tool: 'none' },
 				formatting: { tool: 'none' },
 				testing: { framework: 'none' },
-				// Husky and commitlint are npm packages; a Swift repo has no
-				// node_modules to install them into.
-				gitHooks: false,
+				// Husky is an npm package, but git hooks aren't (#309): the Swift path
+				// commits `.githooks/` and points git at it with `core.hooksPath`.
+				gitHooks: true,
+				// commitlint *is* an npm package and needs node on PATH to run, so
+				// the Swift hooks deliberately wire no commit-msg hook.
 				commitLint: false,
 				// semantic-release publishes to npm. SwiftPM consumes git tags.
 				semanticRelease: false,

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -1,8 +1,8 @@
 import path from 'node:path'
 import fs from 'fs-extra'
-import type { FileCheck } from '../../base/checks.js'
+import type { BadgeAudience, FileCheck, GitHooksProfile } from '../../base/checks.js'
+import { hookHasUncommented } from '../../base/checks.js'
 import type { CheckResult } from '../../base/types.js'
-import { BADGE_START, hasPublicOnlyBadges } from '../../cli/generators/badges.js'
 
 const PACKAGE = '@rtorcato/repo-tooling'
 
@@ -88,13 +88,6 @@ export const FILE_CHECKS: FileCheck[] = [
 		candidates: ['vitest.config.ts', 'vitest.config.js', 'vitest.config.mjs'],
 		expected: `imports "${PACKAGE}/vitest/config"`,
 		matcher: /@rtorcato\/(?:js|repo)-tooling\/vitest\/config/,
-		optional: true,
-	},
-	{
-		check: 'Commitlint',
-		candidates: ['commitlint.config.js', 'commitlint.config.mjs', 'commitlint.config.cjs'],
-		expected: `exports "${PACKAGE}/commitlint/config"`,
-		matcher: /@rtorcato\/(?:js|repo)-tooling\/commitlint\/config/,
 		optional: true,
 	},
 	{
@@ -389,92 +382,21 @@ export async function checkNodeVersionConsistency(
 	}
 }
 
-export async function checkHusky(dir: string, pkg: Pkg | null): Promise<CheckResult> {
-	const huskyDir = await fs.pathExists(path.join(dir, '.husky'))
-	const scripts = (pkg?.scripts as Record<string, string> | undefined) ?? {}
-	const prepareScript = scripts.prepare ?? ''
-	const hasHookScript = /\bhusky\b/.test(prepareScript)
-
-	if (huskyDir && hasHookScript) {
-		return {
-			check: 'Husky',
-			status: 'ok',
-			detail: '.husky/ directory and prepare script configured',
-		}
-	}
-	if (huskyDir || hasHookScript) {
-		return {
-			check: 'Husky',
-			status: 'drift',
-			detail: huskyDir
-				? '.husky/ exists but no `prepare: husky` script'
-				: '`prepare: husky` set but no .husky/ directory',
-			hint: 'Run `pnpm exec husky init` to scaffold both halves',
-		}
-	}
-	return {
-		check: 'Husky',
-		status: 'optional-missing',
-		detail: 'husky not configured',
-		hint: 'Run `pnpm add -D husky && pnpm exec husky init` to enable git hooks',
-	}
-}
-
 /**
- * True when a shell hook has an uncommented line matching `pattern`. A
- * commented-out line (e.g. `# pnpm verify`) doesn't count — the command never
- * runs, so it isn't real wiring.
+ * The JS shape of the base `Git hooks` / `Pre-push hook` checks (#309): husky,
+ * installed by the `prepare` script so a fresh clone wires the hooks on
+ * `pnpm install`.
  */
-function hookHasUncommented(contents: string, pattern: RegExp): boolean {
-	return contents.split('\n').some((line) => {
-		const trimmed = line.trim()
-		return trimmed.length > 0 && !trimmed.startsWith('#') && pattern.test(trimmed)
-	})
-}
-
-export async function checkHuskyPrePush(dir: string, pkg: Pkg | null): Promise<CheckResult> {
-	const huskyDir = await fs.pathExists(path.join(dir, '.husky'))
-	if (!huskyDir) {
-		// If husky isn't in use, pre-push is not relevant
-		return {
-			check: 'Husky pre-push',
-			status: 'optional-missing',
-			detail: 'husky not configured',
-			hint: 'Run `npx @rtorcato/repo-tooling fix husky` to enable git hooks (includes pre-push)',
-		}
-	}
-	const hookPath = path.join(dir, '.husky', 'pre-push')
-	if (!(await fs.pathExists(hookPath))) {
-		return {
-			check: 'Husky pre-push',
-			status: 'optional-missing',
-			detail: 'no .husky/pre-push',
-			hint: 'Run `npx @rtorcato/repo-tooling fix husky` to scaffold a pre-push hook that runs `pnpm verify`',
-		}
-	}
-	const contents = await fs.readFile(hookPath, 'utf-8')
-	if (hookHasUncommented(contents, /\bpnpm\s+verify\b/)) {
-		return {
-			check: 'Husky pre-push',
-			status: 'ok',
-			detail: '.husky/pre-push runs `pnpm verify`',
-		}
-	}
-	// Pre-push exists but doesn't call pnpm verify
+export function jsGitHooksProfile(pkg: Pkg | null): GitHooksProfile {
 	const scripts = (pkg?.scripts as Record<string, string> | undefined) ?? {}
-	if (!scripts.verify) {
-		return {
-			check: 'Husky pre-push',
-			status: 'drift',
-			detail: '.husky/pre-push exists but no `verify` script in package.json',
-			hint: 'Run `npx @rtorcato/repo-tooling fix verify` to add a verify script, then `fix husky` to align the hook',
-		}
-	}
 	return {
-		check: 'Husky pre-push',
-		status: 'drift',
-		detail: '.husky/pre-push exists but does not call `pnpm verify`',
-		hint: 'Run `npx @rtorcato/repo-tooling fix husky` to align the hook with `pnpm verify`',
+		dir: '.husky',
+		install: {
+			present: /\bhusky\b/.test(scripts.prepare ?? ''),
+			label: '`prepare: husky` script',
+		},
+		verifyCommand: 'pnpm verify',
+		fixTarget: 'husky',
 	}
 }
 
@@ -924,40 +846,10 @@ export async function checkPublint(_dir: string, pkg: Pkg | null): Promise<Check
 	}
 }
 
-export async function checkReadmeBadges(dir: string, pkg: Pkg | null): Promise<CheckResult> {
-	const readmePath = path.join(dir, 'README.md')
-	const readme = (await fs.pathExists(readmePath)) ? await fs.readFile(readmePath, 'utf8') : ''
-	const isPrivate = !pkg || pkg.private === true
-
-	if (isPrivate) {
-		// Only a problem if a private/app repo carries badges that would 404.
-		if (readme && hasPublicOnlyBadges(readme)) {
-			return {
-				check: 'README badges',
-				status: 'drift',
-				detail: 'README has npm/coverage badges but the package is private (they 404)',
-				hint: 'Run `npx @rtorcato/repo-tooling fix badges` to rebuild badges for a private repo',
-			}
-		}
-		return { check: 'README badges', status: 'ok', detail: 'not applicable (private package)' }
-	}
-
-	if (!isPublishableLibrary(pkg)) {
-		return { check: 'README badges', status: 'ok', detail: 'not applicable (no published exports)' }
-	}
-
-	const hasBadges =
-		readme.includes(BADGE_START) ||
-		/img\.shields\.io|badge\.svg|badge\.fury\.io|codecov\.io/.test(readme)
-	if (hasBadges) {
-		return { check: 'README badges', status: 'ok', detail: 'README carries status badges' }
-	}
-	return {
-		check: 'README badges',
-		status: 'optional-missing',
-		detail: 'no status badges in README',
-		hint: 'Run `npx @rtorcato/repo-tooling fix badges` to add CI/npm/coverage/license badges',
-	}
+/** Who this package's README badges are for — feeds the base badge check (#309). */
+export function jsBadgeAudience(pkg: Pkg | null): BadgeAudience {
+	if (!pkg || pkg.private === true) return 'private'
+	return isPublishableLibrary(pkg) ? 'public' : 'not-applicable'
 }
 
 export async function checkTreeshakeSetup(dir: string, pkg: Pkg | null): Promise<CheckResult> {

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -8,11 +8,7 @@ import {
 	generateRollupConfig,
 	generateSemanticReleaseConfig,
 } from '../../cli/generators/build.js'
-import {
-	generateCommitlintConfig,
-	generateHuskyConfig,
-	generatePrePushHook,
-} from '../../cli/generators/git.js'
+import { generateHuskyConfig, generatePrePushHook } from '../../cli/generators/git.js'
 import { generateGitHubActions } from '../../cli/generators/github-actions.js'
 import { generateGitLabCI } from '../../cli/generators/gitlab-ci.js'
 import { GH_WORKFLOWS, generateGhWorkflow } from '../../cli/generators/github-workflows.js'
@@ -213,20 +209,9 @@ export const FIXERS: Fixer[] = [
 		},
 	},
 	{
-		target: 'commitlint',
-		description: 'Scaffold commitlint.config.mjs exporting the preset',
-		appliesTo: ['Commitlint'],
-		outputs: ['commitlint.config.mjs'],
-		canFixDrift: true,
-		async run({ targetDir }) {
-			await generateCommitlintConfig(targetDir)
-			return { filesWritten: ['commitlint.config.mjs'] }
-		},
-	},
-	{
 		target: 'husky',
 		description: 'Set up Husky + lint-staged (and a `pnpm verify` pre-push hook)',
-		appliesTo: ['Husky', 'lint-staged', 'Husky pre-push'],
+		appliesTo: ['Git hooks', 'lint-staged', 'Pre-push hook'],
 		outputs: ['.husky/pre-commit', '.husky/pre-push', 'package.json (lint-staged field)'],
 		riskLevel: 'safe-merge',
 		canFixDrift: true,

--- a/src/languages/swift/checks.ts
+++ b/src/languages/swift/checks.ts
@@ -13,8 +13,9 @@
  */
 import path from 'node:path'
 import fs from 'fs-extra'
-import { type FileCheck, checkFile } from '../../base/checks.js'
+import { type FileCheck, type GitHooksProfile, checkFile } from '../../base/checks.js'
 import type { CheckResult } from '../../base/types.js'
+import { SWIFT_HOOKS_DIR } from './git-hooks.js'
 
 const SWIFT_FILE_CHECKS: FileCheck[] = [
 	{
@@ -113,6 +114,19 @@ export async function checkPackageSwift(dir: string): Promise<CheckResult> {
 		status: 'ok',
 		detail: `Package.swift declares tools ${toolsVersion} and explicit platforms`,
 	}
+}
+
+/**
+ * The Swift shape of the base `Git hooks` / `Pre-push hook` checks (#309).
+ * `install` is null because the wiring — `git config core.hooksPath` — is
+ * per-clone local state that nothing commits; flagging its absence would fail
+ * every fresh CI checkout for something that isn't repo drift.
+ */
+export const SWIFT_GIT_HOOKS: GitHooksProfile = {
+	dir: SWIFT_HOOKS_DIR,
+	install: null,
+	verifyCommand: 'swift test',
+	fixTarget: 'swift-git-hooks',
 }
 
 /** The Swift module's suite, layered on top of the base checks by doctor. */

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -2,12 +2,14 @@
  * Swift language module — fixers (#286). One per check in ./checks.ts.
  */
 import path from 'node:path'
+import chalk from 'chalk'
 import fs from 'fs-extra'
 import type { Fixer } from '../../base/fixers.js'
 import { buildPresetConfig } from '../../cli/commands/setup-presets.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
 import { readSwiftPackage, renderSwiftGitLabCI, renderSwiftWorkflow } from './ci.js'
+import { SWIFT_HOOKS_DIR, installSwiftGitHooks } from './git-hooks.js'
 import { ensureSwiftGitignore } from './gitignore.js'
 
 export const SWIFT_FIXERS: Fixer[] = [
@@ -44,6 +46,24 @@ export const SWIFT_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			return { filesWritten: await ensureSwiftGitignore(targetDir) }
+		},
+	},
+	{
+		target: 'swift-git-hooks',
+		description: `Scaffold ${SWIFT_HOOKS_DIR}/pre-commit + pre-push (SwiftLint, swift build/test) and point git at them via core.hooksPath`,
+		appliesTo: ['Git hooks', 'Pre-push hook'],
+		outputs: [`${SWIFT_HOOKS_DIR}/pre-commit`, `${SWIFT_HOOKS_DIR}/pre-push`],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const { filesWritten, hooksPathSet } = await installSwiftGitHooks(targetDir)
+			console.log(
+				hooksPathSet
+					? chalk.dim(`   git config core.hooksPath ${SWIFT_HOOKS_DIR}`)
+					: chalk.yellow(
+							`   run \`git config core.hooksPath ${SWIFT_HOOKS_DIR}\` once per clone — it's local git config, not a committed file`
+						)
+			)
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/languages/swift/git-hooks.ts
+++ b/src/languages/swift/git-hooks.ts
@@ -1,0 +1,73 @@
+/**
+ * Swift git hooks (#309). Husky is an npm package, so a SwiftPM repo can't use
+ * it without dragging node into a toolchain that otherwise has none. The
+ * node-free equivalent is a committed `.githooks/` directory that git is pointed
+ * at with `core.hooksPath`.
+ *
+ * The hooks run the tools directly rather than a `verify` indirection: SwiftPM
+ * has no scripts field, and inventing a Makefile target would be a third place
+ * to keep the CI commands in sync (they already live in .github/workflows/ci.yml
+ * and .swiftlint.yml).
+ */
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import fs from 'fs-extra'
+
+export const SWIFT_HOOKS_DIR = '.githooks'
+
+// SwiftLint's --fix is the formatter (see ./checks.ts), so pre-commit formats
+// then lints. --quiet keeps a clean commit from printing a wall of nothing.
+export const SWIFT_PRE_COMMIT = `#!/bin/sh
+set -e
+swiftlint --fix --quiet
+swiftlint lint --quiet
+`
+
+export const SWIFT_PRE_PUSH = `#!/bin/sh
+set -e
+echo "🔍 Running pre-push verify..."
+swift build
+swift test
+swiftlint lint --strict
+echo "✅ Verify passed — pushing."
+`
+
+/** Best-effort `git config` — a missing git or a non-repo dir is not a failure. */
+function gitConfig(cwd: string, key: string, value: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		execFile('git', ['-C', cwd, 'config', key, value], (err) => resolve(!err))
+	})
+}
+
+/**
+ * Writes both hooks and points git at them. Returns the files written —
+ * `core.hooksPath` is per-clone local config, not a file, so it's reported
+ * separately rather than pretending to be a repo change.
+ */
+export async function installSwiftGitHooks(
+	targetDir: string
+): Promise<{ filesWritten: string[]; hooksPathSet: boolean }> {
+	const hooksDir = path.join(targetDir, SWIFT_HOOKS_DIR)
+	await fs.ensureDir(hooksDir)
+
+	const filesWritten: string[] = []
+	for (const [name, content] of [
+		['pre-commit', SWIFT_PRE_COMMIT],
+		['pre-push', SWIFT_PRE_PUSH],
+	] as const) {
+		const hookPath = path.join(hooksDir, name)
+		await fs.writeFile(hookPath, content)
+		await fs.chmod(hookPath, 0o755)
+		filesWritten.push(`${SWIFT_HOOKS_DIR}/${name}`)
+	}
+
+	// Guard on .git: `fix --diff` shadow-runs fixers in a temp copy that excludes
+	// .git, and that copy can land inside another repo — an unguarded `git config`
+	// there would rewrite the *parent* repo's hooksPath during a mere preview.
+	const isRepo = await fs.pathExists(path.join(targetDir, '.git'))
+	const hooksPathSet = isRepo
+		? await gitConfig(targetDir, 'core.hooksPath', SWIFT_HOOKS_DIR)
+		: false
+
+	return { filesWritten, hooksPathSet }
+}

--- a/src/languages/swift/scaffold.ts
+++ b/src/languages/swift/scaffold.ts
@@ -20,6 +20,7 @@ import { generateCodeQLWorkflow, generateDependabotConfig } from '../../cli/gene
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LANGUAGES } from '../registry.js'
 import { readSwiftPackage, renderSwiftWorkflow } from './ci.js'
+import { SWIFT_HOOKS_DIR, installSwiftGitHooks } from './git-hooks.js'
 import { ensureSwiftGitignore } from './gitignore.js'
 
 /**
@@ -141,6 +142,17 @@ periphery scan         # Report unused declarations
 SwiftLint is the formatter *and* the linter here — SwiftFormat is deliberately
 not part of the standard, because a second formatter fights the first.
 
+### Git hooks
+
+\`.githooks/\` is committed, but git only runs it once each clone points at it:
+
+\`\`\`bash
+git config core.hooksPath .githooks
+\`\`\`
+
+\`pre-commit\` runs \`swiftlint --fix\`; \`pre-push\` runs \`swift build\`,
+\`swift test\` and \`swiftlint lint --strict\` — the same gate as CI.
+
 ## Project Structure
 
 \`\`\`
@@ -148,6 +160,7 @@ ${config.projectName}/
 ├── Sources/${module}/          # Library source
 ├── Tests/${module}Tests/       # XCTest suite
 ├── Package.swift               # SwiftPM manifest
+├── .githooks/                  # pre-commit + pre-push (see Git hooks above)
 ├── .swiftlint.yml              # SwiftLint configuration
 ├── .periphery.yml              # Dead-code scan configuration
 └── README.md
@@ -193,6 +206,9 @@ export function swiftFileList(config: ProjectConfig): string[] {
 		'.editorconfig',
 		'.github/workflows/ci.yml',
 	]
+	if (config.gitHooks) {
+		files.push(`${SWIFT_HOOKS_DIR}/pre-commit`, `${SWIFT_HOOKS_DIR}/pre-push`)
+	}
 	if (config.securityAutomation) {
 		files.push(
 			'.github/dependabot.yml',
@@ -243,6 +259,13 @@ export async function generateSwiftProject(config: ProjectConfig, targetDir: str
 		path.join(workflowsDir, 'ci.yml'),
 		renderSwiftWorkflow(await readSwiftPackage(targetDir))
 	)
+
+	// `core.hooksPath` won't stick here — `setup` scaffolds into a directory that
+	// isn't a git repo yet — so the hooks land as files and the README tells you
+	// the one-line config to run after `git init`.
+	if (config.gitHooks) {
+		await installSwiftGitHooks(targetDir)
+	}
 
 	if (config.securityAutomation) {
 		await generateDependabotConfig(targetDir, LANGUAGES.swift.dependabotEcosystem)

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -20,6 +20,58 @@ async function seedPackageJson(dir: string, withDep = true) {
 	})
 }
 
+// The language-agnostic suite, declared once in doctor's runBaseChecks. Before
+// #309 the JS path re-listed it inline, so anything added to base silently
+// skipped JS repos — and the hook/commit/badge checks lived in the JS module, so
+// a Swift repo never saw them at all.
+const BASE_CHECKS = [
+	'lockfile',
+	'EditorConfig',
+	'Commitlint',
+	'Git hooks',
+	'Pre-push hook',
+	'GitHub Actions',
+	'Dependabot',
+	'CodeQL',
+	'GitLab CI',
+	'CODEOWNERS',
+	'Community health',
+	'AI setup',
+	'README badges',
+	'Coverage upload',
+]
+
+describe('doctor base suite', () => {
+	it('runs every base check for a JS repo and a Swift repo alike', async () => {
+		const jsDir = newTmpDir()
+		await seedPackageJson(jsDir)
+		const swiftDir = newTmpDir()
+		await fs.writeFile(join(swiftDir, 'Package.swift'), '// swift-tools-version: 5.9\n')
+
+		const jsChecks = new Set((await runDoctor(jsDir)).map((r) => r.check))
+		const swiftChecks = new Set((await runDoctor(swiftDir)).map((r) => r.check))
+
+		for (const check of BASE_CHECKS) {
+			expect(jsChecks, `JS: ${check}`).toContain(check)
+			expect(swiftChecks, `Swift: ${check}`).toContain(check)
+		}
+	})
+
+	it('emits each base check exactly once', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const names = (await runDoctor(dir)).map((r) => r.check)
+		const duplicated = names.filter((n, i) => names.indexOf(n) !== i)
+		expect(duplicated).toEqual([])
+	})
+
+	it('suggests the Swift fixer, not the husky one, for a Swift repo', () => {
+		const results = [{ check: 'Git hooks', status: 'optional-missing' as const, detail: '' }]
+		expect(nextStepSuggestions(results, 'swift')[0]).toMatch(/fix swift-git-hooks/)
+		expect(nextStepSuggestions(results, 'js')[0]).toMatch(/fix husky/)
+	})
+})
+
 describe('doctor', () => {
 	it('reports drift when nothing is configured', async () => {
 		const dir = newTmpDir()
@@ -214,16 +266,16 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'Node version consistency')?.status).toBe('ok')
 	})
 
-	it('reports husky drift when .husky/ exists without prepare script', async () => {
+	it('reports git hooks drift when .husky/ exists without prepare script', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.husky'))
 		const results = await runDoctor(dir)
-		const husky = results.find((r) => r.check === 'Husky')
-		expect(husky?.status).toBe('drift')
+		const gitHooks = results.find((r) => r.check === 'Git hooks')
+		expect(gitHooks?.status).toBe('drift')
 	})
 
-	it('reports husky ok when both .husky/ and prepare script exist', async () => {
+	it('reports git hooks ok when both .husky/ and prepare script exist', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
 			name: 'demo',
@@ -232,7 +284,7 @@ describe('doctor extended checks', () => {
 		})
 		await fs.ensureDir(join(dir, '.husky'))
 		const results = await runDoctor(dir)
-		expect(results.find((r) => r.check === 'Husky')?.status).toBe('ok')
+		expect(results.find((r) => r.check === 'Git hooks')?.status).toBe('ok')
 	})
 
 	it('AI setup: optional-missing on a bare project, ok once AGENTS.md has the block', async () => {
@@ -435,16 +487,16 @@ describe('doctor extended checks', () => {
 		expect(verify?.detail).toMatch(/typecheck/)
 	})
 
-	it('reports Husky pre-push ok when the hook calls pnpm verify', async () => {
+	it('reports pre-push hook ok when the hook calls pnpm verify', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.husky'))
 		await fs.writeFile(join(dir, '.husky', 'pre-push'), 'pnpm verify\n')
 		const results = await runDoctor(dir)
-		expect(results.find((r) => r.check === 'Husky pre-push')?.status).toBe('ok')
+		expect(results.find((r) => r.check === 'Pre-push hook')?.status).toBe('ok')
 	})
 
-	it('reports Husky pre-push drift when the hook does not call pnpm verify', async () => {
+	it('reports pre-push hook drift when the hook does not call pnpm verify', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
 			name: 'demo',
@@ -455,12 +507,12 @@ describe('doctor extended checks', () => {
 		await fs.ensureDir(join(dir, '.husky'))
 		await fs.writeFile(join(dir, '.husky', 'pre-push'), 'pnpm test\n')
 		const results = await runDoctor(dir)
-		const prePush = results.find((r) => r.check === 'Husky pre-push')
+		const prePush = results.find((r) => r.check === 'Pre-push hook')
 		expect(prePush?.status).toBe('drift')
 		expect(prePush?.hint).toMatch(/fix husky/)
 	})
 
-	it('reports Husky pre-push drift when the verify call is commented out', async () => {
+	it('reports pre-push hook drift when the verify call is commented out', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
 			name: 'demo',
@@ -471,15 +523,15 @@ describe('doctor extended checks', () => {
 		await fs.ensureDir(join(dir, '.husky'))
 		await fs.writeFile(join(dir, '.husky', 'pre-push'), '#!/usr/bin/env sh\n# pnpm verify\n')
 		const results = await runDoctor(dir)
-		expect(results.find((r) => r.check === 'Husky pre-push')?.status).toBe('drift')
+		expect(results.find((r) => r.check === 'Pre-push hook')?.status).toBe('drift')
 	})
 
-	it('reports Husky pre-push optional-missing when husky is present but the hook is absent', async () => {
+	it('reports pre-push hook optional-missing when husky is present but the hook is absent', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.ensureDir(join(dir, '.husky'))
 		const results = await runDoctor(dir)
-		expect(results.find((r) => r.check === 'Husky pre-push')?.status).toBe('optional-missing')
+		expect(results.find((r) => r.check === 'Pre-push hook')?.status).toBe('optional-missing')
 	})
 
 	it('reports tree-shake check optional-missing on multi-subpath sideEffects-free libraries', async () => {
@@ -762,14 +814,14 @@ describe('doctor + lockfile', () => {
 		expect(results.find((r) => r.check === 'Biome')?.status).toBe('ok')
 	})
 
-	it('demotes Husky, lint-staged, and Husky pre-push when gitHooks=false in lock', async () => {
+	it('demotes git hooks, lint-staged, and pre-push hook when gitHooks=false in lock', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await writeLock(dir, { gitHooks: false, commitLint: false })
 		const results = await runDoctor(dir)
-		expect(results.find((r) => r.check === 'Husky')?.status).toBe('ok')
+		expect(results.find((r) => r.check === 'Git hooks')?.status).toBe('ok')
 		expect(results.find((r) => r.check === 'lint-staged')?.status).toBe('ok')
-		expect(results.find((r) => r.check === 'Husky pre-push')?.status).toBe('ok')
+		expect(results.find((r) => r.check === 'Pre-push hook')?.status).toBe('ok')
 		expect(results.find((r) => r.check === 'Commitlint')?.status).toBe('ok')
 	})
 
@@ -841,7 +893,7 @@ describe('nextStepSuggestions', () => {
 			'Prettier',
 			'Vitest',
 			'Commitlint',
-			'Husky',
+			'Git hooks',
 			'knip',
 			'EditorConfig',
 			'Node version pin',

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -64,9 +64,10 @@ describe('setup-presets', () => {
 		expect(config.projectType).toBe('library')
 		expect(config.typescript.enabled).toBe(false)
 		expect(config.bundler).toBe('none')
-		// Husky/commitlint/semantic-release are all npm packages, and every badge
-		// URL is derived from a package.json this repo doesn't have.
-		expect(config.gitHooks).toBe(false)
+		// commitlint/semantic-release are npm packages, and every badge URL is
+		// derived from a package.json this repo doesn't have. Git hooks are not —
+		// the Swift path commits `.githooks/` and uses `core.hooksPath` (#309).
+		expect(config.gitHooks).toBe(true)
 		expect(config.commitLint).toBe(false)
 		expect(config.semanticRelease).toBe(false)
 		expect(config.badges).toBe(false)

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -57,8 +57,9 @@ describe('swift fixers', () => {
 			.filter((check) => !fixable.has(check))
 		// `language` and `Package.swift` are informational (scaffolding a manifest
 		// is `setup`'s job); `Coverage upload` is a base check only the JS CI
-		// generator satisfies, so Swift has nothing to apply for it.
-		expect(uncovered).toEqual(['language', 'Coverage upload', 'Package.swift'])
+		// generator satisfies; `README badges` needs a package.json name/repository
+		// to build the block from, which a Swift repo hasn't got (#309).
+		expect(uncovered).toEqual(['language', 'README badges', 'Coverage upload', 'Package.swift'])
 	})
 
 	it('swiftlint writes a config the SwiftLint check accepts', async () => {
@@ -74,6 +75,29 @@ describe('swift fixers', () => {
 		const dir = newTmpDir()
 		await fixer('periphery').run(ctx(dir))
 		expect(await fs.readFile(join(dir, '.periphery.yml'), 'utf-8')).toContain('retain_public: true')
+	})
+
+	// #309: the checks moved to src/base, so a Swift repo now gets them — but
+	// husky is an npm package, so the fixer scaffolds plain .githooks instead.
+	it('swift-git-hooks writes hooks the base Git hooks / Pre-push checks accept', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version: 5.9\n')
+		const { filesWritten } = await fixer('swift-git-hooks').run(ctx(dir))
+		expect(filesWritten).toEqual(['.githooks/pre-commit', '.githooks/pre-push'])
+		expect(await fs.readFile(join(dir, '.githooks/pre-push'), 'utf-8')).toContain('swift test')
+		// Executable, or git silently ignores the hook.
+		expect((await fs.stat(join(dir, '.githooks/pre-commit'))).mode & 0o111).toBeTruthy()
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Git hooks')?.status).toBe('ok')
+		expect(results.find((r) => r.check === 'Pre-push hook')?.status).toBe('ok')
+	})
+
+	// No .git in the temp dir: an unguarded `git config` would walk up and
+	// rewrite whatever repo the tmp dir happens to sit inside.
+	it('swift-git-hooks does not touch git config outside a repo', async () => {
+		const dir = newTmpDir()
+		await expect(fixer('swift-git-hooks').run(ctx(dir))).resolves.toBeTruthy()
 	})
 })
 

--- a/tests/languages/swift/scaffold.test.ts
+++ b/tests/languages/swift/scaffold.test.ts
@@ -7,7 +7,8 @@ import {
 	swiftFileList,
 	swiftModuleName,
 } from '../../../src/languages/swift/scaffold.js'
-import { runSwiftChecks } from '../../../src/languages/swift/checks.js'
+import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../../src/languages/swift/checks.js'
+import { checkGitHooks, checkPrePushHook } from '../../../src/base/checks.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -84,6 +85,18 @@ describe('generateSwiftProject', () => {
 			'Periphery: ok',
 			'Swift .gitignore: ok',
 		])
+	})
+
+	// #309: a fresh scaffold must satisfy the base hook checks it now gets, or
+	// `doctor` nags about hooks on a repo `setup` just wrote.
+	it('commits node-free git hooks the base checks accept', async () => {
+		const dir = await scaffold()
+		const profile = SWIFT_GIT_HOOKS
+		expect((await checkGitHooks(dir, profile)).status).toBe('ok')
+		expect((await checkPrePushHook(dir, profile)).status).toBe('ok')
+		const preCommit = await fs.readFile(join(dir, '.githooks/pre-commit'), 'utf-8')
+		expect(preCommit).toContain('swiftlint')
+		expect(preCommit).not.toContain('npx')
 	})
 
 	it('renders Swift CI on macOS with no Node in sight', async () => {


### PR DESCRIPTION
Closes #309

## Why

`doctor` dispatches per language module (#285), so anything living in `src/languages/js` never runs on a Swift repo. Six checks in there had nothing to do with JavaScript — a Swift repo got **no git hooks, no commit linting and no README badge check at all**. That's an incomplete partition left by #281, so the fix is a move into `src/base`, not a per-language reimplementation.

## What moved

Into `src/base/checks.ts`, parameterized by a `GitHooksProfile` the language module supplies rather than forked per language:

| Before (`languages/js`) | After (`base`) | Parameterized by |
|---|---|---|
| `Husky` | `Git hooks` | hooks dir + committed install signal |
| `Husky pre-push` | `Pre-push hook` | verify command |
| Commitlint (file spec) | `Commitlint` | — |
| `checkReadmeBadges` | `README badges` | audience + fix target |

The `commitlint` fixer moved to `BASE_FIXERS` alongside it.

**Deliberately not moved:** `lint-staged` and `verify script`. Both read package.json fields, and the Swift pre-push hook runs the tools inline rather than through a `verify` indirection — so generalizing them would mean inventing a convention (a `Makefile` target) that `swift-common` doesn't have.

## The Husky decision

Husky is an npm package, so a SwiftPM repo can't use it without dragging node into a toolchain that otherwise has none. Swift gets a committed hooks directory instead:

```
.githooks/pre-commit   swiftlint --fix, swiftlint lint
.githooks/pre-push     swift build, swift test, swiftlint lint --strict
$ git config core.hooksPath .githooks
```

`fix swift-git-hooks` writes both (executable) and sets `core.hooksPath`. `setup --preset swift-library` scaffolds them too, so a fresh package passes its own `doctor`; the preset now records `gitHooks: true`.

`core.hooksPath` is per-clone *local* git config, not a committed file, so the Swift profile passes `install: null` — `doctor` reports on the hooks directory alone and never fails a fresh CI checkout for something that isn't repo drift. The generated README documents the one-line config.

No `commit-msg` hook: commitlint needs node on `PATH`. The `Commitlint` check still runs (Conventional Commits is language-agnostic) and stays `optional-missing` unless you opt in.

## De-duplicating doctor.ts

`runBaseChecks` built the base suite; the JS path then re-listed the same eleven calls inline. Any new base check had to be added in two places or it silently skipped JS repos. It's declared once now — the JS path lists only its own checks and appends `runBaseChecks`. A new test asserts both language paths emit every base check, and that none is emitted twice.

## Drive-by

`getFixTargetForCheck` takes the detected language. `doctor` on a Swift repo was suggesting `fix husky`, `fix github-actions`, `fix lockfile` and `fix gitlab-ci` — none of which are in its fixer set — and had no suggestion at all for SwiftLint/Periphery/`.gitignore`. Both fixed.

## Verification

- `pnpm verify` green (558 tests, +6)
- `pnpm dogfood` clean on this repo, `ACCEPTED` unchanged (45 checks)
- `pnpm test:integration` (library preset lifecycle) green
- Manually: `setup --preset swift-library` → `git init` → `doctor` reports `Git hooks: ok`, `Pre-push hook: ok`; deleting `.githooks/` flips both to `not configured` with the `swift-git-hooks` hint; `fix swift-git-hooks` restores them and sets `core.hooksPath`
- `fix swift-git-hooks --diff` shadow-runs without touching the surrounding repo's `core.hooksPath` — the fixer guards its `git config` on `.git` existing, because the preview copy deliberately excludes it

## Docs

Swift guide + reference updated: the git-hooks row, the new checks/fix-target rows, a `## Git hooks` section, and the now-stale "not covered yet" notes (#303 landed the base fixers and the `swift` Dependabot ecosystem).