### PR TITLE
fix(pnpm-workspace): derive the release-age scope, don't hardcode it

### DIFF
--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -5,7 +5,7 @@ import { generateSwiftProject } from '../../languages/swift/scaffold.js'
 import type { ProjectConfig } from '../commands/setup.js'
 import { installAiSetup } from './agent-rules.js'
 import { bundlerNeedsEsbuild, ensureBuildApprovals, generateBuildConfigs } from './build.js'
-import { ensurePnpmSettings } from './pnpm-workspace.js'
+import { ensurePnpmSettings, familyGlob } from './pnpm-workspace.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
 import { generateLintingConfigs } from './linting.js'
@@ -100,7 +100,7 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 
 	// Family-wide pnpm settings (#314). Runs last of the workspace writers so it
 	// merges into whatever they wrote rather than racing them for the file.
-	await ensurePnpmSettings(targetDir, bundlerNeedsEsbuild(config))
+	await ensurePnpmSettings(targetDir, bundlerNeedsEsbuild(config), familyGlob(config.projectName))
 
 	// Turborepo task pipeline (pnpm-workspace monorepos, when opted-in)
 	if (config.turborepo) {

--- a/src/cli/generators/pnpm-workspace.ts
+++ b/src/cli/generators/pnpm-workspace.ts
@@ -14,12 +14,24 @@ export const WORKSPACE_FILE = 'pnpm-workspace.yaml'
 
 /**
  * pnpm's `minimumReleaseAge` cutoff holds back freshly published versions —
- * good against a typosquat-hijack, but it also stalls every consumer of a
- * same-day `@rtorcato/*` fix for 24h. One glob covers the whole family: pnpm
- * matches these entries with `@pnpm/config.matcher`, so there's no package list
- * to keep in sync with `@rtorcato/shared-docs`'s `FAMILY`.
+ * good against a typosquat or a hijacked account, but it also stalls every
+ * consumer of a same-day fix in a sibling package for 24h. Exempting the
+ * repo's *own* scope trades that off only for packages it already publishes.
+ *
+ * Derived from the consuming package's name rather than hardcoded: this is a
+ * public CLI, and writing one organisation's scope into a stranger's config
+ * would loosen a supply-chain guard for packages they neither use nor chose.
+ * An unscoped package gets no such setting at all — there is no "family" to
+ * infer, and guessing one would be worse than leaving it alone.
+ *
+ * One glob covers a whole scope: pnpm matches these entries with
+ * `@pnpm/config.matcher`, so there's no package list to keep in sync.
  */
-const FAMILY_GLOB = '@rtorcato/*'
+export function familyGlob(packageName: unknown): string | null {
+	const name = typeof packageName === 'string' ? packageName : ''
+	const scope = /^(@[^/]+)\//.exec(name)?.[1]
+	return scope ? `${scope}/*` : null
+}
 
 /** Bundlers that pull in esbuild, whose install script pnpm 11 refuses to run unapproved. */
 const ESBUILD_BUNDLERS = ['esbuild', 'tsup', 'vite']
@@ -59,7 +71,32 @@ interface Setting {
 	item: string
 }
 
-const SETTINGS: Setting[] = [
+/**
+ * The managed settings for one repo. A function rather than a constant because
+ * the release-age exemption is scope-derived, and a repo with no scope to
+ * derive doesn't get that setting at all.
+ */
+function settingsFor(glob: string | null): Setting[] {
+	return glob ? [...BASE_SETTINGS, releaseAgeSetting(glob)] : BASE_SETTINGS
+}
+
+function releaseAgeSetting(glob: string): Setting {
+	return {
+		label: `minimumReleaseAgeExclude: ${glob}`,
+		applies: () => true,
+		satisfied: (yaml) =>
+			(section(yaml, 'minimumReleaseAgeExclude') ?? []).some((l) => l.includes(glob)),
+		key: 'minimumReleaseAgeExclude',
+		block: `# Exempt this package's own scope from pnpm's minimumReleaseAge cutoff, so a
+# same-day fix in a sibling package is installable today rather than tomorrow.
+minimumReleaseAgeExclude:
+  - '${glob}'
+`,
+		item: `  - '${glob}'`,
+	}
+}
+
+const BASE_SETTINGS: Setting[] = [
 	{
 		label: 'verifyDepsBeforeRun: false',
 		applies: () => true,
@@ -72,18 +109,6 @@ const SETTINGS: Setting[] = [
 verifyDepsBeforeRun: false
 `,
 		item: '',
-	},
-	{
-		label: `minimumReleaseAgeExclude: ${FAMILY_GLOB}`,
-		applies: () => true,
-		satisfied: (yaml) => (section(yaml, 'minimumReleaseAgeExclude') ?? []).some(hasFamilyGlob),
-		key: 'minimumReleaseAgeExclude',
-		block: `# Exempt the @rtorcato family from pnpm's minimumReleaseAge cutoff, so a
-# same-day fix in a sibling package is installable today rather than tomorrow.
-minimumReleaseAgeExclude:
-  - '${FAMILY_GLOB}'
-`,
-		item: `  - '${FAMILY_GLOB}'`,
 	},
 	{
 		label: 'allowBuilds: esbuild',
@@ -99,13 +124,15 @@ allowBuilds:
 	},
 ]
 
-function hasFamilyGlob(line: string): boolean {
-	return line.includes(FAMILY_GLOB)
-}
-
 /** Managed settings absent from `yaml`, named as doctor reports them. */
-export function missingPnpmSettings(yaml: string, needsEsbuild: boolean): string[] {
-	return SETTINGS.filter((s) => s.applies(needsEsbuild) && !s.satisfied(yaml)).map((s) => s.label)
+export function missingPnpmSettings(
+	yaml: string,
+	needsEsbuild: boolean,
+	glob: string | null
+): string[] {
+	return settingsFor(glob)
+		.filter((s) => s.applies(needsEsbuild) && !s.satisfied(yaml))
+		.map((s) => s.label)
 }
 
 /** Insert `item` directly under an existing `key:` line, keeping the rest untouched. */
@@ -117,9 +144,13 @@ function insertUnder(yaml: string, key: string, item: string): string {
 }
 
 /** Merge every missing managed setting into `yaml` and return the new contents. */
-export function upsertPnpmSettings(yaml: string, needsEsbuild: boolean): string {
+export function upsertPnpmSettings(
+	yaml: string,
+	needsEsbuild: boolean,
+	glob: string | null
+): string {
 	let next = yaml
-	for (const setting of SETTINGS) {
+	for (const setting of settingsFor(glob)) {
 		if (!setting.applies(needsEsbuild) || setting.satisfied(next)) continue
 		if (setting.item && section(next, setting.key)) {
 			next = insertUnder(next, setting.key, setting.item)
@@ -136,11 +167,12 @@ export function upsertPnpmSettings(yaml: string, needsEsbuild: boolean): string 
  */
 export async function ensurePnpmSettings(
 	targetDir: string,
-	needsEsbuild: boolean
+	needsEsbuild: boolean,
+	glob: string | null
 ): Promise<string | null> {
 	const file = path.join(targetDir, WORKSPACE_FILE)
 	const current = (await fs.pathExists(file)) ? await fs.readFile(file, 'utf-8') : ''
-	const next = upsertPnpmSettings(current, needsEsbuild)
+	const next = upsertPnpmSettings(current, needsEsbuild, glob)
 	if (next === current) return null
 	await fs.writeFile(file, next.replace(/^\n+/, ''))
 	return WORKSPACE_FILE

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -5,6 +5,7 @@ import { hookHasUncommented } from '../../base/checks.js'
 import {
 	WORKSPACE_FILE,
 	dependsOnEsbuild,
+	familyGlob,
 	missingPnpmSettings,
 } from '../../cli/generators/pnpm-workspace.js'
 import type { CheckResult } from '../../base/types.js'
@@ -927,7 +928,7 @@ export async function checkPnpmWorkspace(dir: string, pkg: Pkg | null): Promise<
 	}
 
 	const yaml = exists ? await fs.readFile(file, 'utf-8') : ''
-	const missing = missingPnpmSettings(yaml, dependsOnEsbuild(allDeps(pkg)))
+	const missing = missingPnpmSettings(yaml, dependsOnEsbuild(allDeps(pkg)), familyGlob(pkg?.name))
 	if (missing.length === 0) {
 		return { check, status: 'ok', detail: `${WORKSPACE_FILE} carries the managed settings` }
 	}

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -26,6 +26,7 @@ import {
 	WORKSPACE_FILE,
 	dependsOnEsbuild,
 	ensurePnpmSettings,
+	familyGlob,
 } from '../../cli/generators/pnpm-workspace.js'
 import { generatePostcss } from '../../cli/generators/postcss.js'
 import { generateCypressConfig, generateVitestConfig } from '../../cli/generators/testing.js'
@@ -381,7 +382,11 @@ export const FIXERS: Fixer[] = [
 				...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
 				...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
 			}
-			const written = await ensurePnpmSettings(targetDir, dependsOnEsbuild(deps))
+			const written = await ensurePnpmSettings(
+				targetDir,
+				dependsOnEsbuild(deps),
+				familyGlob(pkg?.name)
+			)
 			return { filesWritten: written ? [written] : [] }
 		},
 	},

--- a/tests/cli/generators/pnpm-workspace.test.ts
+++ b/tests/cli/generators/pnpm-workspace.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { checkPnpmWorkspace } from '../../../src/languages/js/checks.js'
 import {
 	ensurePnpmSettings,
+	familyGlob,
 	missingPnpmSettings,
 	upsertPnpmSettings,
 } from '../../../src/cli/generators/pnpm-workspace.js'
@@ -11,13 +12,45 @@ import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
 
+/** Stand-in for a consuming repo that is not the author's. */
+const ACME = familyGlob('@acme/widgets')
+
+describe('familyGlob', () => {
+	it('derives the scope from the consuming package name', () => {
+		expect(familyGlob('@acme/widgets')).toBe('@acme/*')
+		expect(familyGlob('@rtorcato/js-common')).toBe('@rtorcato/*')
+	})
+
+	// This is a public CLI: writing one organisation's scope into a stranger's
+	// config would loosen a supply-chain guard for packages they never chose.
+	it('never invents a scope', () => {
+		expect(familyGlob('lodash')).toBeNull()
+		expect(familyGlob('')).toBeNull()
+		expect(familyGlob(undefined)).toBeNull()
+		expect(familyGlob(null)).toBeNull()
+		expect(familyGlob(42)).toBeNull()
+		// A lone '@' with no slash is not a scope.
+		expect(familyGlob('@nope')).toBeNull()
+	})
+})
+
 describe('upsertPnpmSettings', () => {
 	it('writes every managed setting into an empty file', () => {
-		const yaml = upsertPnpmSettings('', true)
+		const yaml = upsertPnpmSettings('', true, ACME)
 		expect(yaml).toContain('verifyDepsBeforeRun: false')
-		expect(yaml).toContain("- '@rtorcato/*'")
+		expect(yaml).toContain("- '@acme/*'")
 		expect(yaml).toContain('esbuild: true')
-		expect(missingPnpmSettings(yaml, true)).toEqual([])
+		expect(missingPnpmSettings(yaml, true, ACME)).toEqual([])
+	})
+
+	// An unscoped package has no family to infer, so the release-age exemption
+	// is not managed at all rather than guessed at.
+	it('omits the release-age exemption entirely for an unscoped package', () => {
+		const yaml = upsertPnpmSettings('', true, null)
+		expect(yaml).toContain('verifyDepsBeforeRun: false')
+		expect(yaml).toContain('esbuild: true')
+		expect(yaml).not.toContain('minimumReleaseAgeExclude')
+		expect(missingPnpmSettings(yaml, true, null)).toEqual([])
 	})
 
 	// The whole point of #314's "merge, don't overwrite" note: the file also
@@ -33,28 +66,28 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - tinyglobby
 `
-		const after = upsertPnpmSettings(before, true)
+		const after = upsertPnpmSettings(before, true, ACME)
 		expect(after).toContain("- 'apps/*'")
 		expect(after).toContain('core-js: false')
 		expect(after).toContain('- tinyglobby')
-		expect(after).toContain("- '@rtorcato/*'")
+		expect(after).toContain("- '@acme/*'")
 		// esbuild was already approved, so allowBuilds is left exactly as found.
 		expect(after.match(/esbuild: true/g)).toHaveLength(1)
 	})
 
 	it('respects an explicit verifyDepsBeforeRun rather than resetting it', () => {
-		const after = upsertPnpmSettings('verifyDepsBeforeRun: true\n', false)
+		const after = upsertPnpmSettings('verifyDepsBeforeRun: true\n', false, ACME)
 		expect(after).toContain('verifyDepsBeforeRun: true')
 		expect(after).not.toContain('verifyDepsBeforeRun: false')
 	})
 
 	it('leaves allowBuilds alone when no bundler needs esbuild', () => {
-		expect(upsertPnpmSettings('', false)).not.toContain('allowBuilds')
+		expect(upsertPnpmSettings('', false, ACME)).not.toContain('allowBuilds')
 	})
 
 	it('is idempotent', () => {
-		const once = upsertPnpmSettings('', true)
-		expect(upsertPnpmSettings(once, true)).toBe(once)
+		const once = upsertPnpmSettings('', true, ACME)
+		expect(upsertPnpmSettings(once, true, ACME)).toBe(once)
 	})
 })
 
@@ -67,12 +100,26 @@ describe('checkPnpmWorkspace', () => {
 	it('flags an existing workspace file that is missing the settings', async () => {
 		const dir = newTmpDir()
 		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
-		const before = await checkPnpmWorkspace(dir, {})
+		const pkg = { name: '@acme/widgets' }
+		const before = await checkPnpmWorkspace(dir, pkg)
 		expect(before.status).toBe('drift')
-		expect(before.detail).toContain('@rtorcato/*')
+		expect(before.detail).toContain('@acme/*')
 
-		await ensurePnpmSettings(dir, false)
-		expect((await checkPnpmWorkspace(dir, {})).status).toBe('ok')
+		await ensurePnpmSettings(dir, false, ACME)
+		expect((await checkPnpmWorkspace(dir, pkg)).status).toBe('ok')
+	})
+
+	// The regression this guards: doctor used to report a stranger's repo as
+	// drifted for not carrying the author's own scope.
+	it('never asks an unrelated repo for someone else’s scope', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		const r = await checkPnpmWorkspace(dir, { name: '@acme/widgets' })
+		expect(r.detail).not.toContain('@rtorcato')
+
+		// And an unscoped package is never asked for the setting at all.
+		const plain = await checkPnpmWorkspace(dir, { name: 'widgets' })
+		expect(plain.detail).not.toContain('minimumReleaseAgeExclude')
 	})
 
 	// A pnpm repo with no workspace file hasn't drifted — it never opted in — so


### PR DESCRIPTION
```diff
- const FAMILY_GLOB = '@rtorcato/*'
+ export function familyGlob(packageName: unknown): string | null
```

## The problem

`src/cli/generators/pnpm-workspace.ts` hardcoded `@rtorcato/*` and wrote it
into **every consumer's** `pnpm-workspace.yaml`. `checkPnpmWorkspace` then
reported `status: 'drift'` — exit 1, a **failing CI** — for any pnpm repo
that didn't carry it.

This is a public CLI, so that put one organisation's scope into strangers'
configs. The setting is not cosmetic either: `minimumReleaseAgeExclude`
exempts a scope from pnpm's hold-back on freshly published versions, which is
protection against a typosquat or a hijacked publisher account. Loosening it
for packages you publish yourself is a reasonable trade — same-day fixes are
installable today rather than tomorrow. Loosening it for packages a repo
neither uses nor chose is somebody else's trade imposed on them.

Shipped in 3.0.0 via #314.

## The fix

Derive the glob from the consuming package's own name:

| Package | Manages |
|---|---|
| `@rtorcato/js-common` | `@rtorcato/*` |
| `@acme/widgets` | `@acme/*` |
| `widgets` (unscoped) | *nothing — setting not managed* |

An unscoped package has no family to infer, so the exemption is dropped
entirely rather than guessed at. Guessing would be worse than leaving it
alone.

**Behaviour for this repo and its siblings is unchanged** — they are all
`@rtorcato/*` and derive exactly what was hardcoded.

## Shape

`missingPnpmSettings`, `upsertPnpmSettings` and `ensurePnpmSettings` now take
the glob explicitly, and the managed list is built per-repo rather than being
a module constant, because one of its three entries is conditional.

## Testing

598 passing. New cases cover the derivation (including the things that must
*not* yield a scope: unscoped, empty, `undefined`, `null`, non-string, and a
bare `@nope` with no slash), the unscoped path omitting the setting
altogether, and a regression test asserting doctor never reports an unrelated
repo as drifted for missing someone else's scope.

## Related, not fixed here

Two more things in `docs-site.ts` write `@rtorcato` specifics into generated
projects — a theme comment, and `'@rtorcato/repo-tooling': '^2.47.0'` pinned
two majors behind current. The version pin looks like a genuine bug worth its
own issue; say the word and I'll file it.