### PR TITLE
ci: run every preset lifecycle on PRs, not just library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,23 +256,14 @@ jobs:
       - name: 🏗️ Build CLI
         run: pnpm build-cli
 
-      - name: 🧩 Scaffold + install + verify the library preset
-        run: node scripts/integration/preset-lifecycle.mjs library
-
-      # The app presets each cost a full install + build, so on PRs only the
-      # library preset runs (it's the published one, and the #91/#92 packaging
-      # bugs all landed there). The rest gate on push-to-main. The else branch
-      # prints what was skipped so a green PR never implies full preset coverage.
-      - name: 🧩 Scaffold + install + verify the app presets (push to main only)
+      # #313 planned to gate the four app presets on push-to-main over wall-clock
+      # cost. Measured on #343: all five take 1m38s versus 44s for library alone,
+      # so the gate bought ~1 minute and cost full coverage on PRs. Run them all.
+      - name: 🧩 Scaffold + install + verify every preset
         run: |
-          if true; then  # TEMP: prove the app presets on this PR before trusting the gate
-            for preset in node-api web-app react-app nextjs-app; do
-              node scripts/integration/preset-lifecycle.mjs "$preset"
-            done
-          else
-            echo "::notice::Skipped node-api, web-app, react-app and nextjs-app —" \
-              "app presets run on push to main only. Only 'library' was verified here."
-          fi
+          for preset in library node-api web-app react-app nextjs-app; do
+            node scripts/integration/preset-lifecycle.mjs "$preset"
+          done
 
   # Build
   build:

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,9 +40,8 @@ the presets are tooling-only, so the script writes the app source a consumer wou
 bring. Anything the *tooling* needs belongs in the generator's dependency list, not
 in the script's `appDeps`, so a gap there fails the test instead of being hidden.
 
-In CI only `library` runs on pull requests; the four app presets run on push to
-main (each costs a full install + build). A green PR therefore does not mean all
-five presets were verified.
+All five run in CI on every pull request and push, on each supported Node major.
+The whole set takes about 1m40s, so there's no coverage gate to reason about.
 
 ## Writing generator tests
 


### PR DESCRIPTION
Follow-up to #343 / #313.

## Why

#313 suggested gating the four app presets on push-to-main to protect CI
wall-clock, and #343 implemented that. The measurement from #343's own run says
the gate wasn't worth it:

| Presets run | Wall clock |
|---|---|
| `library` only | 44s |
| all five | 1m38s |

~1 minute for full preset coverage on every PR. The gate also forced a caveat —
a green PR didn't mean all five presets were verified — which is exactly the kind
of footnote that gets forgotten.

Both jobs (Node 22 and 24) passed with all five presets on #343 before merge, so
this is proven, not hoped.

## Also cleans up

#343's squash-merge carried a temporary `if true;  # TEMP: …` onto `main` — I'd
pushed it to that branch to prove the app presets on CI before trusting the gate,
and it merged before I reverted it. So the gate was already effectively off; this
removes the conditional properly along with its now-dead skip-notice branch.

`tests/README.md` updated to match.