### PR TITLE
fix(commitlint): ignore bot commits so dependabot PRs stop failing

### DIFF
--- a/apps/docs/docs/reference/commitlint.md
+++ b/apps/docs/docs/reference/commitlint.md
@@ -13,6 +13,14 @@ export default config
 
 The preset enforces [Conventional Commits](https://www.conventionalcommits.org/) with stricter subject-line length limits.
 
+## Skipped commits
+
+Two kinds of commit are ignored outright:
+
+- anything containing `[skip ci]` (semantic-release's own release commits)
+- bot commits, matched on a `Signed-off-by: …[bot]` trailer — Dependabot and
+  Renovate bodies are machine-written blocks that never wrap at 72 characters
+
 ## With Husky
 
 The `setup` wizard wires Husky + lint-staged + commitlint automatically. To add it manually:

--- a/tests/tooling/commitlint.test.ts
+++ b/tests/tooling/commitlint.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import config from '../../tooling/commitlint/commitlint.mjs'
+
+const isIgnored = (commit: string) => (config.ignores ?? []).some((predicate) => predicate(commit))
+
+describe('commitlint ignores', () => {
+	it('ignores release commits marked [skip ci]', () => {
+		expect(isIgnored('chore(release): 3.2.2 [skip ci]')).toBe(true)
+	})
+
+	it('ignores dependabot commits with unwrappable YAML bodies', () => {
+		const commit = [
+			'chore(deps): bump @docusaurus/types from 3.9.2 to 3.9.3',
+			'',
+			'Updates `@docusaurus/types` from 3.9.2 to 3.9.3.',
+			'',
+			'updated-dependencies:',
+			'- dependency-name: "@docusaurus/types"',
+			'  dependency-version: 3.9.3',
+			'  dependency-type: direct:development',
+			'  update-type: version-update:semver-patch',
+			'',
+			'Signed-off-by: dependabot[bot] <support@github.com>',
+		].join('\n')
+		expect(isIgnored(commit)).toBe(true)
+	})
+
+	it('ignores renovate commits', () => {
+		expect(
+			isIgnored('chore(deps): update node\n\nSigned-off-by: renovate[bot] <bot@renovateapp.com>')
+		).toBe(true)
+	})
+
+	it('still lints a human commit that merely mentions a bot', () => {
+		expect(isIgnored('fix(ci): stop dependabot[bot] from reopening the same PR')).toBe(false)
+	})
+
+	it('still lints an ordinary commit', () => {
+		expect(isIgnored('feat(swift): add DocC check\n\nCloses #311')).toBe(false)
+	})
+})

--- a/tooling/commitlint/commitlint.mjs
+++ b/tooling/commitlint/commitlint.mjs
@@ -1,6 +1,16 @@
 export default {
 	extends: ["@commitlint/config-conventional"],
-	ignores: [(commit) => commit.includes("[skip ci]")],
+	ignores: [
+		(commit) => commit.includes("[skip ci]"),
+		// Bot commit bodies are machine-written blocks (dependabot's
+		// `- dependency-name: …` YAML) that never wrap at 72, so every bot PR
+		// failed body-max-line-length. commitlint can't relax a single rule per
+		// commit, so skip bot commits wholesale — squash-merge uses the PR
+		// title, which is still linted on the merge commit.
+		// ponytail: matches the trailer, not a bare "[bot]", so a human commit
+		// that merely mentions a bot is still linted.
+		(commit) => /^Signed-off-by: .*\[bot\]/m.test(commit),
+	],
 	rules: {
 		// Enforce strict type validation
 		"type-enum": [


### PR DESCRIPTION
Closes #339

## Problem

Every Dependabot PR in a repo consuming the shared commitlint preset fails
`body-max-line-length`. The generated body is a machine-written YAML block
(`- dependency-name: "@docusaurus/types"` …) that will never wrap at 72.

Cosmetic — squash-merge uses the PR title/body so `main` stays clean, and
`commitlint` isn't a required check — but it's a permanent red X on every bot PR.

## Fix

A second `ignores` predicate in `tooling/commitlint/commitlint.mjs`.

commitlint can't relax a single rule for a subset of commits, so bot commits are
ignored wholesale rather than only loosening `body-max-line-length`. The
squash-merge commit is built from the PR title, so `type-enum` / `subject-*`
still get enforced on what actually lands on `main`.

The predicate matches the `Signed-off-by: …[bot]` trailer, not a bare `[bot]`,
so a human commit that merely mentions a bot is still linted (covered by a test).

Consumers re-export this config (`export { default } from '@rtorcato/repo-tooling/commitlint/config'`),
so the fix reaches every repo on upgrade — no per-repo change.

## Verification

`tests/tooling/commitlint.test.ts` — 5 cases: `[skip ci]`, a real Dependabot
body, a Renovate trailer, a human commit mentioning a bot, an ordinary commit.