### PR TITLE
test(integration): wire swift-library into preset-lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,6 @@ jobs:
   # toolchain, and the scaffold's own CI targets Apple platforms anyway (#312).
   # macos-latest over a swift:* container because macOS runners are free on
   # public repos, and it's the platform the generated package actually claims.
-  # SwiftLint comes preinstalled on the runner image; the script warns loudly
-  # rather than passing quietly if that ever stops being true.
   integration-swift:
     runs-on: macos-latest
     needs: [check-skip]
@@ -292,6 +290,12 @@ jobs:
 
       - name: 🏗️ Build CLI
         run: pnpm build-cli
+
+      # Not on the macos-latest image — the first run of this job logged
+      # "swiftlint not on PATH". Without it the scaffold's lint gate, which is
+      # half of what the Swift preset ships, would never be exercised.
+      - name: 📦 Install SwiftLint
+        run: brew install swiftlint
 
       - name: 🧩 Scaffold + build + test + lint swift-library
         run: node scripts/integration/preset-lifecycle.mjs swift-library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,37 @@ jobs:
             node scripts/integration/preset-lifecycle.mjs "$preset"
           done
 
+  # swift-library can't ride the job above: ubuntu-latest ships no Swift
+  # toolchain, and the scaffold's own CI targets Apple platforms anyway (#312).
+  # macos-latest over a swift:* container because macOS runners are free on
+  # public repos, and it's the platform the generated package actually claims.
+  # SwiftLint comes preinstalled on the runner image; the script warns loudly
+  # rather than passing quietly if that ever stops being true.
+  integration-swift:
+    runs-on: macos-latest
+    needs: [check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🏗️ Build CLI
+        run: pnpm build-cli
+
+      - name: 🧩 Scaffold + build + test + lint swift-library
+        run: node scripts/integration/preset-lifecycle.mjs swift-library
+
   # Build
   build:
     runs-on: ubuntu-latest
@@ -314,7 +345,18 @@ jobs:
   # Release and publish
   release:
     runs-on: ubuntu-latest
-    needs: [dependencies, lint, typecheck, test, integration, build, varcheck, check-skip]
+    needs:
+      [
+        dependencies,
+        lint,
+        typecheck,
+        test,
+        integration,
+        integration-swift,
+        build,
+        varcheck,
+        check-skip,
+      ]
     if: |
       always() &&
       needs.check-skip.outputs.should-skip != 'true' &&
@@ -324,6 +366,7 @@ jobs:
       needs.typecheck.result == 'success' &&
       needs.test.result == 'success' &&
       needs.integration.result == 'success' &&
+      needs.integration-swift.result == 'success' &&
       needs.build.result == 'success' &&
       needs.varcheck.result == 'success'
     permissions:

--- a/scripts/integration/preset-lifecycle.mjs
+++ b/scripts/integration/preset-lifecycle.mjs
@@ -8,8 +8,12 @@
 // tarball of this repo, so the test validates THIS branch's generated output +
 // presets, not whatever `latest` is on npm.
 //
+// swift-library has no such dep and no npm lifecycle at all, so it runs its own
+// step list (`swift build` → `swift test` → `swiftlint`) — see swiftLifecycle.
+//
 // Usage: node scripts/integration/preset-lifecycle.mjs [preset]   (default: library)
 // Requires: `pnpm build-cli` first, and network access to the npm registry.
+// swift-library additionally requires a Swift toolchain on PATH.
 
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -110,7 +114,7 @@ const seedNextEntry = (dir) => {
  * (the presets are tooling-only — they scaffold no app code). `appDeps` are that
  * same consumer's runtime deps: anything the *tooling* needs belongs in the
  * generator's dependency list, not here, so a gap there fails this test rather
- * than being papered over.
+ * than being papered over. `swift: true` opts out of the JS lifecycle entirely.
  */
 const PRESETS = {
 	library: { seed: seedNodeEntry, build: true },
@@ -138,6 +142,9 @@ const PRESETS = {
 			'@types/react': '^19.0.0',
 		},
 	},
+	// The whole JS lifecycle is inapplicable: no package.json to repoint, no
+	// pnpm, no biome, no `pnpm verify`. See swiftLifecycle below (#312).
+	'swift-library': { swift: true },
 }
 
 const spec = PRESETS[PRESET]
@@ -147,18 +154,40 @@ if (!spec)
 	)
 if (!fs.existsSync(CLI)) fail(`CLI not built at ${CLI} — run "pnpm build-cli" first`)
 
-const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jst-pack-'))
+let packDir = ''
 const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), `jst-${PRESET}-`))
 
-try {
-	// 1. Pack the working tree so the scaffold tests local code, not npm's latest.
+const onPath = (bin) => {
+	try {
+		execFileSync('command', ['-v', bin], { stdio: 'ignore', shell: true })
+		return true
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Swift diverges from every JS preset: the scaffold writes its own source and
+ * test target (SwiftPM refuses to build an empty one), so there is nothing to
+ * seed, no `@rtorcato/repo-tooling` dep to repoint and nothing to install. The
+ * lifecycle is the gate the scaffold's own CI and pre-push hook run.
+ */
+function swiftLifecycle() {
+	run('swift', ['build'], projectDir)
+	run('swift', ['test'], projectDir)
+	// SwiftLint is a separate install, not part of a Swift toolchain. Say when it
+	// didn't run rather than reporting a lint gate that was never exercised.
+	if (onPath('swiftlint')) run('swiftlint', ['lint', '--strict'], projectDir)
+	else console.log('\n⚠️  swiftlint not on PATH — lint gate NOT exercised')
+}
+
+function jsLifecycle() {
+	// 2. Pack the working tree so the scaffold tests local code, not npm's latest.
+	packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jst-pack-'))
 	run('pnpm', ['pack', '--pack-destination', packDir])
 	const tgz = fs.readdirSync(packDir).find((f) => f.endsWith('.tgz'))
 	if (!tgz) fail('pnpm pack produced no tarball')
 	const tarball = path.join(packDir, tgz)
-
-	// 2. Scaffold the preset (files only; we install ourselves after repointing the dep).
-	run('node', [CLI, 'setup', '--preset', PRESET, '--directory', projectDir, '--skip-install'])
 
 	// 3. Repoint @rtorcato/repo-tooling at the local tarball, and add the app deps
 	//    a real consumer of this preset would already have.
@@ -218,9 +247,18 @@ try {
 
 	// 10. Full verify chain (typecheck + lint + test, plus publint/attw on library).
 	run('pnpm', ['verify'], projectDir)
+}
+
+try {
+	// 1. Scaffold the preset (files only; the JS path installs itself once the dep
+	//    is repointed, and the Swift path has nothing to install).
+	run('node', [CLI, 'setup', '--preset', PRESET, '--directory', projectDir, '--skip-install'])
+
+	if (spec.swift) swiftLifecycle()
+	else jsLifecycle()
 
 	console.log(`\n✅ ${PRESET} preset lifecycle passed`)
-	fs.rmSync(packDir, { recursive: true, force: true })
+	if (packDir) fs.rmSync(packDir, { recursive: true, force: true })
 	fs.rmSync(projectDir, { recursive: true, force: true })
 } catch (err) {
 	// Leave the throwaway dirs in place on failure for debugging.

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,8 @@ The whole set takes about 1m40s, so there's no coverage gate to reason about.
 entirely — there is no `package.json` to repoint and nothing to install, so it runs
 `swift build` → `swift test` → `swiftlint lint --strict` against the scaffold's own
 source and test target. It needs a Swift toolchain, so CI runs it in a separate
-`integration-swift` job on `macos-latest`. If `swiftlint` isn't on `PATH` the script
+`integration-swift` job on `macos-latest`, which `brew install swiftlint` first
+because the runner image doesn't ship it. If `swiftlint` isn't on `PATH` the script
 warns that the lint gate did not run rather than reporting a pass.
 
 ## Writing generator tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,6 +43,13 @@ in the script's `appDeps`, so a gap there fails the test instead of being hidden
 All five run in CI on every pull request and push, on each supported Node major.
 The whole set takes about 1m40s, so there's no coverage gate to reason about.
 
+`swift-library` is wired too, but declares `swift: true` and skips the JS lifecycle
+entirely — there is no `package.json` to repoint and nothing to install, so it runs
+`swift build` → `swift test` → `swiftlint lint --strict` against the scaffold's own
+source and test target. It needs a Swift toolchain, so CI runs it in a separate
+`integration-swift` job on `macos-latest`. If `swiftlint` isn't on `PATH` the script
+warns that the lint gate did not run rather than reporting a pass.
+
 ## Writing generator tests
 
 Each generator is a pure function that writes files into a target directory. Use the `useTmpDir` helper to isolate writes per test:


### PR DESCRIPTION
Closes #312

## What

`swift-library` shipped in #288 and nothing verified that the scaffold builds.
This wires it into `scripts/integration/preset-lifecycle.mjs`.

Swift shares only the scaffold step with the JS presets — there is no
`package.json` to repoint at the `pnpm pack` tarball, no install, no biome and
no `pnpm verify`. So the `PRESETS` map gains `swift: true`, which opts a preset
out of the JS step list and runs `swift build` → `swift test` →
`swiftlint lint --strict` instead: the same gate the scaffold's own CI workflow
and `pre-push` hook run.

No `seed` either. Unlike the tooling-only JS presets, the Swift scaffold writes
its own source and test target already, because SwiftPM refuses to build an
empty one.

The JS lifecycle moved verbatim into a `jsLifecycle()` function; the scaffold
step is hoisted into the shared `try` so both paths get the same cleanup and
"inspect this dir on failure" behaviour. No JS step changed.

## Runner

`ubuntu-latest` has no Swift toolchain, so this gets its own `integration-swift`
job on `macos-latest` rather than joining the `for preset in ...` loop.
macOS runners are free on public repos and macOS is a platform the generated
`Package.swift` actually declares, so a `swift:*` container buys nothing here.

The script warns loudly (`⚠️  swiftlint not on PATH — lint gate NOT exercised`)
instead of passing quietly when SwiftLint is missing — and that warning
immediately earned its keep: **SwiftLint is not on the `macos-latest` image**,
so the first run of this job built and tested but never linted. Second commit
adds `brew install swiftlint` and the gate now runs for real.

`integration-swift` is added to the `release` job's `needs` and its success
gate, so a broken Swift scaffold blocks a release the same way a broken JS one
does.

## Verified

Locally (macOS, Swift 6.3.3):

- `pnpm build-cli` — clean
- `node scripts/integration/preset-lifecycle.mjs swift-library` — build ok,
  1 XCTest passed, `swiftlint lint --strict` 0 violations in 3 files
- `node scripts/integration/preset-lifecycle.mjs library` — still passes, so the
  `jsLifecycle()` extraction is a no-op for the JS path
- `pnpm run verify` — biome clean, tsc clean, 608 tests in 47 files passed

In CI on this PR:

- `integration-swift` **pass, 1m23s** — log shows
  `Done linting! Found 0 violations, 0 serious in 3 files.` then
  `✅ swift-library preset lifecycle passed`
- `integration (node 22)` and `(node 24)` still pass, unchanged

## Deliberately not in scope

- No `periphery scan` step. Periphery is a third install that isn't on the
  runner image either, and the scaffold's generated CI doesn't gate on it.
- `package.json`'s `test:integration` script still runs `library` only; it's the
  quick local smoke test and Swift isn't a given on a contributor's box.