### PR TITLE
feat(fix): pnpm-workspace target — managed pnpm settings (#314)

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -206,6 +206,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `rolldown` | `rolldown.config.mjs` re-exporting the shared library preset |
 | `size-limit` | a size-limit budget (`.size-limit.cjs`/`.json`) |
 | `treeshake-check` | `apps/treeshake-check` — esbuild + metafile bundle assertion |
+| `pnpm-workspace` | merges the family-wide pnpm settings into `pnpm-workspace.yaml` (`verifyDepsBeforeRun`, `minimumReleaseAgeExclude`, esbuild's build approval) — never rewrites the file |
 | `turborepo` | `turbo.json` task pipeline (pnpm-workspace monorepos) |
 | `nx` | `nx.json` task orchestrator (alternative to Turborepo) |
 | `tailwind` | Tailwind CSS v4 (`postcss.config.mjs` + `src/styles/globals.css`) |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,4 +21,9 @@ onlyBuiltDependencies:
 # already pinned gets a fresh patch publish. Add entries here when a
 # specific package has been vetted and the wait isn't worth the friction.
 minimumReleaseAgeExclude:
+  - '@rtorcato/*'
   - tinyglobby
+
+# Don't re-verify node_modules on every script run — the check costs a
+# second per invocation and CI installs with --frozen-lockfile anyway.
+verifyDepsBeforeRun: false

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -40,6 +40,7 @@ import {
 	checkSemanticRelease,
 	checkSizeLimit,
 	checkTailwind,
+	checkPnpmWorkspace,
 	checkTreeshakeSetup,
 	checkTurborepo,
 	checkTypedoc,
@@ -302,6 +303,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkPublint(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
+	results.push(await checkPnpmWorkspace(targetDir, pkg))
 	// Turborepo is monorepo-only — only surface the check when a workspace exists.
 	if (await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))) {
 		results.push(await checkTurborepo(targetDir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -33,6 +33,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
 	Turborepo: 'turborepo',
+	'pnpm settings': 'pnpm-workspace',
 	Tailwind: 'tailwind',
 	lockfile: 'lockfile',
 	'.repo-tooling.json': 'lockfile',

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -289,13 +289,10 @@ export function computeFileList(config: ProjectConfig): string[] {
 			'apps/treeshake-check/src/entry.ts'
 		)
 	}
-	// pnpm-workspace.yaml carries pnpm 11 build-script approvals (esbuild) and,
-	// for the treeshake path, the apps/* glob. Written whenever either applies.
-	const bundlerNeedsEsbuild =
-		config.bundler === 'tsup' || config.bundler === 'esbuild' || config.bundler === 'vite'
-	if (bundlerNeedsEsbuild || (config.treeshakeCheck && config.projectType === 'library')) {
-		files.push('pnpm-workspace.yaml')
-	}
+	// pnpm-workspace.yaml carries the family-wide pnpm settings (#314) plus, where
+	// they apply, build-script approvals and the treeshake path's apps/* glob —
+	// so it's written for every JS scaffold.
+	files.push('pnpm-workspace.yaml')
 	if (config.aiSetup) {
 		files.push(
 			'AGENTS.md',

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'node:url'
 import { generateSwiftProject } from '../../languages/swift/scaffold.js'
 import type { ProjectConfig } from '../commands/setup.js'
 import { installAiSetup } from './agent-rules.js'
-import { ensureBuildApprovals, generateBuildConfigs } from './build.js'
+import { bundlerNeedsEsbuild, ensureBuildApprovals, generateBuildConfigs } from './build.js'
+import { ensurePnpmSettings } from './pnpm-workspace.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
 import { generateLintingConfigs } from './linting.js'
@@ -96,6 +97,10 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 	// after the treeshake-check path so its richer workspace file (if written)
 	// is never clobbered.
 	await ensureBuildApprovals(config, targetDir)
+
+	// Family-wide pnpm settings (#314). Runs last of the workspace writers so it
+	// merges into whatever they wrote rather than racing them for the file.
+	await ensurePnpmSettings(targetDir, bundlerNeedsEsbuild(config))
 
 	// Turborepo task pipeline (pnpm-workspace monorepos, when opted-in)
 	if (config.turborepo) {

--- a/src/cli/generators/pnpm-workspace.ts
+++ b/src/cli/generators/pnpm-workspace.ts
@@ -1,0 +1,147 @@
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * Since pnpm 10, repo-wide settings live in `pnpm-workspace.yaml` rather than
+ * `.npmrc` — for single-package repos too, not just workspaces. These are the
+ * family-wide settings that otherwise get hand-copied and drift (#314).
+ *
+ * Every write here is a merge: `pnpm-workspace.yaml` also carries the repo's own
+ * `packages:` globs and hand-vetted `allowBuilds` entries, so nothing is
+ * rewritten and no existing value is overridden.
+ */
+export const WORKSPACE_FILE = 'pnpm-workspace.yaml'
+
+/**
+ * pnpm's `minimumReleaseAge` cutoff holds back freshly published versions —
+ * good against a typosquat-hijack, but it also stalls every consumer of a
+ * same-day `@rtorcato/*` fix for 24h. One glob covers the whole family: pnpm
+ * matches these entries with `@pnpm/config.matcher`, so there's no package list
+ * to keep in sync with `@rtorcato/shared-docs`'s `FAMILY`.
+ */
+const FAMILY_GLOB = '@rtorcato/*'
+
+/** Bundlers that pull in esbuild, whose install script pnpm 11 refuses to run unapproved. */
+const ESBUILD_BUNDLERS = ['esbuild', 'tsup', 'vite']
+
+/** True when the repo depends on a bundler that drags esbuild in. */
+export function dependsOnEsbuild(deps: Record<string, string>): boolean {
+	return ESBUILD_BUNDLERS.some((name) => name in deps)
+}
+
+/**
+ * The lines of a top-level YAML block, e.g. everything indented under
+ * `allowBuilds:`. Returns null when the key isn't present at all. Hand-rolled
+ * because adding a YAML parser to a 5-dependency CLI to read three keys isn't
+ * worth it — and the same shape is already parsed this way in `misc.ts`.
+ */
+function section(yaml: string, key: string): string[] | null {
+	const lines = yaml.split('\n')
+	const start = lines.findIndex((line) => line.startsWith(`${key}:`))
+	if (start === -1) return null
+	const body: string[] = []
+	for (const line of lines.slice(start + 1)) {
+		if (/^\S/.test(line)) break // a new top-level key ends the block
+		body.push(line)
+	}
+	return body
+}
+
+interface Setting {
+	/** How doctor names this setting when it's missing. */
+	label: string
+	/** Only managed when this returns true for the repo. */
+	applies: (needsEsbuild: boolean) => boolean
+	satisfied: (yaml: string) => boolean
+	/** Merged in when absent: appended as a new block, or inserted under an existing key. */
+	key: string
+	block: string
+	item: string
+}
+
+const SETTINGS: Setting[] = [
+	{
+		label: 'verifyDepsBeforeRun: false',
+		applies: () => true,
+		// Any explicit value counts — a repo that deliberately opted into
+		// verification shouldn't be nagged back to the family default.
+		satisfied: (yaml) => /^verifyDepsBeforeRun:/m.test(yaml),
+		key: 'verifyDepsBeforeRun',
+		block: `# Don't re-verify node_modules on every script run — the check costs a
+# second per invocation and CI installs with --frozen-lockfile anyway.
+verifyDepsBeforeRun: false
+`,
+		item: '',
+	},
+	{
+		label: `minimumReleaseAgeExclude: ${FAMILY_GLOB}`,
+		applies: () => true,
+		satisfied: (yaml) => (section(yaml, 'minimumReleaseAgeExclude') ?? []).some(hasFamilyGlob),
+		key: 'minimumReleaseAgeExclude',
+		block: `# Exempt the @rtorcato family from pnpm's minimumReleaseAge cutoff, so a
+# same-day fix in a sibling package is installable today rather than tomorrow.
+minimumReleaseAgeExclude:
+  - '${FAMILY_GLOB}'
+`,
+		item: `  - '${FAMILY_GLOB}'`,
+	},
+	{
+		label: 'allowBuilds: esbuild',
+		applies: (needsEsbuild) => needsEsbuild,
+		satisfied: (yaml) => (section(yaml, 'allowBuilds') ?? []).some((l) => /^\s*esbuild:/.test(l)),
+		key: 'allowBuilds',
+		block: `# pnpm 11 reads build-script approvals from this map, not the older
+# onlyBuiltDependencies list, and fails the install outright without them.
+allowBuilds:
+  esbuild: true
+`,
+		item: '  esbuild: true',
+	},
+]
+
+function hasFamilyGlob(line: string): boolean {
+	return line.includes(FAMILY_GLOB)
+}
+
+/** Managed settings absent from `yaml`, named as doctor reports them. */
+export function missingPnpmSettings(yaml: string, needsEsbuild: boolean): string[] {
+	return SETTINGS.filter((s) => s.applies(needsEsbuild) && !s.satisfied(yaml)).map((s) => s.label)
+}
+
+/** Insert `item` directly under an existing `key:` line, keeping the rest untouched. */
+function insertUnder(yaml: string, key: string, item: string): string {
+	const lines = yaml.split('\n')
+	const at = lines.findIndex((line) => line.startsWith(`${key}:`))
+	lines.splice(at + 1, 0, item)
+	return lines.join('\n')
+}
+
+/** Merge every missing managed setting into `yaml` and return the new contents. */
+export function upsertPnpmSettings(yaml: string, needsEsbuild: boolean): string {
+	let next = yaml
+	for (const setting of SETTINGS) {
+		if (!setting.applies(needsEsbuild) || setting.satisfied(next)) continue
+		if (setting.item && section(next, setting.key)) {
+			next = insertUnder(next, setting.key, setting.item)
+		} else {
+			next = `${next.replace(/\n*$/, '\n')}\n${setting.block}`
+		}
+	}
+	return next
+}
+
+/**
+ * Merge the managed pnpm settings into `pnpm-workspace.yaml`, creating it when
+ * absent. Returns the relative path if anything changed, else null.
+ */
+export async function ensurePnpmSettings(
+	targetDir: string,
+	needsEsbuild: boolean
+): Promise<string | null> {
+	const file = path.join(targetDir, WORKSPACE_FILE)
+	const current = (await fs.pathExists(file)) ? await fs.readFile(file, 'utf-8') : ''
+	const next = upsertPnpmSettings(current, needsEsbuild)
+	if (next === current) return null
+	await fs.writeFile(file, next.replace(/^\n+/, ''))
+	return WORKSPACE_FILE
+}

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -2,6 +2,11 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import type { BadgeAudience, FileCheck, GitHooksProfile } from '../../base/checks.js'
 import { hookHasUncommented } from '../../base/checks.js'
+import {
+	WORKSPACE_FILE,
+	dependsOnEsbuild,
+	missingPnpmSettings,
+} from '../../cli/generators/pnpm-workspace.js'
 import type { CheckResult } from '../../base/types.js'
 
 const PACKAGE = '@rtorcato/repo-tooling'
@@ -900,6 +905,38 @@ export async function checkTurborepo(dir: string): Promise<CheckResult> {
 		status: 'optional-missing',
 		detail: 'pnpm workspace without a task orchestrator',
 		hint: 'Run `npx @rtorcato/repo-tooling fix turborepo` (or `fix nx`) to scaffold a task pipeline',
+	}
+}
+
+/**
+ * pnpm settings that would otherwise be hand-copied across the family (#314).
+ * Only reported for pnpm repos — an npm or yarn repo has no use for the file,
+ * and inventing one there would be noise.
+ */
+export async function checkPnpmWorkspace(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const check = 'pnpm settings'
+	const hint = `Run \`npx ${PACKAGE} fix pnpm-workspace\` to merge them in`
+	const file = path.join(dir, WORKSPACE_FILE)
+	const exists = await fs.pathExists(file)
+	const usesPnpm =
+		exists ||
+		(await fs.pathExists(path.join(dir, 'pnpm-lock.yaml'))) ||
+		((pkg?.packageManager as string | undefined) ?? '').startsWith('pnpm')
+	if (!usesPnpm) {
+		return { check, status: 'ok', detail: 'not a pnpm repo' }
+	}
+
+	const yaml = exists ? await fs.readFile(file, 'utf-8') : ''
+	const missing = missingPnpmSettings(yaml, dependsOnEsbuild(allDeps(pkg)))
+	if (missing.length === 0) {
+		return { check, status: 'ok', detail: `${WORKSPACE_FILE} carries the managed settings` }
+	}
+	return {
+		check,
+		// A repo with no workspace file at all hasn't drifted — it never opted in.
+		status: exists ? 'drift' : 'optional-missing',
+		detail: `missing ${missing.join(', ')}`,
+		hint,
 	}
 }
 

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -22,6 +22,11 @@ import {
 	generateVscodeExtensions,
 } from '../../cli/generators/misc.js'
 import { composeVerifyScriptFromPkg } from '../../cli/generators/package-json.js'
+import {
+	WORKSPACE_FILE,
+	dependsOnEsbuild,
+	ensurePnpmSettings,
+} from '../../cli/generators/pnpm-workspace.js'
 import { generatePostcss } from '../../cli/generators/postcss.js'
 import { generateCypressConfig, generateVitestConfig } from '../../cli/generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../../cli/generators/treeshake.js'
@@ -360,6 +365,24 @@ export const FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const written = await generateTurborepo(targetDir)
 			return { filesWritten: [written] }
+		},
+	},
+	{
+		target: 'pnpm-workspace',
+		description: 'Merge the managed pnpm settings into pnpm-workspace.yaml',
+		appliesTo: ['pnpm settings'],
+		outputs: [WORKSPACE_FILE],
+		// safe-merge: the file also carries the repo's own packages: globs and
+		// hand-vetted allowBuilds entries, so only missing keys are added.
+		riskLevel: 'safe-merge',
+		canFixDrift: true,
+		async run({ targetDir, pkg }) {
+			const deps = {
+				...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
+				...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
+			}
+			const written = await ensurePnpmSettings(targetDir, dependsOnEsbuild(deps))
+			return { filesWritten: written ? [written] : [] }
 		},
 	},
 	{

--- a/tests/cli/generators/pnpm-workspace.test.ts
+++ b/tests/cli/generators/pnpm-workspace.test.ts
@@ -1,0 +1,85 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { checkPnpmWorkspace } from '../../../src/languages/js/checks.js'
+import {
+	ensurePnpmSettings,
+	missingPnpmSettings,
+	upsertPnpmSettings,
+} from '../../../src/cli/generators/pnpm-workspace.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('upsertPnpmSettings', () => {
+	it('writes every managed setting into an empty file', () => {
+		const yaml = upsertPnpmSettings('', true)
+		expect(yaml).toContain('verifyDepsBeforeRun: false')
+		expect(yaml).toContain("- '@rtorcato/*'")
+		expect(yaml).toContain('esbuild: true')
+		expect(missingPnpmSettings(yaml, true)).toEqual([])
+	})
+
+	// The whole point of #314's "merge, don't overwrite" note: the file also
+	// carries the repo's own globs and hand-vetted build approvals.
+	it('keeps existing keys and merges into the lists already there', () => {
+		const before = `packages:
+  - 'apps/*'
+
+allowBuilds:
+  core-js: false
+  esbuild: true
+
+minimumReleaseAgeExclude:
+  - tinyglobby
+`
+		const after = upsertPnpmSettings(before, true)
+		expect(after).toContain("- 'apps/*'")
+		expect(after).toContain('core-js: false')
+		expect(after).toContain('- tinyglobby')
+		expect(after).toContain("- '@rtorcato/*'")
+		// esbuild was already approved, so allowBuilds is left exactly as found.
+		expect(after.match(/esbuild: true/g)).toHaveLength(1)
+	})
+
+	it('respects an explicit verifyDepsBeforeRun rather than resetting it', () => {
+		const after = upsertPnpmSettings('verifyDepsBeforeRun: true\n', false)
+		expect(after).toContain('verifyDepsBeforeRun: true')
+		expect(after).not.toContain('verifyDepsBeforeRun: false')
+	})
+
+	it('leaves allowBuilds alone when no bundler needs esbuild', () => {
+		expect(upsertPnpmSettings('', false)).not.toContain('allowBuilds')
+	})
+
+	it('is idempotent', () => {
+		const once = upsertPnpmSettings('', true)
+		expect(upsertPnpmSettings(once, true)).toBe(once)
+	})
+})
+
+describe('checkPnpmWorkspace', () => {
+	it('stays quiet on a repo that does not use pnpm', async () => {
+		const dir = newTmpDir()
+		expect((await checkPnpmWorkspace(dir, {})).status).toBe('ok')
+	})
+
+	it('flags an existing workspace file that is missing the settings', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		const before = await checkPnpmWorkspace(dir, {})
+		expect(before.status).toBe('drift')
+		expect(before.detail).toContain('@rtorcato/*')
+
+		await ensurePnpmSettings(dir, false)
+		expect((await checkPnpmWorkspace(dir, {})).status).toBe('ok')
+	})
+
+	// A pnpm repo with no workspace file hasn't drifted — it never opted in — so
+	// this is a gray suggestion, not a CI-failing finding.
+	it('only suggests the file when a pnpm repo has none', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n')
+		expect((await checkPnpmWorkspace(dir, {})).status).toBe('optional-missing')
+	})
+})


### PR DESCRIPTION
Closes #314.

## What

Adds a `pnpm-workspace` fix target and a matching `pnpm settings` doctor check, so the family-wide pnpm settings stop being hand-copied across consumer repos.

Managed keys:

| Key | Value | Why |
|---|---|---|
| `minimumReleaseAgeExclude` | `'@rtorcato/*'` | pnpm's release-age cutoff otherwise holds back a freshly published sibling package for 24h |
| `verifyDepsBeforeRun` | `false` | re-verifying `node_modules` on every script run costs a second per invocation; CI installs `--frozen-lockfile` anyway |
| `allowBuilds` | `esbuild: true` | pnpm 11 fails the install outright without it — only managed when the repo actually depends on esbuild/tsup/vite |

## Notes

- **Merges, never rewrites.** `pnpm-workspace.yaml` also carries the repo's own `packages:` globs and hand-vetted `allowBuilds` entries. `upsertPnpmSettings` inserts under an existing key or appends a new block, and is idempotent. An explicit `verifyDepsBeforeRun: true` is respected, not reset.
- **One glob instead of a package list.** #314 suggested reusing `FAMILY` from `@rtorcato/shared-docs`. pnpm matches `minimumReleaseAgeExclude` entries with `@pnpm/config.matcher`, so `'@rtorcato/*'` covers the family in one entry — no list to keep in sync, and no new dependency on a docs package for a lean CLI.
- **No noise on non-pnpm repos.** The check reports `ok` unless the repo has a `pnpm-workspace.yaml`, a `pnpm-lock.yaml`, or a pnpm `packageManager` field. A pnpm repo with no workspace file gets `optional-missing` (gray, non-failing) — it never opted in, so it hasn't drifted.
- Wired into `setup` (after `ensureBuildApprovals`, so it merges into whatever the workspace writers produced) so a fresh scaffold isn't born drifting.

## Verification

- Applied to this repo's own `pnpm-workspace.yaml`; `pnpm install --frozen-lockfile` still parses and passes the supply-chain policy step.
- biome clean, `tsc` clean, 566 tests across 43 files, dogfood green at 46 checks.