### PR TITLE
fix(docs): depend on shared-docs from the registry, not github:

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,7 +29,7 @@
 		"@docusaurus/module-type-aliases": "^3.10.2",
 		"@docusaurus/tsconfig": "^3.10.2",
 		"@docusaurus/types": "^3.10.2",
-		"@rtorcato/shared-docs": "github:rtorcato/shared-docs",
+		"@rtorcato/shared-docs": "^1.2.2",
 		"@types/react": "^19.0.0",
 		"typescript": "~7.0.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^3.10.2
         version: 3.10.2(esbuild@0.28.1)(postcss@8.5.19)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@rtorcato/shared-docs':
-        specifier: github:rtorcato/shared-docs
-        version: https://codeload.github.com/rtorcato/shared-docs/tar.gz/eca402829e3a1a7bab82050d75a067c7b0618ed6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.2.2
+        version: 1.2.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -3413,9 +3413,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/eca402829e3a1a7bab82050d75a067c7b0618ed6':
-    resolution: {gitHosted: true, integrity: sha512-senKjLRH640H02ws2r1ENdRtBZWK0sC6kCY+Q8HLN1ajpbwnzC1kPHdzmrbi1ZCT2kEpkoE/DWxYkH36glHpkg==, tarball: https://codeload.github.com/rtorcato/shared-docs/tar.gz/eca402829e3a1a7bab82050d75a067c7b0618ed6}
-    version: 1.2.0
+  '@rtorcato/shared-docs@1.2.2':
+    resolution: {integrity: sha512-gaaFboV1QIgqZgJcw8B7BuX6Ppz46Sn67ua4bM8Vbfbx4O380rYl8I5NTyb0qNczVLGaPVs+bmUJY4lEgW/RnQ==}
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -15004,7 +15003,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
-  '@rtorcato/shared-docs@https://codeload.github.com/rtorcato/shared-docs/tar.gz/eca402829e3a1a7bab82050d75a067c7b0618ed6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@rtorcato/shared-docs@1.2.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)


### PR DESCRIPTION
The actual fix for #332 — #333 closed it but only added the *detection*.

```diff
- "@rtorcato/shared-docs": "github:rtorcato/shared-docs"
+ "@rtorcato/shared-docs": "^1.2.2"
```

## No publish was needed

I expected this to require publishing shared-docs first — the issue proposed
that as the most-work option, and repo-tooling's own rename showed that a
first npm publish can't bootstrap over OIDC. None of that applies:
`@rtorcato/shared-docs` **is already on npm**, currently at 1.2.2.

I verified the published tarball rather than trusting the version number —
downloaded 1.2.2 and read `dist/family.js`. It carries
`@rtorcato/repo-tooling`, so the registry copy is post-rename and switching
to it is not a regression.

So the whole problem was that nothing pointed at the registry. The git spec
was pinning a tarball by commit, which is how the sibling grid kept
advertising a package name that had not existed for days.

## What the range restores

Everything a git pin silently removes: Dependabot sees the dependency,
`pnpm outdated` reports it, and a new shared-docs release reaches this site
without anyone re-resolving by hand.

## Verification

- Rebuilt the docs and parsed the grid out of `build/index.html`: **nine
  cards, byte-identical to before**, no `js-tooling` anywhere on the page,
  repo-tooling still correctly self-excluded.
- Ran doctor's own `Git dependencies` check against `apps/docs` — flips from
  one finding to `no git dependencies`. The check shipped this afternoon
  confirming its own fix.
- `biome check`, `tsc --noEmit`, 594 tests.

## Not covered here

Other sibling repos may consume shared-docs the same way; this PR only fixes
this one. Worth a sweep — and now that doctor detects the pattern, running it
across the family will find them without guessing.