### PR TITLE
fix(docs-theme): let code blocks follow the theme in light mode

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -153,8 +153,9 @@ const config: Config = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} Richard Torcato. Built with Docusaurus.`,
     },
+    // `theme` is the LIGHT-mode Prism theme, `darkTheme` the dark one (#324).
     prism: {
-      theme: prismThemes.vsDark,
+      theme: prismThemes.vsLight,
       darkTheme: prismThemes.vsDark,
       additionalLanguages: ['bash', 'json', 'typescript'],
     },

--- a/apps/docs/src/css/theme.css
+++ b/apps/docs/src/css/theme.css
@@ -185,10 +185,15 @@ body,
 }
 
 /* ---------- Code ----------
-   Prism is vsDark in both light & dark mode (to match the navy aesthetic),
-   so fenced code blocks must stay dark in BOTH themes — otherwise the pale
-   vsDark tokens wash out on a light background. Inline code (the `code` pills)
-   keeps the themed --ifm-code-background and stays readable. */
+   Every surface and text colour here comes from the theme tokens, which already
+   flip between light and dark — the values that used to be hardcoded (#0c111b,
+   #dfe5ee, #94a1b4) were simply the dark side of tokens that existed all along.
+
+   This pairs with `prism.theme: vsLight` / `prism.darkTheme: vsDark` in
+   docusaurus.config.ts. The two must move together (#324): vsDark tokens on a
+   light surface are pale and unreadable, which is why the background was pinned
+   dark in both modes in the first place. If a fenced block still renders dark in
+   light mode, that config is the thing to check. */
 code {
 	background: var(--jt-code-bg);
 	border: 1px solid var(--jt-border);
@@ -202,23 +207,30 @@ div[class*="codeBlockContainer"],
 pre[class*="language-"] {
 	border: 1px solid var(--jt-border);
 	border-radius: 12px;
-	background: #0c111b !important;
+	/* !important beats the inline background the Prism theme sets on the <pre>. */
+	background: var(--jt-code-bg) !important;
 }
 .theme-code-block code,
 pre[class*="language-"] code {
 	background: transparent !important;
 	border: none !important;
-	color: #dfe5ee;
+	/* Base colour for anything Prism does not tokenise. */
+	color: var(--jt-text);
 }
 div[class*="codeBlockTitle"] {
-	background: #0a0e16 !important;
-	color: #94a1b4 !important;
+	background: var(--jt-surface2) !important;
+	color: var(--jt-muted) !important;
 	border-bottom: 1px solid var(--jt-border);
+}
+/* In dark the title sits a shade *below* the block; in light there is no token
+   darker than --jt-code-bg, so the bottom border does the separating instead. */
+[data-theme="dark"] div[class*="codeBlockTitle"] {
+	background: var(--jt-bg) !important;
 }
 [data-theme="light"] .theme-code-block,
 [data-theme="light"] div[class*="codeBlockContainer"],
 [data-theme="light"] pre[class*="language-"] {
-	border-color: rgba(12, 18, 28, 0.16);
+	border-color: var(--jt-border2);
 	box-shadow: 0 8px 24px -18px rgba(12, 18, 28, 0.5);
 }
 

--- a/src/cli/generators/docs-site.ts
+++ b/src/cli/generators/docs-site.ts
@@ -213,8 +213,12 @@ ${typedocPlugins}    [
       ],
       copyright: \`Copyright © \${new Date().getFullYear()} ${meta.title}. Built with Docusaurus.\`,
     },
+    // \`theme\` is the LIGHT-mode Prism theme and \`darkTheme\` the dark one. Both
+    // were vsDark here, which is why the shared stylesheet had to pin fenced
+    // blocks dark in light mode too (#324). Keep this pairing and the CSS in
+    // step — vsDark tokens on a light surface are unreadable.
     prism: {
-      theme: prismThemes.vsDark,
+      theme: prismThemes.vsLight,
       darkTheme: prismThemes.vsDark,
       additionalLanguages: ['bash', 'json', 'typescript'],
     },

--- a/tests/cli/docs-site.test.ts
+++ b/tests/cli/docs-site.test.ts
@@ -54,6 +54,12 @@ describe('generateDocsSite', () => {
 		expect(config).toContain("url: 'https://rtorcato.github.io'")
 		expect(config).toContain("baseUrl: '/js-tooling/'")
 
+		// #324: `theme` is the LIGHT-mode Prism theme. Both slots were vsDark, which
+		// forced the shared stylesheet to pin fenced blocks dark in light mode too —
+		// and the wrong pairing was copied into ten sites before anyone noticed.
+		expect(config).toContain('theme: prismThemes.vsLight')
+		expect(config).toContain('darkTheme: prismThemes.vsDark')
+
 		// Workflow drives the shared reusable deploy with the docs package filter.
 		const wf = await fs.readFile(join(dir, '.github/workflows/docs.yml'), 'utf-8')
 		expect(wf).toContain('rtorcato/repo-tooling/.github/workflows/docs-deploy.yml@main')

--- a/tooling/docusaurus/theme.css
+++ b/tooling/docusaurus/theme.css
@@ -185,10 +185,15 @@ body,
 }
 
 /* ---------- Code ----------
-   Prism is vsDark in both light & dark mode (to match the navy aesthetic),
-   so fenced code blocks must stay dark in BOTH themes — otherwise the pale
-   vsDark tokens wash out on a light background. Inline code (the `code` pills)
-   keeps the themed --ifm-code-background and stays readable. */
+   Every surface and text colour here comes from the theme tokens, which already
+   flip between light and dark — the values that used to be hardcoded (#0c111b,
+   #dfe5ee, #94a1b4) were simply the dark side of tokens that existed all along.
+
+   This pairs with `prism.theme: vsLight` / `prism.darkTheme: vsDark` in
+   docusaurus.config.ts. The two must move together (#324): vsDark tokens on a
+   light surface are pale and unreadable, which is why the background was pinned
+   dark in both modes in the first place. If a fenced block still renders dark in
+   light mode, that config is the thing to check. */
 code {
 	background: var(--jt-code-bg);
 	border: 1px solid var(--jt-border);
@@ -202,23 +207,30 @@ div[class*="codeBlockContainer"],
 pre[class*="language-"] {
 	border: 1px solid var(--jt-border);
 	border-radius: 12px;
-	background: #0c111b !important;
+	/* !important beats the inline background the Prism theme sets on the <pre>. */
+	background: var(--jt-code-bg) !important;
 }
 .theme-code-block code,
 pre[class*="language-"] code {
 	background: transparent !important;
 	border: none !important;
-	color: #dfe5ee;
+	/* Base colour for anything Prism does not tokenise. */
+	color: var(--jt-text);
 }
 div[class*="codeBlockTitle"] {
-	background: #0a0e16 !important;
-	color: #94a1b4 !important;
+	background: var(--jt-surface2) !important;
+	color: var(--jt-muted) !important;
 	border-bottom: 1px solid var(--jt-border);
+}
+/* In dark the title sits a shade *below* the block; in light there is no token
+   darker than --jt-code-bg, so the bottom border does the separating instead. */
+[data-theme="dark"] div[class*="codeBlockTitle"] {
+	background: var(--jt-bg) !important;
 }
 [data-theme="light"] .theme-code-block,
 [data-theme="light"] div[class*="codeBlockContainer"],
 [data-theme="light"] pre[class*="language-"] {
-	border-color: rgba(12, 18, 28, 0.16);
+	border-color: var(--jt-border2);
 	box-shadow: 0 8px 24px -18px rgba(12, 18, 28, 0.5);
 }
 


### PR DESCRIPTION
Closes #324.

In light mode every fenced block rendered on the dark navy surface — a black
slab in the middle of a white page. Ten sibling docs sites carry the same copy.

## Both halves had to move

The config set Docusaurus' **light**-mode Prism slot to a dark theme:

```ts
theme: prismThemes.vsDark,      // <- this slot is the LIGHT theme
darkTheme: prismThemes.vsDark,
```

and `theme.css` then pinned the surface dark unconditionally to stop the pale
vsDark tokens washing out on white. Flipping either one alone makes things
worse: the `!important` background beats a light Prism theme, and dropping the
background leaves unreadable pale-on-white tokens.

## The CSS half is almost pure deletion

The hardcoded values turned out to be exactly the **dark side of tokens that
already existed and already flip per theme**:

| Was | Is | Light | Dark |
|---|---|---|---|
| `#0c111b` | `--jt-code-bg` | `#f3f6f9` | `#0c111b` |
| `#dfe5ee` | `--jt-text` | `#374253` | `#dfe5ee` |
| `#94a1b4` | `--jt-muted` | `#5b6675` | `#94a1b4` |
| `#0a0e16` | `--jt-bg` (dark-only rule) | — | `#0a0e16` |

No new tokens, so a consumer running an older copy of `_jt-tokens.css` keeps
working.

## Fixed at the source

`src/cli/generators/docs-site.ts` emitted the bad pairing — that is how it
reached ten separate configs. New sites now get `vsLight`/`vsDark`, and a test
asserts the pairing so it cannot drift back.

Also updated this repo's own `apps/docs` config and its byte-identical copy of
`theme.css`.

## Verified in a real browser

Not just the stylesheet — served the built site and measured computed styles
in both modes.

**Light** — surface `rgb(243,246,249)`, tokens `rgb(0,0,0)`. The CSS
`!important` correctly beats vsLight's inline white background, so the block
sits on the themed grey rather than pure white.

**Dark** — surface `rgb(12,17,27)`, tokens `rgb(156,220,254)`, title
`rgb(10,14,22)` on `rgb(148,161,180)`. **Every dark value is byte-identical to
the literal it replaced**, so there is no visual change in the default mode.

## Deliberately not done

- **The suggested doctor check.** The generator now owns the pairing, so a
  check is belt-and-braces for already-scaffolded sites. Worth revisiting if
  the nine consumers hand-patch instead of taking the corrected copy.
- **Preset owning the whole `prism` block.** That would mean the preset
  depending on `prism-react-renderer` and every consumer deleting their block
  — a migration, not a fix.
- **The nine consumer repos**, which have their own issues pointing here.
- **shared-docs** `CommandBlock.module.css` / `InstallTabs.module.css` hardcode
  the same `#0c111b`; tracked in that repo.

598 tests passing.