### PR TITLE
fix(ci): widen the action-pin guard past the actions/ org

### DIFF
--- a/src/languages/js/ci.ts
+++ b/src/languages/js/ci.ts
@@ -120,7 +120,7 @@ export function githubJobs(config: ProjectConfig): CiJob[] {
 			? `
 
       - name: 📊 Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: \${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false`

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1110,7 +1110,7 @@ describe('doctor README badges check', () => {
 		await fs.ensureDir(join(dir, '.github', 'workflows'))
 		await fs.writeFile(
 			join(dir, '.github', 'workflows', 'ci.yml'),
-			'name: CI\njobs:\n  test:\n    steps:\n      - uses: codecov/codecov-action@v5\n'
+			'name: CI\njobs:\n  test:\n    steps:\n      - uses: codecov/codecov-action@v7\n'
 		)
 		const results = await runDoctor(dir)
 		const r = results.find((c) => c.check === 'Coverage upload')

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -149,7 +149,7 @@ jobs:
         run: pnpm coverage
 
       - name: 📊 Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: \${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/tests/cli/generators/action-pins.test.ts
+++ b/tests/cli/generators/action-pins.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 /**
- * Guard against the drift loop in #340: the generators embed `actions/*` pins as
+ * Guard against the drift loop in #340: the generators embed action pins as
  * plain strings, so Dependabot can't see them. It bumps this repo's own
  * workflows, the emitted pins stay behind, the next workflow sync in a consuming
  * repo silently reverts that repo's bump, and Dependabot re-opens the same PR.
@@ -12,12 +12,17 @@ import { describe, expect, it } from 'vitest'
  * Dependabot PR that bumps our own ci.yml also fails here until the generators
  * follow — the reminder lands on the PR that caused the drift.
  *
+ * Matches ANY org, not just `actions/`. The first cut of this test was scoped to
+ * `actions/` and so covered 24 of the 42 emitted pins; the 18 it skipped were
+ * already drifting the day it landed (codecov-action was two majors behind, and
+ * pnpm/action-setup was pinned at both v4 and v6 within the emitted set).
+ *
  * ponytail: a text scan over the sources, not a generator invocation. The pins
  * are literals in template strings, so grepping is what a reader would do.
  */
 
 const repoRoot = path.resolve(import.meta.dirname, '../../..')
-const PIN = /(actions\/[a-z0-9-]+)@v(\d+)/g
+const PIN = /\b([a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*)@v(\d+)/g
 
 const pinsIn = (files: string[]) => {
 	const found = new Map<string, Map<string, string[]>>()
@@ -39,7 +44,7 @@ const emittedPins = pinsIn([
 	...glob('tooling/github-actions/workflows/*.yml'),
 ])
 
-describe("emitted actions/* pins track this repo's own workflows", () => {
+describe("emitted action pins track this repo's own workflows", () => {
 	it('finds pins on both sides (the scan itself still works)', () => {
 		expect(ownPins.size).toBeGreaterThan(0)
 		expect(emittedPins.size).toBeGreaterThan(0)

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -108,7 +108,7 @@ describe('generateGitHubActions', () => {
 
 		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
 		expect(content).toContain('pnpm coverage')
-		expect(content).toContain('codecov/codecov-action@v5')
+		expect(content).toContain('codecov/codecov-action@v7')
 		expect(content).toContain('CODECOV_TOKEN')
 		expect(await fs.pathExists(join(dir, 'codecov.yml'))).toBe(true)
 	})

--- a/tooling/github-actions/workflows/cloudflare-pages.yml
+++ b/tooling/github-actions/workflows/cloudflare-pages.yml
@@ -26,7 +26,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Follow-up to #342. Found while answering #316 — measuring the pin surface for the
reusable-workflow decision exposed a hole in the guard I added yesterday.

## The gap

`action-pins.test.ts` matched only `actions/*`, so it covered **24 of 42 emitted
pins (57%)** and 4 of 18 distinct actions. Everything outside that org was
unguarded — and was already drifting the day the guard landed, which is precisely
the failure mode it exists to prevent.

| Pin | Emitted | This repo runs |
|---|---|---|
| `codecov/codecov-action` | `@v5` | `@v7` (two majors behind) |
| `pnpm/action-setup` | `@v4` in `cloudflare-pages.yml`, `@v6` elsewhere | `@v6` |

The second one was inconsistent *within* the emitted set — the kind of thing the
guard should never have allowed through.

## Change

One regex: `actions/…` → any `org/name`. Checked intersection goes **4 → 7
actions**, now including `pnpm/action-setup`, `codecov/codecov-action` and
`dependabot/fetch-metadata`. Actions we scaffold but never run ourselves
(`docker/*`, `cloudflare/wrangler-action`, `peaceiris/*`, `googleapis/*`,
`maxim-lobanov/setup-xcode`) still have no counterpart to compare against — that
limit is unchanged and stated in the test's comment.

Both drifted pins fixed; three stale test fixtures and one snapshot updated to match.

## Verification

Guard confirmed to fail on drift and pass when correct:

```
# codecov reverted to v5
× codecov/codecov-action matches the major this repo runs
  Tests  1 failed | 7 passed (8)

# restored
  Tests  8 passed (8)
```

`pnpm run verify` — 611 tests, check, typecheck, build all green.