### PR TITLE
chore: decline the unrs-resolver build script

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,10 @@ packages:
 allowBuilds:
   core-js: false
   core-js-pure: false
+  # napi-postinstall only *checks* that the platform binary is present — the
+  # binary itself arrives as an optional dep — so there's no real build to run.
+  # Same call as core-js; esbuild/sharp below genuinely compile.
+  unrs-resolver: false
   esbuild: true
   sharp: true
 


### PR DESCRIPTION
Unblocks #321.

## Why

pnpm fails the install outright when a dependency has an unlisted build script. Every job on #321 died at `pnpm install --frozen-lockfile`, before a single test ran:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: unrs-resolver@1.12.2
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

`unrs-resolver` arrives transitively with #321's ESLint-side majors. It isn't a new direct dependency and nothing on `main` pulls it in yet — the entry is inert until that PR lands.

## Why declined, not allowed

Its postinstall is `napi-postinstall`, which only *checks* that the correct platform binary is present; the binary itself ships as an optional dependency, so there is no compilation step to run. That's the same shape as `core-js`, which this repo already declines. `esbuild` and `sharp` stay allowed because they do real native builds.

## Verification

Applied to #321's branch in a worktree and ran the full gate:

- `pnpm install --frozen-lockfile` — clean
- `tsc --noEmit` under **TypeScript 7.0.2** — clean
- `biome check src scripts` — clean
- `vitest run` — 558 passed
- `pnpm dogfood` — clean, `ACCEPTED` unchanged

So all seven majors (typescript 7, jest 30, jsdom 29, commander 15, @eslint/js 10, @semantic-release/changelog 7, @semantic-release/git 11) pass on their own; the build-script config was the only blocker.

Once this merges, `@dependabot recreate` on #321 to pick it up.