### PR TITLE
fix(presets): make every JS preset survive a real install and verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       # prints what was skipped so a green PR never implies full preset coverage.
       - name: 🧩 Scaffold + install + verify the app presets (push to main only)
         run: |
-          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if true; then  # TEMP: prove the app presets on this PR before trusting the gate
             for preset in node-api web-app react-app nextjs-app; do
               node scripts/integration/preset-lifecycle.mjs "$preset"
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,21 @@ jobs:
       - name: 🧩 Scaffold + install + verify the library preset
         run: node scripts/integration/preset-lifecycle.mjs library
 
+      # The app presets each cost a full install + build, so on PRs only the
+      # library preset runs (it's the published one, and the #91/#92 packaging
+      # bugs all landed there). The rest gate on push-to-main. The else branch
+      # prints what was skipped so a green PR never implies full preset coverage.
+      - name: 🧩 Scaffold + install + verify the app presets (push to main only)
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            for preset in node-api web-app react-app nextjs-app; do
+              node scripts/integration/preset-lifecycle.mjs "$preset"
+            done
+          else
+            echo "::notice::Skipped node-api, web-app, react-app and nextjs-app —" \
+              "app presets run on push to main only. Only 'library' was verified here."
+          fi
+
   # Build
   build:
     runs-on: ubuntu-latest

--- a/scripts/integration/preset-lifecycle.mjs
+++ b/scripts/integration/preset-lifecycle.mjs
@@ -20,9 +20,6 @@ const REPO = process.cwd()
 const CLI = path.join(REPO, 'dist', 'cli', 'index.js')
 const PRESET = process.argv[2] ?? 'library'
 
-// Only `library` is wired end-to-end today; other presets join once green (#99).
-const SUPPORTED = new Set(['library'])
-
 function run(cmd, args, cwd) {
 	console.log(`\n$ ${cmd} ${args.join(' ')}${cwd && cwd !== REPO ? `  (cwd=${cwd})` : ''}`)
 	execFileSync(cmd, args, { stdio: 'inherit', cwd: cwd ?? REPO })
@@ -33,8 +30,121 @@ function fail(msg) {
 	process.exit(1)
 }
 
-if (!SUPPORTED.has(PRESET))
-	fail(`preset "${PRESET}" is not wired for integration yet (have: ${[...SUPPORTED].join(', ')})`)
+const write = (dir, rel, body) => {
+	const file = path.join(dir, rel)
+	fs.mkdirSync(path.dirname(file), { recursive: true })
+	fs.writeFileSync(file, body)
+}
+
+// A plain TS entry + one test. The base tsconfig excludes *.test.ts, so the
+// test is exercised by vitest, not tsc.
+const seedNodeEntry = (dir) => {
+	write(dir, 'src/index.ts', 'export const greet = (name: string): string => `hello ${name}`\n')
+	write(
+		dir,
+		'src/index.test.ts',
+		"import { expect, it } from 'vitest'\nimport { greet } from './index'\n\nit('greets', () => {\n\texpect(greet('world')).toBe('hello world')\n})\n"
+	)
+}
+
+// `vite build` on an app (as opposed to library mode) resolves from index.html,
+// so a bare src/ entry is not enough.
+const seedWebEntry = (dir) => {
+	seedNodeEntry(dir)
+	write(
+		dir,
+		'index.html',
+		'<!doctype html>\n<html lang="en">\n\t<head>\n\t\t<meta charset="utf-8" />\n\t\t<title>probe</title>\n\t</head>\n\t<body>\n\t\t<div id="root"></div>\n\t\t<script type="module" src="/src/main.ts"></script>\n\t</body>\n</html>\n'
+	)
+	write(
+		dir,
+		'src/main.ts',
+		"import { greet } from './index'\n\nconst root = document.querySelector('#root')\nif (root) root.textContent = greet('world')\n"
+	)
+}
+
+// Exercises the jsx transform, .tsx linting and a real react-dom mount, which is
+// what distinguishes react-app from web-app.
+const seedReactEntry = (dir) => {
+	write(
+		dir,
+		'src/App.tsx',
+		'export const App = ({ name }: { name: string }) => <h1>hello {name}</h1>\n'
+	)
+	write(
+		dir,
+		'src/App.test.tsx',
+		"import { expect, it } from 'vitest'\nimport { App } from './App'\n\nit('builds an element', () => {\n\texpect(App({ name: 'world' }).props.children).toContain('hello ')\n})\n"
+	)
+	write(
+		dir,
+		'src/main.tsx',
+		"import { createRoot } from 'react-dom/client'\nimport { App } from './App'\n\ncreateRoot(document.querySelector('#root') as HTMLElement).render(<App name=\"world\" />)\n"
+	)
+	write(
+		dir,
+		'index.html',
+		'<!doctype html>\n<html lang="en">\n\t<head>\n\t\t<meta charset="utf-8" />\n\t\t<title>probe</title>\n\t</head>\n\t<body>\n\t\t<div id="root"></div>\n\t\t<script type="module" src="/src/main.tsx"></script>\n\t</body>\n</html>\n'
+	)
+}
+
+// The next tsconfig includes app/ and next-env.d.ts; the eslint preset's
+// @next/next rules only fire on a real page/component tree.
+const seedNextEntry = (dir) => {
+	write(dir, 'next-env.d.ts', '/// <reference types="next" />\n')
+	write(dir, 'app/page.tsx', 'export default function Page() {\n\treturn <h1>hello world</h1>\n}\n')
+	write(
+		dir,
+		'app/layout.tsx',
+		'export default function Layout({ children }: { children: React.ReactNode }) {\n\treturn (\n\t\t<html lang="en">\n\t\t\t<body>{children}</body>\n\t\t</html>\n\t)\n}\n'
+	)
+	write(
+		dir,
+		'src/page.test.tsx',
+		"import { expect, it } from 'vitest'\nimport Page from '../app/page'\n\nit('renders a heading', () => {\n\texpect(Page().type).toBe('h1')\n})\n"
+	)
+}
+
+/**
+ * Per-preset lifecycle. `seed` writes the source a real consumer would bring
+ * (the presets are tooling-only — they scaffold no app code). `appDeps` are that
+ * same consumer's runtime deps: anything the *tooling* needs belongs in the
+ * generator's dependency list, not here, so a gap there fails this test rather
+ * than being papered over.
+ */
+const PRESETS = {
+	library: { seed: seedNodeEntry, build: true },
+	'node-api': { seed: seedNodeEntry, build: true },
+	'web-app': { seed: seedWebEntry, build: true },
+	'react-app': {
+		seed: seedReactEntry,
+		build: true,
+		appDeps: {
+			react: '^19.0.0',
+			'react-dom': '^19.0.0',
+			'@types/react': '^19.0.0',
+			'@types/react-dom': '^19.0.0',
+		},
+	},
+	// bundler: 'none' — the preset emits no build script, so there is nothing to
+	// run here. Wiring up `next build` would be testing Next.js, not the scaffold.
+	'nextjs-app': {
+		seed: seedNextEntry,
+		build: false,
+		appDeps: {
+			next: '^16.0.0',
+			react: '^19.0.0',
+			'react-dom': '^19.0.0',
+			'@types/react': '^19.0.0',
+		},
+	},
+}
+
+const spec = PRESETS[PRESET]
+if (!spec)
+	fail(
+		`preset "${PRESET}" is not wired for integration yet (have: ${Object.keys(PRESETS).join(', ')})`
+	)
 if (!fs.existsSync(CLI)) fail(`CLI not built at ${CLI} — run "pnpm build-cli" first`)
 
 const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jst-pack-'))
@@ -50,26 +160,18 @@ try {
 	// 2. Scaffold the preset (files only; we install ourselves after repointing the dep).
 	run('node', [CLI, 'setup', '--preset', PRESET, '--directory', projectDir, '--skip-install'])
 
-	// 3. Repoint @rtorcato/repo-tooling at the local tarball.
+	// 3. Repoint @rtorcato/repo-tooling at the local tarball, and add the app deps
+	//    a real consumer of this preset would already have.
 	const pkgPath = path.join(projectDir, 'package.json')
 	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
 	if (!pkg.devDependencies?.['@rtorcato/repo-tooling'])
 		fail('scaffold has no @rtorcato/repo-tooling devDependency')
 	pkg.devDependencies['@rtorcato/repo-tooling'] = `file:${tarball}`
+	if (spec.appDeps) pkg.dependencies = { ...pkg.dependencies, ...spec.appDeps }
 	fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`)
 
-	// 4. Seed what a real consumer writes: an entry module + one test. The base
-	// tsconfig excludes *.test.ts, so the test is exercised by vitest, not tsc.
-	const srcDir = path.join(projectDir, 'src')
-	fs.mkdirSync(srcDir, { recursive: true })
-	fs.writeFileSync(
-		path.join(srcDir, 'index.ts'),
-		'export const greet = (name: string): string => `hello ${name}`\n'
-	)
-	fs.writeFileSync(
-		path.join(srcDir, 'index.test.ts'),
-		"import { expect, it } from 'vitest'\nimport { greet } from './index'\n\nit('greets', () => {\n\texpect(greet('world')).toBe('hello world')\n})\n"
-	)
+	// 4. Seed what a real consumer writes: an entry module + one test.
+	spec.seed(projectDir)
 
 	// 5. git init so husky's `prepare` hook has a repo to attach to.
 	run('git', ['init', '-q'], projectDir)
@@ -79,10 +181,14 @@ try {
 
 	// 7. Format generated files — mirrors what `setup` does post-install (the
 	//    scaffold's biome/prettier config; templates are hand-written).
-	run('pnpm', ['exec', 'biome', 'check', '--write', '.'], projectDir)
+	const formatter = fs.existsSync(path.join(projectDir, 'biome.jsonc'))
+		? ['exec', 'biome', 'check', '--write', '.']
+		: ['exec', 'prettier', '--write', '.']
+	run('pnpm', formatter, projectDir)
 
 	// 8. Build.
-	run('pnpm', ['build'], projectDir)
+	if (spec.build) run('pnpm', ['build'], projectDir)
+	else console.log(`\nℹ️  ${PRESET} has no build script (bundler: none) — skipping build`)
 
 	// 9. Every path the package advertises (main/module/types/exports) must exist
 	//    on disk after the build — the #92 exports/output mismatch class.
@@ -102,9 +208,15 @@ try {
 	const missing = [...advertised].filter((rel) => !fs.existsSync(path.join(projectDir, rel)))
 	if (missing.length > 0)
 		fail(`package.json points at files that don't exist after build:\n  ${missing.join('\n  ')}`)
-	console.log(`\n✅ all ${advertised.size} advertised entry paths exist`)
+	// App presets advertise nothing (they're not published), so this check is
+	// vacuous for them — say so rather than printing a reassuring "all 0".
+	console.log(
+		advertised.size > 0
+			? `\n✅ all ${advertised.size} advertised entry paths exist`
+			: `\nℹ️  ${PRESET} advertises no entry paths (not a published package) — nothing to check`
+	)
 
-	// 10. Full verify chain (typecheck + lint + test + publint for the library preset).
+	// 10. Full verify chain (typecheck + lint + test, plus publint/attw on library).
 	run('pnpm', ['verify'], projectDir)
 
 	console.log(`\n✅ ${PRESET} preset lifecycle passed`)

--- a/src/cli/generators/linting.ts
+++ b/src/cli/generators/linting.ts
@@ -52,7 +52,18 @@ export async function generateESLintConfig(config: ProjectConfig, targetDir: str
 
 	const configType = config.linting.eslintConfig || 'base'
 
-	const eslintConfig = `import { default as config } from '@rtorcato/repo-tooling/eslint/${configType}'
+	// eslint/nextjs is a fragment: it registers the @next/next plugin and its
+	// rules but sets no parser, so on its own it can't even parse .tsx ("Parsing
+	// error: Unexpected token <"). It has to be layered onto the base config,
+	// which is what brings typescript-eslint.
+	const eslintConfig =
+		configType === 'nextjs'
+			? `import base from '@rtorcato/repo-tooling/eslint/base'
+import nextjs from '@rtorcato/repo-tooling/eslint/nextjs'
+
+export default [...base, ...nextjs]
+`
+			: `import { default as config } from '@rtorcato/repo-tooling/eslint/${configType}'
 
 export default config
 `

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -252,6 +252,24 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 	if (config.linting.tool === 'eslint' || config.linting.tool === 'both') {
 		deps['eslint'] = '^9.0.0'
 		deps['prettier'] = '^3.0.0'
+		// Everything tooling/eslint/base.mjs imports. All optional peers of
+		// repo-tooling, so pnpm skips them and `eslint .` dies on the config
+		// import — the scaffold shipped a lint script that could never run.
+		deps['@eslint/js'] = '^9.0.0'
+		deps['@typescript-eslint/eslint-plugin'] = '^8.0.0'
+		deps['typescript-eslint'] = '^8.0.0'
+		deps['eslint-plugin-import'] = '^2.0.0'
+		deps['eslint-plugin-jest'] = '^29.0.0'
+	}
+	// The shipped prettier preset lists this in `plugins`, and the nextjs eslint
+	// preset imports the Next plugin. Both are only *optional* peers of
+	// repo-tooling, so pnpm skips them and the scaffold's first format/lint dies
+	// with ERR_MODULE_NOT_FOUND.
+	if (config.formatting.tool === 'prettier') {
+		deps['@ianvs/prettier-plugin-sort-imports'] = '^4.7.0'
+	}
+	if (config.linting.eslintConfig === 'nextjs') {
+		deps['@next/eslint-plugin-next'] = '^16.2.11'
 	}
 
 	// Testing frameworks
@@ -279,6 +297,10 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['tsup'] = '^8.0.0'
 	} else if (config.bundler === 'esbuild') {
 		deps['esbuild'] = '^0.25.0'
+		// The generated build.mjs imports this directly. It's only an *optional*
+		// peer of repo-tooling, so pnpm won't pull it in — without it here every
+		// esbuild scaffold fails its first `pnpm build` with ERR_MODULE_NOT_FOUND.
+		deps['esbuild-node-externals'] = '^1.18.0'
 	} else if (config.bundler === 'rollup') {
 		deps['rollup'] = '^4.0.0'
 		deps['@rollup/plugin-typescript'] = '^12.0.0'
@@ -288,6 +310,10 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 		deps['rolldown'] = '^1.0.0'
 	} else if (config.bundler === 'vite') {
 		deps['vite'] = '^6.0.0'
+		// generateViteConfig emits `import react from '@vitejs/plugin-react'` for
+		// react-app, so the plugin has to be installed or `vite build` can't even
+		// load the config. Keep this condition in step with that one.
+		if (config.projectType === 'react-app') deps['@vitejs/plugin-react'] = '^5.0.0'
 	}
 
 	// Tailwind CSS v4 — CSS-first, wired via the PostCSS plugin.

--- a/src/cli/generators/testing.ts
+++ b/src/cli/generators/testing.ts
@@ -17,10 +17,23 @@ export async function generateTestingConfigs(config: ProjectConfig, targetDir: s
 export async function generateVitestConfig(config: ProjectConfig, targetDir: string) {
 	const vitestConfigPath = path.join(targetDir, 'vitest.config.ts')
 
+	// Vite reads `jsx` from tsconfig, and the next preset sets it to "preserve" so
+	// Next's own compiler handles the transform. Vitest has no such compiler, so
+	// .tsx tests fail to parse ("Unexpected token <") unless we opt back in here.
+	// `oxc` (not `esbuild`) is the Vite 8 spelling — vitest ^4 resolves Vite 8,
+	// and Vite 8 silently ignores the old `esbuild` key.
+	const jsxOverride =
+		config.projectType === 'nextjs-app'
+			? `  // tsconfig sets jsx: "preserve" for Next's compiler; vitest needs a
+  // transform of its own or .tsx tests won't parse.
+  oxc: { jsx: { runtime: 'automatic' } },
+`
+			: ''
+
 	const vitestConfig = `import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  test: {
+${jsxOverride}  test: {
     globals: true,
     environment: '${config.testing.environment === 'browser' ? 'jsdom' : 'node'}',
     setupFiles: ['./vitest.setup.ts'],

--- a/src/cli/generators/tsconfig.ts
+++ b/src/cli/generators/tsconfig.ts
@@ -24,6 +24,13 @@ export async function generateTSConfig(config: ProjectConfig, targetDir: string)
 		tsconfig.compilerOptions.rootDir = './src'
 	}
 
+	// web-app is the only browser target that lands on the `base` preset, whose
+	// lib is ES2022 — so `document`/`window` don't typecheck. The react and next
+	// presets already add the DOM libs themselves.
+	if (config.projectType === 'web-app' && preset === 'base') {
+		tsconfig.compilerOptions.lib = ['ES2022', 'DOM', 'DOM.Iterable']
+	}
+
 	if (config.projectType === 'nextjs-app') {
 		tsconfig.include = ['next-env.d.ts', 'src', 'app', 'pages', 'components', 'reset.d.ts']
 		tsconfig.exclude.push('.next')

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,29 @@ pnpm test --run    # single run (used in CI)
 pnpm coverage      # coverage report
 ```
 
+## Integration (preset lifecycle)
+
+`scripts/integration/preset-lifecycle.mjs <preset>` scaffolds a preset from the
+current working tree, repoints its `@rtorcato/repo-tooling` dep at a `pnpm pack`
+tarball, then installs, builds and runs `pnpm verify` against it. This is the only
+check that exercises a real install, so it's where missing dependencies and bad
+shipped configs surface.
+
+```bash
+pnpm build-cli                                          # required first
+node scripts/integration/preset-lifecycle.mjs react-app
+```
+
+Wired presets: `library`, `node-api`, `web-app`, `react-app`, `nextjs-app`. Each
+declares its own seed files and whether it has a build step in the `PRESETS` map —
+the presets are tooling-only, so the script writes the app source a consumer would
+bring. Anything the *tooling* needs belongs in the generator's dependency list, not
+in the script's `appDeps`, so a gap there fails the test instead of being hidden.
+
+In CI only `library` runs on pull requests; the four app presets run on push to
+main (each costs a full install + build). A green PR therefore does not mean all
+five presets were verified.
+
 ## Writing generator tests
 
 Each generator is a pure function that writes files into a target directory. Use the `useTmpDir` helper to isolate writes per test:

--- a/tooling/eslint/base.mjs
+++ b/tooling/eslint/base.mjs
@@ -43,6 +43,14 @@ export default tseslint.config(
 		ignores: [
 			//
 			'**/*.config.js',
+			// Root-level TS config files are outside the tsconfig `include` of every
+			// app preset, and this config lints type-aware (parserOptions.project),
+			// so linting them fails with "file was not found in any of the provided
+			// project(s)". The .js forms were already ignored; these are the same
+			// thing (the scaffold emits vitest.config.ts / vitest.setup.ts).
+			'**/*.config.ts',
+			'**/*.config.mts',
+			'**/*.setup.ts',
 			'.turbo',
 			'dist',
 			'build',

--- a/tooling/typescript/tsconfig.base.json
+++ b/tooling/typescript/tsconfig.base.json
@@ -9,8 +9,12 @@
     // "moduleResolution": "node", // Prefer "bundler" if you're using Vite, esbuild, etc.
     // "target": "esnext", // 
     "lib": ["ES2022"], // Specify library files to be included in the compilation
-    "rootDir": "src",
-    "outDir": "dist",
+    // ${configDir} for the same reason as paths/tsBuildInfoFile below: a bare
+    // "src" resolves against THIS file, i.e. inside node_modules, so every
+    // consumer that didn't redeclare rootDir got TS6059 "not under rootDir" the
+    // moment a file outside the preset's own directory entered the program.
+    "rootDir": "${configDir}/src",
+    "outDir": "${configDir}/dist",
 
     
     // 🔍 JavaScript Support

--- a/tooling/typescript/tsconfig.next.json
+++ b/tooling/typescript/tsconfig.next.json
@@ -2,12 +2,19 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "jsx": "preserve", // Let Next.js handle JSX transformation
+    // The base pins rootDir to src/, but `include` below spans app/, pages/ and
+    // components/ — all siblings of src/ — so tsc raised TS6059 on any Next repo
+    // using the app router. These presets are noEmit, so rootDir buys nothing
+    // here beyond that trap; widen it to the project root.
+    "rootDir": "${configDir}",
     "lib": ["DOM", "DOM.Iterable", "ESNext"], // Include DOM types for browser APIs
     "module": "esnext", // Next.js expects ESNext modules
     "moduleResolution": "bundler", // Modern module resolution for Next.js
     "allowJs": true, // Allow JavaScript files
     "esModuleInterop": true, // Interop for CommonJS/ESM
-    "types": ["react", "tailwindcss", "vitest"],
+    // No "tailwindcss" — see tsconfig.react.json; it broke TS2688 for every
+    // project without Tailwind installed.
+    "types": ["react", "vitest"],
     "plugins": [ { "name": "next" } ], // Next.js plugin for TypeScript
     // ${configDir} anchors paths to the consuming project (drops deprecated baseUrl)
     "paths": {

--- a/tooling/typescript/tsconfig.react.json
+++ b/tooling/typescript/tsconfig.react.json
@@ -2,8 +2,14 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx", // Use the new JSX transform for React 17+
+    // Same TS6059 trap as the next preset: `include` below covers index.d.ts and
+    // types/ alongside src/, which a src-rooted rootDir can't contain.
+    "rootDir": "${configDir}",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],// Include DOM types for browser APIs
-    "types": ["react", "react-dom", "tailwindcss", "vitest"],
+    // No "tailwindcss": listing it here made tsc fail with TS2688 on every React
+    // project that doesn't install Tailwind. Tailwind v4 is CSS-first and ships
+    // no ambient types a project needs, so nothing is lost by dropping it.
+    "types": ["react", "react-dom", "vitest"],
     // ${configDir} anchors paths to the consuming project (drops deprecated baseUrl)
     "paths": {
       "~/*": ["${configDir}/src/*"],


### PR DESCRIPTION
Closes #313

Wires `node-api`, `web-app`, `react-app` and `nextjs-app` into
`preset-lifecycle.mjs`. Doing so turned up **nine defects** that only appear on a
real install, so this is mostly a fix PR with a test PR attached.

Each preset was taken green one at a time, as the issue asked. All five pass locally.

## The harness

`PRESETS` is now a per-preset map declaring seed files, whether there's a build
step, and the consumer's own runtime deps — no inline branching in the steps.

The split that matters: **anything the *tooling* needs is a generator dependency,
not an `appDeps` entry.** Otherwise the harness papers over exactly the bugs it
exists to find. `appDeps` holds only what a real consumer brings (`react`, `next`),
since these presets are tooling-only and scaffold no app code.

Two steps became preset-aware: the formatter (biome vs prettier) and the build
(`nextjs-app` is `bundler: 'none'` and has no build script — running `next build`
would test Next.js, not the scaffold). The advertised-entry-path check is vacuous
for app presets, so it now says so instead of printing a reassuring "all 0".

## Missing dependencies

All are *optional* peers of repo-tooling, so pnpm never installs them — every
scaffold shipped a config importing a package it didn't have.

| Package | Imported by | Symptom |
|---|---|---|
| `esbuild-node-externals` | generated `build.mjs` | `pnpm build` → ERR_MODULE_NOT_FOUND |
| `@vitejs/plugin-react` | react-app `vite.config.ts` | `vite build` can't load its config |
| `@ianvs/prettier-plugin-sort-imports` | shipped prettier preset | `prettier --write` fails |
| `@next/eslint-plugin-next` | shipped `eslint/nextjs` | `eslint .` fails |
| `@eslint/js`, `typescript-eslint`, `@typescript-eslint/eslint-plugin`, `eslint-plugin-import`, `eslint-plugin-jest` | `tooling/eslint/base.mjs` | `eslint .` fails |

The last row means **every** eslint scaffold shipped a `lint` script that could
never run, not just `nextjs-app`.

## Broken shipped configs

- **`tsconfig.base.json` `rootDir`** was a bare `"src"`, which resolves against
  the preset file — i.e. *inside node_modules*. Any consumer that didn't
  redeclare `rootDir` got TS6059. The library preset emits its own, which is the
  only reason it was ever green. The file already used `${configDir}` for
  `paths`/`tsBuildInfoFile`; this was an oversight.
- **`tailwindcss` in `types`** (react + next presets) → TS2688 unless Tailwind is
  installed. Tailwind v4 is CSS-first and ships no ambient types, so dropping it
  costs nothing.
- **src-rooted `rootDir` on react/next** while `include` spans `app/`, `pages/`
  and `index.d.ts`. Both presets are `noEmit`, so `rootDir` bought nothing but
  the TS6059 trap; widened to `${configDir}`.
- **`eslint/base` ignored only `*.config.js`.** It lints type-aware
  (`parserOptions.project`), so the scaffold's own `vitest.config.ts` /
  `vitest.setup.ts` — outside every app preset's tsconfig `include` — failed to
  parse. The `.js` forms were already ignored; added the `.ts`/`.mts` ones.
- **`eslint/nextjs` sets no parser.** It's a plugin-only fragment, but the
  generator emitted it standalone, so `.tsx` failed with "Unexpected token <". Now
  layered onto `eslint/base`. Fixed in the generator, not the fragment, so
  consumers already composing `[...base, ...nextjs]` don't get base twice.
- **`nextjs-app` vitest couldn't transform `.tsx`**, because the next tsconfig
  sets `jsx: "preserve"` for Next's compiler. Generated config now sets
  `oxc: { jsx: { runtime: 'automatic' } }` — `oxc`, not `esbuild`, because
  vitest ^4 resolves Vite 8, which silently ignores the old key (verified both ways).
- **`web-app` had no DOM lib.** It's the only browser target landing on the
  `base` tsconfig, whose lib is ES2022, so `document` didn't typecheck.

## CI cost

Per the issue: on pull requests only `library` runs; the four app presets run on
push to main. The `else` branch emits a `::notice::` naming what it skipped, so a
green PR never reads as full preset coverage. `tests/README.md` says the same.

## Left out, deliberately

- **`v1/` tsconfig snapshots** keep the old `rootDir` — they're frozen for
  consumers who pin. That means a consumer on `typescript/base@1` still hits
  TS6059. Unbreaking them is a one-line change but it's a call about what "frozen"
  means, so I left it to you.
- **A unit-level "generated file imports X ⇒ X is a dependency" guard.** Tempting
  after six bugs of that shape, but the integration test now proves it on every
  push to main, and a static scan can't see string plugin refs like prettier's
  `plugins: ['@ianvs/...']` — which is how that one was actually caught.

## Verification

- All 5 presets pass `preset-lifecycle.mjs` locally
- `pnpm run verify` — 608 unit tests, check, typecheck, build all green