### PR TITLE
fix(deps): narrow the biome peer range to ^2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
 		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
-		"@biomejs/biome": "^2.0.0",
+		"@biomejs/biome": "^2.5.0",
 		"@commitlint/cli": "^20.0.0 || ^21.0.0",
 		"@commitlint/config-conventional": "^21.2.0",
 		"@commitlint/types": "^21.2.0",


### PR DESCRIPTION
Closes the underlying defect behind #330.

```diff
  "peerDependencies": {
-   "@biomejs/biome": "^2.0.0",
+   "@biomejs/biome": "^2.5.0",
```

The shipped preset `tooling/biome/biome.json` targets Biome 2.5 — its
`$schema` says `2.5.0` and it uses `linter.rules.preset`, a 2.5 key. The peer
range claimed support back to 2.0, so any consumer resolving 2.0–2.4 got a
hard config error with nothing pointing at the range:

```
× Found an unknown key `preset`.
i Known keys: recommended, a11y, complexity, correctness, nursery,
  performance, security, style, suspicious
```

js-common hit exactly this on `^2.3.0` while migrating to the renamed
package, and had to bump Biome before its lint would pass.

## Note on tracking

#330 was auto-closed by #333, which added the *detection* rather than the
fix — my "Closes #330" on that PR was wrong. Doctor's `Config schema
versions` check has been reporting this on every run since. After this change
it reports:

```
Config schema versions — ok
  1 config schema within the declared version range
```

The check confirming its own fix, same as the `Git dependencies` one did in
#334.

## Scope

Only the floor moves. The devDependency stays `^2.5.5`, and no config
changes — the preset was already correct, the range was the lie.

598 tests passing.