### PR TITLE
feat(swift): check and scaffold tag-based SwiftPM releases

### DIFF
--- a/apps/docs/docs/guides/swift.md
+++ b/apps/docs/docs/guides/swift.md
@@ -40,6 +40,7 @@ SwiftPM resolves dependencies on the first `swift build`, and there's no
 | `.githooks/pre-commit` + `pre-push` | Node-free git hooks (SwiftLint, `swift build`/`test`) |
 | `.editorconfig` | Shared baseline plus a `[*.swift]` 4-space override |
 | `.github/workflows/ci.yml` | Swift CI on macOS runners |
+| `.github/workflows/release.yml` | Build/test gate + GitHub Release on a version tag |
 | `.github/workflows/codeql.yml` | CodeQL with `language: swift` |
 | `.github/dependabot.yml` + auto-merge workflow | Grouped dependency updates |
 | `AGENTS.md`, `CLAUDE.md`, Cursor/Copilot rules, Claude skill, `.mcp.json.example` | AI agent files (language-agnostic) |
@@ -93,7 +94,7 @@ not having. Concretely:
 | Dead code | knip | Periphery |
 | Install step | `pnpm install` | none — SwiftPM resolves on build |
 | Git hooks | Husky + lint-staged (`.husky/`) | committed `.githooks/` + `core.hooksPath` |
-| Release | semantic-release → npm | git tags → SwiftPM |
+| Release | semantic-release → npm | version tag → GitHub Release (`release.yml`) |
 | CI runner | `ubuntu-latest` | `macos-latest` (Xcode) |
 | CodeQL | `javascript-typescript` | `swift` |
 
@@ -136,6 +137,7 @@ npx @rtorcato/repo-tooling fix periphery       # .periphery.yml
 npx @rtorcato/repo-tooling fix swift-gitignore  # append build artefacts
 npx @rtorcato/repo-tooling fix swift-git-hooks  # .githooks/ + core.hooksPath
 npx @rtorcato/repo-tooling fix swift-ci         # .github/workflows/ci.yml
+npx @rtorcato/repo-tooling fix swift-release    # .github/workflows/release.yml
 npx @rtorcato/repo-tooling fix swift-codeql     # .github/workflows/codeql.yml
 npx @rtorcato/repo-tooling fix swift-gitlab-ci  # .gitlab-ci.yml
 ```

--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -19,6 +19,7 @@ The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-
 | SwiftLint | `missing` | `swiftlint` |
 | Periphery | `optional-missing` | `periphery` |
 | Swift `.gitignore` | `missing` | `swift-gitignore` |
+| Release automation | `optional-missing` | `swift-release` |
 | Git hooks | `optional-missing` | `swift-git-hooks` |
 | Pre-push hook | `optional-missing` | `swift-git-hooks` |
 
@@ -146,6 +147,31 @@ The `platforms` matrix is emitted only when the manifest declares both a `platfo
 
 CodeQL uses `language: swift` rather than the JS matrix.
 
+### Releases
+
+```bash
+npx @rtorcato/repo-tooling fix swift-release   # .github/workflows/release.yml
+```
+
+SwiftPM has no registry publish step — a release *is* a semver git tag that
+consumers resolve with `.package(url:from:)` — so the workflow fires on the tag
+rather than on a merge:
+
+| Trigger | What runs |
+|---|---|
+| push of `1.2.3` or `v1.2.3` | `swift build`, `swift test`, then `gh release create --generate-notes --verify-tag` |
+
+The build/test gate runs *before* the release is cut because a tag is
+effectively permanent: SwiftPM caches resolved tags, so re-pointing a bad one
+doesn't reliably reach consumers who already resolved it. `gh` is preinstalled
+on GitHub runners, which is one fewer third-party action pin to track.
+
+`semantic-release` is deliberately not accepted as evidence for this check — its
+pipeline is npm end to end, and a Swift repo running it publishes the wrong
+thing. The lockfile's `semanticRelease` field is the release-automation flag
+either way: set it to `false` and `doctor` records the check as intentionally
+declined.
+
 ### GitLab
 
 GitLab runs Swift in the official Linux image (`swift:6.0`), which has no Xcode — so `.gitlab-ci.yml` covers the Linux-portable half only, `swift build` then `swift test`. No SwiftLint, no platform matrix.
@@ -157,5 +183,4 @@ GitLab runs Swift in the official Linux image (`swift:6.0`), which has no Xcode 
 ## What isn't covered yet
 
 - **README badges.** The `README badges` check runs on a Swift repo, but there's no fixer: `fix badges` derives every badge URL from a package.json `name` + `repository`, which a SwiftPM repo hasn't got. `doctor` reports; you add the badges by hand.
-- **Release automation.** SwiftPM consumes git tags, so there's no `semantic-release` equivalent wired up. Tracked in [#310](https://github.com/rtorcato/repo-tooling/issues/310).
 - **DocC, swift-format and test configuration.** Tracked in [#311](https://github.com/rtorcato/repo-tooling/issues/311).

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -61,6 +61,7 @@ const SWIFT_FIX_TARGETS: Record<string, string> = {
 	SwiftLint: 'swiftlint',
 	Periphery: 'periphery',
 	'Swift .gitignore': 'swift-gitignore',
+	'Release automation': 'swift-release',
 }
 
 export function getFixTargetForCheck(checkName: string, language?: string): string | null {
@@ -104,6 +105,10 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 				c.testing?.framework === 'none'
 			)
 		case 'semantic-release':
+		// The Swift shape of the same recorded choice (#310): `semanticRelease`
+		// is the config's release-automation flag, and on a SwiftPM repo that
+		// means a tag-triggered workflow rather than an npm publish.
+		case 'Release automation':
 			return c.semanticRelease === false
 		case 'Dependabot':
 		case 'CodeQL':
@@ -167,6 +172,7 @@ export function lockfilePatchForTarget(
 		case 'swift-git-hooks':
 			return c.gitHooks ? null : { gitHooks: true }
 		case 'semantic-release':
+		case 'swift-release':
 			return c.semanticRelease ? null : { semanticRelease: true }
 		case 'dependabot':
 		case 'renovate':

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -101,8 +101,10 @@ export function buildPresetConfig(name: PresetName, projectName: string): Projec
 				// commitlint *is* an npm package and needs node on PATH to run, so
 				// the Swift hooks deliberately wire no commit-msg hook.
 				commitLint: false,
-				// semantic-release publishes to npm. SwiftPM consumes git tags.
-				semanticRelease: false,
+				// The release-automation flag, not the npm tool: semantic-release
+				// publishes to npm, and SwiftPM consumes git tags, so on this path it
+				// means a tag-triggered release workflow instead (#310).
+				semanticRelease: true,
 				securityAutomation: true,
 				bundler: 'none',
 				// Every badge URL is derived from package.json (name + repository),

--- a/src/languages/swift/checks.ts
+++ b/src/languages/swift/checks.ts
@@ -117,6 +117,48 @@ export async function checkPackageSwift(dir: string): Promise<CheckResult> {
 }
 
 /**
+ * Release automation for a SwiftPM package (#310). There is no publish step to
+ * look for — a release *is* a semver git tag consumers resolve with
+ * `.package(url:from:)` — so "configured" means a workflow that fires on a tag
+ * push. semantic-release is deliberately not accepted as evidence: its pipeline
+ * is npm end to end, and a Swift repo running it is publishing the wrong thing.
+ *
+ * Only the trigger section is searched (everything above `jobs:`), because
+ * `tags:` also appears inside job steps — docker/metadata-action emits one — and
+ * a step that mentions tags is not a release trigger.
+ */
+export async function checkSwiftRelease(dir: string): Promise<CheckResult> {
+	const check = 'Release automation'
+	const hint =
+		'Run `npx @rtorcato/repo-tooling fix swift-release` to scaffold a tag-triggered release workflow'
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+
+	if (await fs.pathExists(workflowsDir)) {
+		const files = (await fs.readdir(workflowsDir)).filter(
+			(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+		)
+		for (const file of files) {
+			const contents = await fs.readFile(path.join(workflowsDir, file), 'utf-8')
+			const triggers = contents.split(/^jobs:/m)[0] ?? ''
+			if (/^\s+tags:/m.test(triggers)) {
+				return {
+					check,
+					status: 'ok',
+					detail: `.github/workflows/${file} releases on a tag push`,
+				}
+			}
+		}
+	}
+
+	return {
+		check,
+		status: 'optional-missing',
+		detail: 'no workflow triggered by a version tag',
+		hint,
+	}
+}
+
+/**
  * The Swift shape of the base `Git hooks` / `Pre-push hook` checks (#309).
  * `install` is null because the wiring — `git config core.hooksPath` — is
  * per-clone local state that nothing commits; flagging its absence would fail
@@ -135,5 +177,6 @@ export async function runSwiftChecks(dir: string): Promise<CheckResult[]> {
 		await checkPackageSwift(dir),
 		...(await Promise.all(SWIFT_FILE_CHECKS.map((spec) => checkFile(dir, spec)))),
 		await checkSwiftGitignore(dir),
+		await checkSwiftRelease(dir),
 	]
 }

--- a/src/languages/swift/ci.ts
+++ b/src/languages/swift/ci.ts
@@ -164,6 +164,50 @@ export function renderSwiftWorkflow(pkg: SwiftPackage): string {
 }
 
 /**
+ * The release pipeline (#310). SwiftPM has no registry publish step — a release
+ * *is* a semver git tag that consumers resolve with `.package(url:from:)` — so
+ * the workflow fires on the tag rather than on a merge, and its only output is
+ * a GitHub Release with generated notes.
+ *
+ * The build/test gate runs before the release is cut because a tag is
+ * effectively permanent: SwiftPM caches resolved tags, so re-pointing a bad one
+ * doesn't reliably reach consumers who already resolved it.
+ *
+ * `gh` (preinstalled on the runner) rather than a release action: one fewer
+ * third-party pin to track, and `--verify-tag` refuses to invent a tag that
+ * isn't actually pushed.
+ */
+export function renderSwiftReleaseWorkflow(): string {
+	return `name: 🏷️  Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    runs-on: ${MACOS}
+    permissions:
+      contents: write
+    steps:
+${XCODE_SETUP}
+
+      - name: 🏗️  swift build
+        run: swift build
+
+      - name: 🧪 swift test
+        run: swift test
+
+      - name: 🏷️  Publish GitHub Release
+        env:
+          GH_TOKEN: \${{ github.token }}
+        run: gh release create "\${{ github.ref_name }}" --generate-notes --verify-tag
+`
+}
+
+/**
  * GitLab runs Swift in the official Linux image. That rules out Xcode — so no
  * platform matrix and no SwiftLint (a Homebrew/macOS tool in practice); the
  * Linux-portable half of the pipeline is `swift build` + `swift test`.

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -8,7 +8,12 @@ import type { Fixer } from '../../base/fixers.js'
 import { buildPresetConfig } from '../../cli/commands/setup-presets.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
-import { readSwiftPackage, renderSwiftGitLabCI, renderSwiftWorkflow } from './ci.js'
+import {
+	readSwiftPackage,
+	renderSwiftGitLabCI,
+	renderSwiftReleaseWorkflow,
+	renderSwiftWorkflow,
+} from './ci.js'
 import { SWIFT_HOOKS_DIR, installSwiftGitHooks } from './git-hooks.js'
 import { ensureSwiftGitignore } from './gitignore.js'
 
@@ -79,6 +84,20 @@ export const SWIFT_FIXERS: Fixer[] = [
 			const workflow = renderSwiftWorkflow(await readSwiftPackage(targetDir))
 			await fs.writeFile(path.join(workflowsDir, 'ci.yml'), workflow)
 			return { filesWritten: ['.github/workflows/ci.yml'] }
+		},
+	},
+	{
+		target: 'swift-release',
+		description:
+			'Scaffold .github/workflows/release.yml (build + test on a version tag, then publish a GitHub Release)',
+		appliesTo: ['Release automation'],
+		outputs: ['.github/workflows/release.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const workflowsDir = path.join(targetDir, '.github', 'workflows')
+			await fs.ensureDir(workflowsDir)
+			await fs.writeFile(path.join(workflowsDir, 'release.yml'), renderSwiftReleaseWorkflow())
+			return { filesWritten: ['.github/workflows/release.yml'] }
 		},
 	},
 	{

--- a/src/languages/swift/scaffold.ts
+++ b/src/languages/swift/scaffold.ts
@@ -19,7 +19,7 @@ import { generateEditorConfig } from '../../cli/generators/misc.js'
 import { generateCodeQLWorkflow, generateDependabotConfig } from '../../cli/generators/security.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LANGUAGES } from '../registry.js'
-import { readSwiftPackage, renderSwiftWorkflow } from './ci.js'
+import { readSwiftPackage, renderSwiftReleaseWorkflow, renderSwiftWorkflow } from './ci.js'
 import { SWIFT_HOOKS_DIR, installSwiftGitHooks } from './git-hooks.js'
 import { ensureSwiftGitignore } from './gitignore.js'
 
@@ -174,7 +174,20 @@ ${config.projectName}/
 - **GitHub Actions** — \`swift build\`/\`swift test\` on macOS, plus \`xcodebuild\` per declared platform
 
 Run \`npx @rtorcato/repo-tooling doctor\` any time to audit this repo against the standard.
+${
+	config.semanticRelease
+		? `
+## Releasing
 
+SwiftPM has no registry: a release is a semver git tag. Pushing one runs the
+build/test gate and publishes a GitHub Release from it.
+
+\`\`\`bash
+git tag 1.0.0 && git push origin 1.0.0
+\`\`\`
+`
+		: ''
+}
 ## Contributing
 
 1. Fork the repository
@@ -206,6 +219,9 @@ export function swiftFileList(config: ProjectConfig): string[] {
 		'.editorconfig',
 		'.github/workflows/ci.yml',
 	]
+	if (config.semanticRelease) {
+		files.push('.github/workflows/release.yml')
+	}
 	if (config.gitHooks) {
 		files.push(`${SWIFT_HOOKS_DIR}/pre-commit`, `${SWIFT_HOOKS_DIR}/pre-push`)
 	}
@@ -259,6 +275,11 @@ export async function generateSwiftProject(config: ProjectConfig, targetDir: str
 		path.join(workflowsDir, 'ci.yml'),
 		renderSwiftWorkflow(await readSwiftPackage(targetDir))
 	)
+
+	// A tag-triggered release, not an npm publish (#310) — see the preset.
+	if (config.semanticRelease) {
+		await fs.writeFile(path.join(workflowsDir, 'release.yml'), renderSwiftReleaseWorkflow())
+	}
 
 	// `core.hooksPath` won't stick here — `setup` scaffolds into a directory that
 	// isn't a git repo yet — so the hooks land as files and the README tells you

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -64,12 +64,14 @@ describe('setup-presets', () => {
 		expect(config.projectType).toBe('library')
 		expect(config.typescript.enabled).toBe(false)
 		expect(config.bundler).toBe('none')
-		// commitlint/semantic-release are npm packages, and every badge URL is
-		// derived from a package.json this repo doesn't have. Git hooks are not —
-		// the Swift path commits `.githooks/` and uses `core.hooksPath` (#309).
+		// commitlint is an npm package, and every badge URL is derived from a
+		// package.json this repo doesn't have. Git hooks are not — the Swift path
+		// commits `.githooks/` and uses `core.hooksPath` (#309) — and
+		// `semanticRelease` is the release-automation flag, which on Swift means a
+		// tag-triggered workflow rather than an npm publish (#310).
 		expect(config.gitHooks).toBe(true)
 		expect(config.commitLint).toBe(false)
-		expect(config.semanticRelease).toBe(false)
+		expect(config.semanticRelease).toBe(true)
 		expect(config.badges).toBe(false)
 		// Security automation and the AI agent files are language-agnostic.
 		expect(config.securityAutomation).toBe(true)

--- a/tests/languages/swift/checks.test.ts
+++ b/tests/languages/swift/checks.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	checkPackageSwift,
 	checkSwiftGitignore,
+	checkSwiftRelease,
 	runSwiftChecks,
 } from '../../../src/languages/swift/checks.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -87,10 +88,57 @@ describe('checkSwiftGitignore', () => {
 	})
 })
 
+describe('checkSwiftRelease', () => {
+	const workflow = (triggers: string) =>
+		`name: x\n\non:\n${triggers}\njobs:\n  release:\n    runs-on: macos-latest\n`
+
+	it('is optional-missing with no workflows at all', async () => {
+		const result = await checkSwiftRelease(newTmpDir())
+		expect(result.status).toBe('optional-missing')
+		expect(result.hint).toContain('fix swift-release')
+	})
+
+	it('passes on a workflow triggered by a tag push', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(
+			join(dir, '.github/workflows/release.yml'),
+			workflow("  push:\n    tags:\n      - '[0-9]+.[0-9]+.[0-9]+'\n")
+		)
+		const result = await checkSwiftRelease(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('release.yml')
+	})
+
+	it('does not count a branch-triggered CI workflow', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(
+			join(dir, '.github/workflows/ci.yml'),
+			workflow('  push:\n    branches: [main]\n')
+		)
+		expect((await checkSwiftRelease(dir)).status).toBe('optional-missing')
+	})
+
+	// `tags:` inside a step (docker/metadata-action emits one) is not a trigger.
+	it('does not count `tags:` appearing inside a job', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(
+			join(dir, '.github/workflows/ci.yml'),
+			`${workflow('  push:\n    branches: [main]\n')}    steps:\n      - uses: docker/metadata-action@v5\n        with:\n          tags: latest\n`
+		)
+		expect((await checkSwiftRelease(dir)).status).toBe('optional-missing')
+	})
+})
+
 describe('runSwiftChecks', () => {
-	it('covers Package.swift, SwiftLint, Periphery and the gitignore', async () => {
+	it('covers Package.swift, SwiftLint, Periphery, the gitignore and releases', async () => {
 		const names = (await runSwiftChecks(newTmpDir())).map((r) => r.check)
-		expect(names).toEqual(['Package.swift', 'SwiftLint', 'Periphery', 'Swift .gitignore'])
+		expect(names).toEqual([
+			'Package.swift',
+			'SwiftLint',
+			'Periphery',
+			'Swift .gitignore',
+			'Release automation',
+		])
 	})
 
 	it('treats Periphery as optional but SwiftLint as required', async () => {

--- a/tests/languages/swift/ci.test.ts
+++ b/tests/languages/swift/ci.test.ts
@@ -1,10 +1,17 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
+import { checkSwiftRelease } from '../../../src/languages/swift/checks.js'
 import {
 	parsePackageSwift,
 	renderSwiftGitLabCI,
+	renderSwiftReleaseWorkflow,
 	renderSwiftWorkflow,
 	swiftGithubJobs,
 } from '../../../src/languages/swift/ci.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
 
 const MANIFEST = `// swift-tools-version: 5.9
 
@@ -91,6 +98,29 @@ describe('swiftGithubJobs', () => {
 	it('skips the platform matrix when there is no library product to use as a scheme', () => {
 		const noProducts = parsePackageSwift('platforms: [.macOS(.v13)]')
 		expect(swiftGithubJobs(noProducts).map((j) => j.id)).not.toContain('platforms')
+	})
+})
+
+describe('renderSwiftReleaseWorkflow', () => {
+	it('fires on a version tag, bare or v-prefixed', () => {
+		const yaml = renderSwiftReleaseWorkflow()
+		expect(yaml).toContain("      - '[0-9]+.[0-9]+.[0-9]+'")
+		expect(yaml).toContain("      - 'v[0-9]+.[0-9]+.[0-9]+'")
+	})
+
+	// A tag is effectively permanent once SwiftPM has resolved it, so the gate
+	// has to run before the release is cut, not after.
+	it('builds and tests before publishing the release', () => {
+		const yaml = renderSwiftReleaseWorkflow()
+		expect(yaml.indexOf('swift test')).toBeLessThan(yaml.indexOf('gh release create'))
+		expect(yaml).toContain('--verify-tag')
+		expect(yaml).toContain('contents: write')
+	})
+
+	it('is the shape the Release automation check accepts', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(join(dir, '.github/workflows/release.yml'), renderSwiftReleaseWorkflow())
+		expect((await checkSwiftRelease(dir)).status).toBe('ok')
 	})
 })
 

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { runDoctor } from '../../../src/cli/commands/doctor.js'
 import { BASE_FIXERS } from '../../../src/base/fixers.js'
 import { FIXERS } from '../../../src/languages/js/fixers.js'
-import { checkSwiftGitignore } from '../../../src/languages/swift/checks.js'
+import { checkSwiftGitignore, checkSwiftRelease } from '../../../src/languages/swift/checks.js'
 import { SWIFT_FIXERS } from '../../../src/languages/swift/fixers.js'
 import { ensureSwiftGitignore } from '../../../src/languages/swift/gitignore.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -83,6 +83,13 @@ describe('swift fixers', () => {
 		const dir = newTmpDir()
 		await fixer('periphery').run(ctx(dir))
 		expect(await fs.readFile(join(dir, '.periphery.yml'), 'utf-8')).toContain('retain_public: true')
+	})
+
+	it('swift-release writes a workflow the Release automation check accepts', async () => {
+		const dir = newTmpDir()
+		const { filesWritten } = await fixer('swift-release').run(ctx(dir))
+		expect(filesWritten).toEqual(['.github/workflows/release.yml'])
+		expect((await checkSwiftRelease(dir)).status).toBe('ok')
 	})
 
 	// #309: the checks moved to src/base, so a Swift repo now gets them — but

--- a/tests/languages/swift/scaffold.test.ts
+++ b/tests/languages/swift/scaffold.test.ts
@@ -84,7 +84,27 @@ describe('generateSwiftProject', () => {
 			'SwiftLint: ok',
 			'Periphery: ok',
 			'Swift .gitignore: ok',
+			'Release automation: ok',
 		])
+	})
+
+	// #310: SwiftPM has no registry, so the scaffold's release path is a
+	// tag-triggered workflow rather than anything npm-shaped.
+	it('writes a tag-triggered release workflow with no npm publish in it', async () => {
+		const dir = await scaffold()
+		const release = await fs.readFile(join(dir, '.github/workflows/release.yml'), 'utf-8')
+		expect(release).toContain('tags:')
+		expect(release).toContain('gh release create')
+		expect(release).not.toMatch(/npm|semantic-release/)
+	})
+
+	it('omits the release workflow when release automation is declined', async () => {
+		const dir = newTmpDir()
+		await generateSwiftProject(
+			{ ...buildPresetConfig('swift-library', 'demo'), semanticRelease: false },
+			dir
+		)
+		expect(await fs.pathExists(join(dir, '.github/workflows/release.yml'))).toBe(false)
 	})
 
 	// #309: a fresh scaffold must satisfy the base hook checks it now gets, or


### PR DESCRIPTION
Closes #310

## What

`doctor` gets a `Release automation` check for Swift repos, and `fix
swift-release` scaffolds the workflow that satisfies it.

SwiftPM has no registry publish step — a release **is** a semver git tag that
consumers resolve with `.package(url:from:)` — so "configured" means a workflow
triggered by a tag push, not a publish pipeline.

## Decisions

- **What counts as configured.** A workflow whose *trigger* section contains
  `tags:`. Only the text above `jobs:` is scanned, because `tags:` also appears
  inside steps (docker/metadata-action emits one) and a step is not a trigger.
- **semantic-release is not evidence.** Its pipeline is npm end to end; a Swift
  repo running it publishes the wrong thing.
- **The opt-out is the lockfile's `semanticRelease` field**, re-read as the
  release-automation flag rather than the name of an npm tool. `false` →
  `doctor` reports the check as intentionally declined, via the existing
  `declinedInLock` path. That also means the `swift-library` preset now sets it
  `true` (previously `false` with a comment explaining the gap this issue is
  about), so a fresh scaffold ships `release.yml` and passes its own check.
- **`gh release create` over a release action.** Preinstalled on the runner, so
  one fewer third-party pin in the emitted set; `--verify-tag` refuses to invent
  a tag that was never pushed.
- **Build/test before the release is cut.** A tag is effectively permanent once
  SwiftPM has resolved it, so re-pointing a bad one doesn't reliably reach
  consumers.

## Verification

- `pnpm run verify` — biome clean, tsc clean, 621 tests passed (47 files), build ok.
- `pnpm build-cli && node scripts/integration/preset-lifecycle.mjs swift-library`
  — `swift build`, `swift test` (1 test, 0 failures) and `swiftlint lint
  --strict` (0 violations) all green on the scaffolded package.

## Left out

No fixer for adding a tag *to* the repo, and no changelog generation — GitHub's
`--generate-notes` covers the notes, and anything more is a release tool, which
is the thing SwiftPM doesn't need.