### PR TITLE
fix(docs-site): derive the self-pin from the running version

### DIFF
--- a/src/cli/generators/docs-site.ts
+++ b/src/cli/generators/docs-site.ts
@@ -1,10 +1,25 @@
 import path from 'node:path'
 import fs from 'fs-extra'
+import selfPackageJson from '../../../package.json' with { type: 'json' }
 import { copyPreset, PRESETS } from '../utils/copy-preset.js'
 import { buildBadgeRow, parseRepository } from './badges.js'
 import { inferSubpathsFromExports } from './treeshake.js'
 
 type Pkg = Record<string, unknown> | null
+
+/**
+ * What a scaffolded docs site should depend on for *this* CLI — read from the
+ * running version rather than written down, because a literal here goes stale
+ * silently. It had drifted to `^2.47.0`, two majors behind, so every site
+ * scaffolded since was handed a pre-rename version predating the peer-dependency
+ * split.
+ *
+ * The floor is the exact running version, not `^<major>.0.0`: the config being
+ * generated is the one this version emits, and claiming compatibility back to
+ * the start of the major would be the same over-wide-range problem doctor's
+ * `Config schema versions` check exists to catch (#330).
+ */
+const SELF_RANGE = `^${selfPackageJson.version}`
 
 /**
  * Docs-site (Docusaurus) generator — the Phase 2 counterpart to the shared
@@ -259,7 +274,7 @@ const TSCONFIG = `// Improves IDE type-checking; not used by \`docusaurus start/
 
 function customCss(accent: { light: string; dark: string }): string {
 	// Import the shared tokens, then override only the accent (per #54's model).
-	return `/* Site theme: shared @rtorcato tokens + this project's accent. */
+	return `/* Site theme: the shared design tokens + this project's accent. */
 @import "./_jt-tokens.css";
 
 :root {
@@ -277,7 +292,7 @@ function customCss(accent: { light: string; dark: string }): string {
 function docsPackageJson(meta: SiteMeta, typedoc: boolean): string {
 	const typedocDevDeps = typedoc
 		? {
-				'@rtorcato/repo-tooling': '^2.47.0',
+				'@rtorcato/repo-tooling': SELF_RANGE,
 				'docusaurus-plugin-typedoc': '^1.4.0',
 				typedoc: '^0.28.0',
 				'typedoc-plugin-markdown': '^4.9.0',
@@ -316,7 +331,7 @@ function docsPackageJson(meta: SiteMeta, typedoc: boolean): string {
 			'@docusaurus/tsconfig': '^3.8.1',
 			'@docusaurus/types': '^3.10.2',
 			'@playwright/test': '^1.49.0',
-			'@rtorcato/repo-tooling': '^2.47.0',
+			'@rtorcato/repo-tooling': SELF_RANGE,
 			'@types/react': '^19.0.0',
 			typescript: '~5.6.3',
 			...typedocDevDeps,

--- a/tests/cli/docs-site.test.ts
+++ b/tests/cli/docs-site.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
+import selfPackageJson from '../../package.json' with { type: 'json' }
 import { runDoctor } from '../../src/cli/commands/doctor.js'
 import { generateDocsSite } from '../../src/cli/generators/docs-site.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
@@ -43,6 +44,14 @@ describe('generateDocsSite', () => {
 		expect(docsPkg.scripts.build).toMatch(/sync-changelog/)
 		expect(docsPkg.scripts['test:e2e']).toBe('playwright test')
 		expect(docsPkg.devDependencies['@playwright/test']).toBeTruthy()
+
+		// The guard that stops this rotting again: the self-pin handed to a
+		// scaffolded site must track the running version. It had been a literal
+		// `^2.47.0` — two majors stale — so new sites were given a pre-rename
+		// version predating the peer-dependency split.
+		expect(docsPkg.devDependencies['@rtorcato/repo-tooling']).toBe(
+			`^${selfPackageJson.version}`
+		)
 
 		// Smoke test reuses the shipped preset and targets the site's base path.
 		const pw = await fs.readFile(join(dir, 'apps/docs/playwright.config.ts'), 'utf-8')


### PR DESCRIPTION
Follow-up to #335, same class of problem: a literal in a generator that goes
stale without anything noticing.

## The bug

A scaffolded docs site was handed:

```json
"@rtorcato/repo-tooling": "^2.47.0"
```

Hardcoded, and **two majors behind**. Every site generated since 3.0.0 got a
pre-rename version — one that also predates the peer-dependency split in
2.0.0, so a new project would install a tool that behaves differently from
the one that scaffolded it.

## The fix

Read the running version instead, using the same
`import ... with { type: 'json' }` the CLI already uses to serve `--version`.
It cannot go stale again.

Verified against the **built** output, not just the source — ran
`generateDocsSite` from `dist/` to confirm the relative JSON path resolves one
directory deeper than `index.ts`:

```
built CLI emits self-pin: ^3.2.0
```

The floor is the exact running version rather than `^<major>.0.0`. The config
being generated is the one *this* version emits, and claiming compatibility
back to the start of the major is precisely the over-wide-range problem
doctor's `Config schema versions` check exists to catch (#330).

## Also

Drops `@rtorcato` from the generated theme comment — it gets written into a
consumer's own `custom.css` and names an org with nothing to do with their
project.

**Left alone deliberately:** `_jt-tokens.css` and the `--jt-*` variable prefix
are pre-rename initials, but renaming them would break the `@import` in every
site already scaffolded. Worth doing behind a migration, not as a drive-by.

## Testing

New assertion that the emitted pin tracks the running version, so a future
release cannot quietly reintroduce a stale literal. 598 passing on top of
current main.