### PR TITLE
fix(pack): ship dist/base so the published CLI can start

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	"files": [
 		"dist/cli/**/*.js",
 		"dist/languages/**/*.js",
+		"dist/base/**/*.js",
 		"tooling/commitlint/commitlint.mjs",
 		"tooling/commitlint/commitlint.d.mts",
 		"tooling/esbuild/index.mjs",

--- a/scripts/integration/preset-lifecycle.mjs
+++ b/scripts/integration/preset-lifecycle.mjs
@@ -179,6 +179,17 @@ try {
 	// 6. Install (fresh scaffold has no lockfile, so not --frozen).
 	run('pnpm', ['install'], projectDir)
 
+	// 6b. Run the CLI *from the installed tarball*. Up to here the tarball is
+	//     only ever a dependency — never executed — so #345 shipped: dist/base/
+	//     was missing from the `files` allowlist and every command died at load
+	//     with ERR_MODULE_NOT_FOUND, with all five preset lifecycles still green.
+	//     `--version` is enough: the crash was an unresolved static import, which
+	//     happens before any command runs.
+	//     ponytail: this catches missing *modules* only. A tooling/ asset the CLI
+	//     reads at runtime could still be absent from the tarball — run a real
+	//     command here if that ever bites.
+	run('pnpm', ['exec', 'repo-tooling', '--version'], projectDir)
+
 	// 7. Format generated files — mirrors what `setup` does post-install (the
 	//    scaffold's biome/prettier config; templates are hand-written).
 	const formatter = fs.existsSync(path.join(projectDir, 'biome.jsonc'))


### PR DESCRIPTION
Closes #345

**The published CLI at `latest` is unusable.** `npx @rtorcato/repo-tooling@3.2.4 doctor`
dies before running anything.

## Cause

`files` covered `dist/cli` and `dist/languages` but not `dist/base` — `src/` has
three top-level dirs, the allowlist had two. `dist/languages/swift/checks.js`
imports `dist/base/checks.js` as a static import, so resolution fails at load
time and takes down *every* command, not just the Swift path.

## Why five green preset lifecycles missed it

The integration harness installs the tarball **as a dependency and never executes
the CLI from it**. So a tarball that cannot start still passed everything.

The guard is one line in the existing harness rather than a new smoke-test
script: after install, run `repo-tooling --version` from the installed package.
`--version` suffices because the failure is an unresolved static import, which
happens before any command dispatches.

Verified in both directions:

```
# files entry reverted:
❌ library preset lifecycle failed
Command failed: pnpm exec repo-tooling --version
ERR_MODULE_NOT_FOUND … /dist/base/github-settings.js

# files entry restored:
$ pnpm exec repo-tooling --version
3.2.4
✅ library preset lifecycle passed
```

Also confirmed by hand that `doctor` runs to completion from an `npm pack` +
`npm install` of this tree — so no other runtime asset is missing today. The
harness check has a known ceiling (modules only, not `tooling/` data files read
at runtime); that's marked with a `ponytail:` comment naming the upgrade path.

## Please merge and release promptly

Every consumer on `latest` is broken, and rtorcato/shared-docs#13 is blocked
behind it. I have not cut a release — that's yours to trigger.

## Not done here

The issue also suggests `publint` / `attw` against our own tarball. The smoke
test already covers this failure class end-to-end, so I didn't add a second
mechanism for the same bug. Easy to add later if a non-module asset ever goes
missing.