### PR TITLE
feat(doctor): config schema versions + refless git dependency checks

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -30,8 +30,10 @@ import type { CheckResult, CheckStatus } from '../../base/types.js'
 import {
 	allDeps,
 	checkAreTheTypesWrong,
+	checkConfigSchemaVersions,
 	checkDocsSite,
 	checkEnginesNode,
+	checkGitDependencies,
 	checkKnip,
 	checkLintStaged,
 	checkNodeVersionConsistency,
@@ -288,6 +290,8 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(evaluateNodeVersion(process.version))
 	results.push(checkPackageJson(pkg))
 	results.push(checkEnginesNode(pkg))
+	results.push(await checkConfigSchemaVersions(targetDir, pkg))
+	results.push(checkGitDependencies(pkg))
 	results.push(await checkVscodeExtensions(targetDir))
 	results.push(await checkNodeVersionPin(targetDir))
 	results.push(await checkNodeVersionConsistency(targetDir, pkg))

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -1031,3 +1031,172 @@ export async function checkTailwind(dir: string, pkg: Pkg | null): Promise<Check
 		hint: 'Run `npx @rtorcato/repo-tooling fix tailwind` to scaffold the v4 PostCSS wiring',
 	}
 }
+
+/**
+ * Both checks below read `package.json` alone — no network, no lockfile. They
+ * report `optional-missing` rather than `drift`: each is a policy call a repo
+ * can legitimately decide against, so they surface in doctor's output and can
+ * be declined in `.repo-tooling.json`, but neither fails a build.
+ */
+
+/** `[major, minor, patch]` floor of a range, or null when it hasn't got one. */
+export function rangeFloor(range: string): [number, number, number] | null {
+	const m = /^[\s^~>=<v]*(\d+)\.(\d+)\.(\d+)/.exec(range)
+	return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null
+}
+
+/**
+ * Major.minor only — patch is deliberately ignored. New config keys and new
+ * behaviour arrive in minors; a dev floor five patches above the peer floor
+ * (`^2.5.0` vs `^2.5.5`) is just a routine bump and flagging it would make
+ * this check fire on almost every package.
+ */
+function compareFloor(a: [number, number, number], b: [number, number, number]): number {
+	return a[0] - b[0] || a[1] - b[1]
+}
+
+/**
+ * Config files whose `$schema` URL carries the tool version the config is
+ * written for, and the package that reads them. One entry per tool; adding
+ * another is a line here.
+ */
+const SCHEMA_CONFIGS: { files: string[]; host: string; pkg: string }[] = [
+	{ files: ['biome.json', 'biome.jsonc'], host: 'biomejs.dev', pkg: '@biomejs/biome' },
+]
+
+/** The version out of `https://biomejs.dev/schemas/2.5.0/schema.json`. */
+export function schemaUrlVersion(url: string): [number, number, number] | null {
+	const m = /\/(\d+\.\d+\.\d+)\//.exec(url)
+	return m?.[1] ? rangeFloor(m[1]) : null
+}
+
+/**
+ * `"$schema": "..."` without parsing the file. Biome configs may be JSONC, and
+ * a comment is enough to break `JSON.parse` — the one field this needs is
+ * cheaper and safer to read directly.
+ */
+function readSchemaUrl(contents: string): string | null {
+	return /"\$schema"\s*:\s*"([^"]+)"/.exec(contents)?.[1] ?? null
+}
+
+/**
+ * A shipped config written for a newer tool version than the package claims to
+ * support (#330). The `$schema` URL is an explicit, machine-readable statement
+ * of which version the config targets, so comparing it against the declared
+ * dependency floor is exact — no heuristics, no false positives.
+ *
+ * This is the #330 defect precisely: `tooling/biome/biome.json` carries
+ * `$schema` 2.5.0 and uses `linter.rules.preset`, a 2.5 key, while
+ * `peerDependencies` advertised `@biomejs/biome: ^2.0.0`. Consumers on 2.0–2.4
+ * got `Found an unknown key \`preset\`` with nothing pointing at the range.
+ *
+ * It reads the same way in a consuming repo: a `biome.json` targeting 2.5.0
+ * with `@biomejs/biome: ^2.3.0` in devDependencies is the identical failure,
+ * one level down.
+ *
+ * The floor is what matters, not the ceiling — `^2.0.0` resolves to the newest
+ * 2.x today, so the repo's own install works and only consumers pinned lower
+ * break. That is exactly why this goes unnoticed.
+ */
+export async function checkConfigSchemaVersions(
+	dir: string,
+	pkg: Pkg | null
+): Promise<CheckResult> {
+	const check = 'Config schema versions'
+	// peerDependencies is the contract a publisher offers; devDependencies is
+	// what a leaf repo actually installs. Prefer the former when present.
+	const declared = {
+		...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
+		...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
+		...((pkg?.peerDependencies as Record<string, string> | undefined) ?? {}),
+	}
+
+	const mismatches: string[] = []
+	let checked = 0
+	for (const spec of SCHEMA_CONFIGS) {
+		for (const file of spec.files) {
+			const filepath = path.join(dir, file)
+			if (!(await fs.pathExists(filepath))) continue
+			const url = readSchemaUrl(await fs.readFile(filepath, 'utf8'))
+			if (!url?.includes(spec.host)) continue
+			const schemaVersion = schemaUrlVersion(url)
+			const range = declared[spec.pkg]
+			if (!schemaVersion || !range) continue
+			const floor = rangeFloor(range)
+			if (!floor) continue
+			checked++
+			if (compareFloor(schemaVersion, floor) > 0) {
+				const v = schemaVersion.join('.')
+				mismatches.push(`${file} targets ${spec.pkg} ${v} but the range is ${range}`)
+			}
+		}
+	}
+
+	if (checked === 0) {
+		return { check, status: 'ok', detail: 'no versioned config schemas to compare' }
+	}
+	if (mismatches.length === 0) {
+		return {
+			check,
+			status: 'ok',
+			detail: `${checked} config schema${checked === 1 ? '' : 's'} within the declared version range`,
+		}
+	}
+	return {
+		check,
+		status: 'optional-missing',
+		detail: `${mismatches.length} config${mismatches.length === 1 ? '' : 's'} written for a newer tool than declared: ${mismatches.join('; ')}`,
+		hint: 'Raise the dependency floor to the version the config targets, or rewrite the config for the oldest version supported. Anyone resolving below the schema version gets a config-parse error that never mentions the version range.',
+	}
+}
+
+/** npm git specifiers, including the bare `owner/repo` GitHub shorthand. */
+const GIT_PROTOCOL = /^(?:github|gitlab|bitbucket|gist):|^git\+|^git:\/\//
+const GITHUB_SHORTHAND = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*(?:#.*)?$/
+
+export function isGitSpecifier(spec: string): boolean {
+	return GIT_PROTOCOL.test(spec) || GITHUB_SHORTHAND.test(spec)
+}
+
+/**
+ * A git dependency with no `#ref` (#332). The package manager resolves it once
+ * and pins the commit in the lockfile, so it never moves again until somebody
+ * re-resolves by hand — with no version mismatch, no Dependabot PR, and no
+ * signal of any kind that it has gone stale.
+ *
+ * This is how the docs homepage kept advertising `@rtorcato/js-tooling` for
+ * days after the rename: `github:rtorcato/shared-docs` had been pinned to a
+ * pre-rename commit and nothing could tell.
+ */
+export function checkGitDependencies(pkg: Pkg | null): CheckResult {
+	const check = 'Git dependencies'
+	const fields = ['dependencies', 'devDependencies', 'optionalDependencies'] as const
+	const refless: string[] = []
+	let total = 0
+
+	for (const field of fields) {
+		const deps = (pkg?.[field] as Record<string, string> | undefined) ?? {}
+		for (const [name, spec] of Object.entries(deps)) {
+			if (typeof spec !== 'string' || !isGitSpecifier(spec)) continue
+			total++
+			if (!spec.includes('#')) refless.push(`${name} (${spec})`)
+		}
+	}
+
+	if (total === 0) {
+		return { check, status: 'ok', detail: 'no git dependencies' }
+	}
+	if (refless.length === 0) {
+		return {
+			check,
+			status: 'ok',
+			detail: `${total} git dependenc${total === 1 ? 'y' : 'ies'}, all with an explicit ref`,
+		}
+	}
+	return {
+		check,
+		status: 'optional-missing',
+		detail: `${refless.length} git dependenc${refless.length === 1 ? 'y' : 'ies'} with no ref — pinned to whatever commit was current at install time: ${refless.join('; ')}`,
+		hint: 'Prefer publishing to a registry and depending on a semver range. Failing that, add an explicit ref — `#semver:^1.2.0` is strongest, `#main` at least makes the intent legible and `pnpm update` meaningful.',
+	}
+}

--- a/tests/languages/js/dependency-hygiene.test.ts
+++ b/tests/languages/js/dependency-hygiene.test.ts
@@ -1,0 +1,188 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import {
+	checkConfigSchemaVersions,
+	checkGitDependencies,
+	isGitSpecifier,
+	rangeFloor,
+	schemaUrlVersion,
+} from '../../../src/languages/js/checks.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+/** A dir with a biome.json targeting `schemaVersion`. */
+function repoWith(schemaVersion: string, pkg: object, file = 'biome.json'): string {
+	const dir = newTmpDir()
+	fs.writeFileSync(
+		join(dir, file),
+		`{\n\t"$schema": "https://biomejs.dev/schemas/${schemaVersion}/schema.json"\n}\n`
+	)
+	fs.writeJsonSync(join(dir, 'package.json'), pkg)
+	return dir
+}
+
+describe('rangeFloor', () => {
+	it('reads the floor out of the common range operators', () => {
+		expect(rangeFloor('^2.0.0')).toEqual([2, 0, 0])
+		expect(rangeFloor('~2.5.1')).toEqual([2, 5, 1])
+		expect(rangeFloor('2.5.5')).toEqual([2, 5, 5])
+		expect(rangeFloor('>=2.1.0 <3.0.0')).toEqual([2, 1, 0])
+		expect(rangeFloor('v1.2.3')).toEqual([1, 2, 3])
+	})
+
+	it('returns null for ranges with no single floor', () => {
+		expect(rangeFloor('*')).toBeNull()
+		expect(rangeFloor('workspace:*')).toBeNull()
+		expect(rangeFloor('catalog:')).toBeNull()
+		expect(rangeFloor('2.x')).toBeNull()
+	})
+})
+
+describe('schemaUrlVersion', () => {
+	it('reads the version out of a versioned schema URL', () => {
+		expect(schemaUrlVersion('https://biomejs.dev/schemas/2.5.0/schema.json')).toEqual([2, 5, 0])
+	})
+
+	it('returns null for an unversioned URL', () => {
+		expect(schemaUrlVersion('https://biomejs.dev/schemas/latest/schema.json')).toBeNull()
+		expect(schemaUrlVersion('https://json.schemastore.org/package.json')).toBeNull()
+	})
+})
+
+describe('checkConfigSchemaVersions', () => {
+	it('passes when there is no versioned config schema to compare', async () => {
+		expect((await checkConfigSchemaVersions(newTmpDir(), {})).status).toBe('ok')
+	})
+
+	// The actual #330 defect: a preset written for 2.5 shipped under a ^2.0.0
+	// peer range, so consumers on 2.0-2.4 got an unknown-key parse error.
+	it('flags a config targeting a version above the declared peer floor', async () => {
+		const dir = repoWith('2.5.0', { peerDependencies: { '@biomejs/biome': '^2.0.0' } })
+		const r = await checkConfigSchemaVersions(dir, {
+			peerDependencies: { '@biomejs/biome': '^2.0.0' },
+		})
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('2.5.0')
+		expect(r.detail).toContain('^2.0.0')
+	})
+
+	// The same failure one level down — this is what broke js-common's lint.
+	it('flags it in a consuming repo via devDependencies', async () => {
+		const dir = repoWith('2.5.0', {})
+		const r = await checkConfigSchemaVersions(dir, {
+			devDependencies: { '@biomejs/biome': '^2.3.0' },
+		})
+		expect(r.status).toBe('optional-missing')
+	})
+
+	it('passes when the declared floor covers the schema version', async () => {
+		const dir = repoWith('2.5.0', {})
+		const r = await checkConfigSchemaVersions(dir, {
+			devDependencies: { '@biomejs/biome': '^2.5.0' },
+		})
+		expect(r.status).toBe('ok')
+	})
+
+	// A floor above the schema version is fine — the config is older than the
+	// tool, which parses it happily.
+	it('does not flag a floor above the schema version', async () => {
+		const dir = repoWith('2.5.0', {})
+		const r = await checkConfigSchemaVersions(dir, {
+			devDependencies: { '@biomejs/biome': '^2.6.0' },
+		})
+		expect(r.status).toBe('ok')
+	})
+
+	it('ignores the config when the tool is not a declared dependency', async () => {
+		const dir = repoWith('2.5.0', {})
+		expect((await checkConfigSchemaVersions(dir, { devDependencies: {} })).status).toBe('ok')
+	})
+
+	// Biome configs may be JSONC, where a comment defeats JSON.parse.
+	it('reads $schema out of a config with comments', async () => {
+		const dir = newTmpDir()
+		fs.writeFileSync(
+			join(dir, 'biome.jsonc'),
+			'{\n\t// linter preset\n\t"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json"\n}\n'
+		)
+		const r = await checkConfigSchemaVersions(dir, {
+			devDependencies: { '@biomejs/biome': '^2.0.0' },
+		})
+		expect(r.status).toBe('optional-missing')
+	})
+})
+
+describe('isGitSpecifier', () => {
+	it('recognises the git protocols and the GitHub shorthand', () => {
+		expect(isGitSpecifier('github:rtorcato/shared-docs')).toBe(true)
+		expect(isGitSpecifier('gitlab:owner/repo')).toBe(true)
+		expect(isGitSpecifier('git+https://example.com/a/b.git')).toBe(true)
+		expect(isGitSpecifier('git://example.com/a/b.git')).toBe(true)
+		expect(isGitSpecifier('rtorcato/shared-docs')).toBe(true)
+		expect(isGitSpecifier('rtorcato/shared-docs#main')).toBe(true)
+	})
+
+	it('does not mistake ordinary specifiers for git ones', () => {
+		for (const spec of [
+			'^2.0.0',
+			'2.5.5',
+			'*',
+			'workspace:*',
+			'catalog:',
+			'npm:@scope/pkg@1.0.0',
+			'file:../local',
+			'link:../local',
+			'../local',
+			'https://example.com/x.tar.gz',
+		]) {
+			expect(isGitSpecifier(spec), spec).toBe(false)
+		}
+	})
+})
+
+describe('checkGitDependencies', () => {
+	it('passes when there are none', () => {
+		expect(checkGitDependencies({ dependencies: { chalk: '^5.0.0' } }).status).toBe('ok')
+		expect(checkGitDependencies(null).status).toBe('ok')
+	})
+
+	// The actual #332 defect.
+	it('flags a refless git dependency', () => {
+		const r = checkGitDependencies({
+			dependencies: { '@rtorcato/shared-docs': 'github:rtorcato/shared-docs' },
+		})
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('@rtorcato/shared-docs')
+	})
+
+	it('accepts a git dependency carrying any explicit ref', () => {
+		for (const spec of [
+			'github:rtorcato/shared-docs#main',
+			'github:rtorcato/shared-docs#semver:^1.2.0',
+			'git+https://example.com/a/b.git#v1.0.0',
+		]) {
+			expect(checkGitDependencies({ dependencies: { dep: spec } }).status, spec).toBe('ok')
+		}
+	})
+
+	it('looks in devDependencies and optionalDependencies too', () => {
+		expect(checkGitDependencies({ devDependencies: { a: 'github:o/r' } }).status).toBe(
+			'optional-missing'
+		)
+		expect(checkGitDependencies({ optionalDependencies: { a: 'github:o/r' } }).status).toBe(
+			'optional-missing'
+		)
+	})
+
+	it('reports every offender, not just the first', () => {
+		const r = checkGitDependencies({
+			dependencies: { a: 'github:o/a', b: 'github:o/b#main' },
+			devDependencies: { c: 'gitlab:o/c' },
+		})
+		expect(r.detail).toContain('a (github:o/a)')
+		expect(r.detail).toContain('c (gitlab:o/c)')
+		expect(r.detail).not.toContain('b (')
+	})
+})


### PR DESCRIPTION
Closes #330. Closes #332.

Two JS-module checks, both reading `package.json` and config files only — no
network, no lockfile, no `node_modules`.

## Config schema versions (#330)

Compares a config file's `$schema` version against the declared floor for the
tool that reads it.

`tooling/biome/biome.json` carries `$schema` 2.5.0 and uses
`linter.rules.preset`, a Biome **2.5** key, while `peerDependencies`
advertised `@biomejs/biome: ^2.0.0`. Consumers resolving 2.0–2.4 got:

```
× Found an unknown key `preset`.
```

…with nothing connecting it to the version range. It reads the same way one
level down: a repo whose `biome.json` targets 2.5.0 with `^2.3.0` installed
hits the identical error — which is exactly what broke js-common's lint step
during its migration.

## Git dependencies (#332)

Flags a git dependency with no `#ref`. The package manager resolves it once
and pins the commit in the lockfile, so it never moves again — no version
mismatch, no Dependabot PR, no signal of any kind.
`github:rtorcato/shared-docs` sat on a pre-rename commit long enough for the
docs homepage to advertise a package name that no longer existed.

## Why I did not build #330 as specified

The issue proposed comparing **every peer range against its devDependency
floor**, and I described that as a reliable signal. I built it, then measured
it against this repo: **24 findings**, nearly all correct practice.
`prettier` peer `^3.0.0` with dev `^3.9.6` is how a peer range is *supposed*
to look. A check with that hit rate is worse than no check.

The `$schema` URL is an explicit, machine-readable statement of the version a
config targets, so comparing that instead is exact rather than heuristic.
Same defect caught, no false positives. Both checks now report exactly one
finding on this repo, and both are real:

```
Config schema versions  biome.json targets @biomejs/biome 2.5.0 but the range is ^2.0.0
Git dependencies        @rtorcato/shared-docs (github:rtorcato/shared-docs)
```

I've noted the correction on #330.

## Status choice

Both report `optional-missing`, not `drift`. Each is a policy call a repo can
legitimately decide against, so they surface in doctor's output and can be
declined via `.repo-tooling.json` without failing a build. This also keeps
`dogfood` green while the two underlying issues are open on this repo — both
checks fire here, and `drift` would turn main red until they're resolved.

No fixers: raising a dependency floor and choosing a git ref strategy are
judgement calls, not mechanical edits.

## Testing

18 new cases in `tests/languages/js/dependency-hygiene.test.ts`. The
version-comparison and specifier-classification helpers are pure and tested
directly; the config check runs against real files in a temp dir. Covers the
JSONC case (a comment defeats `JSON.parse`, so `$schema` is read with a regex)
and every specifier form that must *not* be mistaken for a git dep —
`workspace:`, `catalog:`, `npm:`, `file:`, `link:`, tarball URLs.

Full suite: 594 passing.