### PR TITLE
feat(ci): ship doctor as a composite GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,22 @@ jobs:
           # gracefully if the token lacks admin:read, so this never hard-fails.
           GH_TOKEN: ${{ github.token }}
 
+      # Smoke-test the composite action we ship (#315) the way a consumer uses
+      # it. `fail-on: none` because doctor has genuine self-repo findings (see
+      # scripts/dogfood.mjs) — this proves the wiring, dogfood proves the checks.
+      - name: 🎬 Smoke-test the composite action
+        id: action-smoke
+        uses: ./
+        with:
+          fail-on: none
+        env:
+          REPO_TOOLING_ALLOW_SELF: '1'
+
+      - name: 🎬 Assert the action emitted a report
+        run: jq -e '.results | length > 0' <<<"$REPORT" >/dev/null
+        env:
+          REPORT: ${{ steps.action-smoke.outputs.json }}
+
       - name: 📦 Upload build artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ See the [Getting Started guide](https://rtorcato.github.io/repo-tooling/guides/g
 | `doctor` | Diagnose an existing project for missing or drifted tooling. | `npx @rtorcato/repo-tooling doctor` |
 | `fix [target]` | Apply scaffolders for what `doctor` flagged (`--yes`, `--dry-run`, `--diff`). | `npx @rtorcato/repo-tooling fix` |
 
+Prefer to run the audit in CI? `doctor` also ships as a GitHub Action:
+
+```yaml
+- uses: rtorcato/repo-tooling@v3.2.5
+```
+
+See the [GitHub Actions reference](https://rtorcato.github.io/repo-tooling/reference/github-actions/#run-doctor-as-a-github-action) for its inputs and outputs.
+
 Every command takes `-d, --directory <path>`; run any with `--help` for its full flags. Run `list` (or `list --json`) for the full set of `fix` targets — it's the source of truth. Notable ones include `fix docs-site` (scaffold a [Docusaurus docs site](https://rtorcato.github.io/repo-tooling/guides/docs-site/)) and `fix bun` (Bun runtime config).
 
 ## The `.repo-tooling.json` lockfile

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,6 +15,21 @@ Releases are driven by **conventional commit** messages on `main`:
 
 If no release-worthy commits exist since the last tag, semantic-release exits without publishing — that's expected, not a failure.
 
+## The GitHub Action tag (#315)
+
+`action.yml` at the repo root is consumed by **git ref**, not by npm, so it needs
+no extra release step: consumers pin an exact release tag (`rtorcato/repo-tooling@v3.2.5`),
+which semantic-release already creates on the commit that bumps `package.json`.
+The action reads its own `package.json` at runtime and runs that exact npm
+version, so the git tag and the CLI version can't diverge.
+
+**No floating `v3` tag is maintained**, deliberately. A moving major is a second
+release channel to operate — every `action.yml` change becomes a breaking-change
+judgement on a tag consumers can't pin below — for a benefit Dependabot's
+`github-actions` ecosystem already delivers by bumping exact tags. Revisit only
+if consumers ask for it; adding a floating tag later is backwards-compatible,
+removing one is not.
+
 ## Before an API-changing release
 
 semantic-release owns the version, tag, CHANGELOG, and npm publish — **never bump

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ branding:
 
 inputs:
   directory:
-    description: Directory to diagnose, relative to the workspace.
+    description: Directory to diagnose, relative to the workspace (or absolute).
     required: false
     default: .
   fail-on:
@@ -56,11 +56,22 @@ runs:
         version="$(node -p "require('$GITHUB_ACTION_PATH/package.json').version")"
         report="$RUNNER_TEMP/repo-tooling-doctor.json"
 
+        # Resolve the target to an absolute path, then run npx from outside the
+        # workspace. npx treats a spec already satisfied by the *current
+        # project* as installed and runs its bin from node_modules/.bin — which
+        # a repo that merely declares the dependency hasn't linked, so it fails
+        # with "repo-tooling: command not found". Running elsewhere and pointing
+        # doctor at the target with --directory makes the version we resolved
+        # above the version that actually runs, whatever the workspace contains.
+        cd "$GITHUB_WORKSPACE"
+        target="$(cd "$INPUT_DIRECTORY" && pwd)"
+        cd "$RUNNER_TEMP"
+
         # doctor exits 1 on findings; that is this action's gate, not an error,
         # so decide from the report rather than letting `set -e` end the step.
         status=0
         npx --yes "@rtorcato/repo-tooling@$version" doctor \
-          --directory "$INPUT_DIRECTORY" --json >"$report" || status=$?
+          --directory "$target" --json >"$report" || status=$?
         if [ ! -s "$report" ]; then
           echo "::error::repo-tooling doctor produced no JSON (exit $status)"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,75 @@
+# Composite action so consumer repos can gate on `doctor` in three lines (#315).
+#
+# Composite, not Docker: doctor is a read-only file audit that already ships as
+# an npm CLI, so a container would only add an image to build, publish and pull
+# for something `npx` does in seconds. It also keeps the action running on the
+# host filesystem, so no volume-mount dance to reach the checkout.
+#
+# The npm version is derived from this action's own checkout rather than
+# floating on `@latest`, so `uses: rtorcato/repo-tooling@v3.2.5` runs CLI 3.2.5.
+# The git ref is the pin; there is nothing else to keep in sync.
+name: repo-tooling doctor
+description: Audit a repo against @rtorcato/repo-tooling presets and fail on drift.
+author: Richard Torcato
+
+branding:
+  icon: activity
+  color: blue
+
+inputs:
+  directory:
+    description: Directory to diagnose, relative to the workspace.
+    required: false
+    default: .
+  fail-on:
+    description: >-
+      Which findings fail the step: `drift` (drift or missing — the default,
+      matching doctor's own exit code), `missing` (missing config only), or
+      `none` (annotate and report, never fail).
+    required: false
+    default: drift
+
+outputs:
+  json:
+    description: The full `doctor --json` payload, for posting to a PR comment.
+    value: ${{ steps.doctor.outputs.json }}
+
+runs:
+  using: composite
+  steps:
+    # The CLI needs Node >= 22 (package.json `engines`). doctor never executes
+    # the audited project's code, so pinning the runtime here is safe: it is the
+    # action's own floor, not a claim about the consumer's Node version.
+    - uses: actions/setup-node@v7
+      with:
+        node-version: '22'
+
+    - id: doctor
+      shell: bash
+      # Inputs go through env, never `${{ }}` inside the script — an input is
+      # attacker-controlled on a `pull_request_target` caller.
+      env:
+        INPUT_DIRECTORY: ${{ inputs.directory }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+      run: |
+        set -euo pipefail
+        version="$(node -p "require('$GITHUB_ACTION_PATH/package.json').version")"
+        report="$RUNNER_TEMP/repo-tooling-doctor.json"
+
+        # doctor exits 1 on findings; that is this action's gate, not an error,
+        # so decide from the report rather than letting `set -e` end the step.
+        status=0
+        npx --yes "@rtorcato/repo-tooling@$version" doctor \
+          --directory "$INPUT_DIRECTORY" --json >"$report" || status=$?
+        if [ ! -s "$report" ]; then
+          echo "::error::repo-tooling doctor produced no JSON (exit $status)"
+          exit 1
+        fi
+
+        {
+          echo 'json<<REPO_TOOLING_DOCTOR_JSON'
+          cat "$report"
+          echo 'REPO_TOOLING_DOCTOR_JSON'
+        } >>"$GITHUB_OUTPUT"
+
+        node "$GITHUB_ACTION_PATH/scripts/doctor-gate.mjs" "$report" "$INPUT_FAIL_ON"

--- a/apps/docs/docs/reference/github-actions.md
+++ b/apps/docs/docs/reference/github-actions.md
@@ -1,7 +1,70 @@
 ---
 title: GitHub Actions
-description: The CI workflow scaffolded by setup, plus optional deploy workflows you can add with fix.
+description: Run doctor as a GitHub Action, plus the CI workflow scaffolded by setup and the optional deploy workflows you can add with fix.
 ---
+
+## Run `doctor` as a GitHub Action
+
+This repo is itself a **composite action**, so a consumer repo can gate on the
+audit without hand-writing the step:
+
+```yaml
+- uses: actions/checkout@v7
+- uses: rtorcato/repo-tooling@v3.2.5
+```
+
+That fails the job when `doctor` finds drift or missing config — the same exit
+code you get from the CLI.
+
+### Inputs
+
+| Input | Default | What it does |
+|---|---|---|
+| `directory` | `.` | Directory to diagnose, relative to the workspace. |
+| `fail-on` | `drift` | `drift` fails on drift **or** missing; `missing` fails only on missing config; `none` annotates and never fails. |
+
+Every finding becomes a job annotation regardless of `fail-on`, so `none` is the
+report-only mode for a repo adopting the audit before it's clean:
+
+```yaml
+- uses: rtorcato/repo-tooling@v3.2.5
+  with:
+    directory: packages/app
+    fail-on: none
+```
+
+### Outputs
+
+| Output | What it is |
+|---|---|
+| `json` | The full `doctor --json` payload — feed it to a PR comment or a report. |
+
+```yaml
+- uses: rtorcato/repo-tooling@v3.2.5
+  id: doctor
+  with:
+    fail-on: none
+- run: jq '.results' <<< '${{ steps.doctor.outputs.json }}'
+```
+
+### Versioning
+
+Pin an **exact release tag** (`@v3.2.5`), not a floating major. The action runs
+the npm package at the version recorded in the tag it was checked out from, so
+the git ref is the only pin — there's no second channel that can drift out from
+under you, and Dependabot's `github-actions` ecosystem bumps the tag for you.
+
+### Notes
+
+- The action runs `actions/setup-node` internally to guarantee Node 22, since
+  the CLI requires it. That also sets Node for later steps in the same job — put
+  the audit in its own job if that matters.
+- It's a composite action, not a Docker one: `doctor` is a read-only file audit
+  already published as an npm CLI, so a container would only add an image to
+  build, publish and pull.
+- `doctor` never executes the audited project's code — it reads config files.
+
+## Scaffolded workflows
 
 Every scaffold gets a `ci.yml` (lint / typecheck / test / build, and release for
 libraries) out of the box. Beyond that, repo-tooling ships **optional deploy

--- a/scripts/doctor-gate.mjs
+++ b/scripts/doctor-gate.mjs
@@ -1,0 +1,51 @@
+// Gate + human summary for the composite action in action.yml (#315).
+//
+// `doctor --json` prints only JSON, so the action renders the findings as job
+// annotations itself and then decides whether they should fail the step. The
+// severity threshold is the one thing doctor's own exit code can't express: it
+// fails on drift-or-missing, and a repo adopting the audit needs to be able to
+// report first (`fail-on: none`) or gate on missing config alone.
+import { readFileSync } from 'node:fs'
+
+const FAIL_ON = {
+	drift: ['drift', 'missing'],
+	missing: ['missing'],
+	none: [],
+}
+
+export function gate(results, failOn) {
+	const blocking = FAIL_ON[failOn]
+	if (!blocking) {
+		throw new Error(`fail-on must be one of ${Object.keys(FAIL_ON).join(', ')} — got "${failOn}"`)
+	}
+	const findings = results.filter((r) => r.status === 'drift' || r.status === 'missing')
+	return {
+		findings,
+		blocking: findings.filter((r) => blocking.includes(r.status)),
+	}
+}
+
+// `node scripts/doctor-gate.mjs <report.json> <fail-on>` — the action's entry.
+if (process.argv[1] === import.meta.filename) {
+	const [reportPath, failOn = 'drift'] = process.argv.slice(2)
+	const { results } = JSON.parse(readFileSync(reportPath, 'utf8'))
+
+	let outcome
+	try {
+		outcome = gate(results, failOn)
+	} catch (err) {
+		console.error(`::error::${err.message}`)
+		process.exit(1)
+	}
+
+	for (const r of outcome.findings) {
+		const level = outcome.blocking.includes(r) ? 'error' : 'warning'
+		console.log(`::${level}::${r.check} (${r.status}) — ${r.detail}`)
+	}
+	console.log(
+		`doctor: ${results.length} checks, ${outcome.findings.length} finding(s), ` +
+			`${outcome.blocking.length} blocking at fail-on=${failOn}`
+	)
+
+	if (outcome.blocking.length > 0) process.exit(1)
+}

--- a/tests/cli/generators/action-pins.test.ts
+++ b/tests/cli/generators/action-pins.test.ts
@@ -42,6 +42,9 @@ const ownPins = pinsIn(glob('.github/workflows/*.yml'))
 const emittedPins = pinsIn([
 	...glob('src/**/*.ts'),
 	...glob('tooling/github-actions/workflows/*.yml'),
+	// action.yml (#315) runs on consumers' runners, so its pins drift the same
+	// way an emitted workflow's do.
+	'action.yml',
 ])
 
 describe("emitted action pins track this repo's own workflows", () => {

--- a/tests/scripts/doctor-gate.test.ts
+++ b/tests/scripts/doctor-gate.test.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The gate the composite action (`action.yml`, #315) puts in front of a CI job.
+ * Run as a subprocess because the exit code *is* the feature — an assertion on
+ * the returned object alone would pass while the step silently stopped failing.
+ */
+const script = path.resolve(import.meta.dirname, '../../scripts/doctor-gate.mjs')
+
+const report = (...results: Array<{ status: string }>) => {
+	const file = path.join(mkdtempSync(path.join(tmpdir(), 'doctor-gate-')), 'doctor.json')
+	writeFileSync(
+		file,
+		JSON.stringify({
+			results: results.map((r, i) => ({ check: `check-${i}`, detail: 'detail', ...r })),
+		})
+	)
+	return file
+}
+
+const run = (file: string, failOn: string) =>
+	spawnSync(process.execPath, [script, file, failOn], { encoding: 'utf8' })
+
+describe('doctor-gate', () => {
+	const findings = report({ status: 'ok' }, { status: 'drift' }, { status: 'missing' })
+
+	it('fails on drift or missing with fail-on=drift', () => {
+		const { status, stdout } = run(findings, 'drift')
+		expect(status).toBe(1)
+		expect(stdout).toContain('2 finding(s), 2 blocking')
+	})
+
+	it('ignores drift with fail-on=missing but still annotates it', () => {
+		const { status, stdout } = run(findings, 'missing')
+		expect(status).toBe(1)
+		expect(stdout).toContain('2 finding(s), 1 blocking')
+		expect(stdout).toContain('::warning::check-1 (drift)')
+	})
+
+	it('never fails with fail-on=none', () => {
+		const { status, stdout } = run(findings, 'none')
+		expect(status).toBe(0)
+		expect(stdout).toContain('2 finding(s), 0 blocking')
+	})
+
+	it('passes a clean report', () => {
+		expect(run(report({ status: 'ok' }), 'drift').status).toBe(0)
+	})
+
+	it('rejects an unknown fail-on rather than passing the job', () => {
+		const { status, stderr } = run(findings, 'warn')
+		expect(status).toBe(1)
+		expect(stderr).toContain('fail-on must be one of')
+	})
+})


### PR DESCRIPTION
Closes #315

## What

`action.yml` at the repo root, so a consumer repo gates on `doctor` in two lines:

```yaml
- uses: actions/checkout@v7
- uses: rtorcato/repo-tooling@v3.2.5
```

## Composite, not Docker

`doctor` is a read-only file audit already published as an npm CLI. A container adds an image to build, publish and pull, plus a volume mount to reach the checkout, and buys nothing — `npx` does it in seconds on the host filesystem.

## Surface (deliberately two inputs, one output)

| Name | Kind | Default | Why it exists |
|---|---|---|---|
| `directory` | input | `.` | Mirrors the CLI's `--directory`; monorepos need it. |
| `fail-on` | input | `drift` | The one thing doctor's exit code can't express. |
| `json` | output | — | `doctor --json`, for posting to a PR comment. |

`doctor` sets `process.exitCode = 1` on drift-or-missing, which **is** a usable CI gate — `fail-on: drift` is exactly that, and the default. What it can't express is the adoption path: a repo turning the audit on before it's clean needs `none` (annotate, never fail), and `missing` gates on absent config while tolerating drift. Findings become job annotations at every level (`::error::` for blocking, `::warning::` otherwise).

**No `node-version` input.** The action runs `actions/setup-node` at Node 22 (the CLI's `engines` floor). `doctor` never executes the audited project's code, so the runtime is the action's own concern, not a claim about the consumer's. Documented as a side effect on the calling job.

## Versioning

Consumers pin an exact release tag. The action reads `package.json` from its own checkout and runs that npm version, so the git ref is the only pin and the tag can't diverge from the CLI. No floating `v3` is maintained — a moving major is a second release channel to operate for a benefit Dependabot's `github-actions` ecosystem already delivers. Recorded with reasoning in `RELEASING.md`; adding a floating tag later is backwards-compatible, removing one isn't.

## Guards

- `action.yml` joins the emitted-pin scan from #342 — its `setup-node` pin drifts exactly like a generated workflow's.
- `tests/scripts/doctor-gate.test.ts` runs the gate as a subprocess, because the exit code is the feature; an assertion on a return value would pass while the step silently stopped failing.
- The `build` job smoke-tests the action through `uses: ./` with `fail-on: none` (this repo has genuine self-repo findings that `dogfood` already accounts for), then asserts the `json` output parses and is non-empty.

## Verified locally

`pnpm run verify` — 47 files / 598 tests passed. Simulating the composite's run block against the built CLI: version derived `3.2.5`, doctor exit `1`, `GITHUB_OUTPUT` 8675 bytes, gate exits `1 / 1 / 0` for `drift / missing / none` over 49 checks and 5 findings.

## Left out

Reusable workflow (#316 — this landing is the input to that call), a floating major tag, `node-version` / `json-output-path` / `annotate` inputs, and `$GITHUB_STEP_SUMMARY` rendering.
