### PR TITLE
fix(ci): stop silently overwriting a consumer's ci.yml, and let doctor see the drift

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -187,7 +187,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 
 | Target | Scaffolds |
 |---|---|
-| `github-actions` | `.github/workflows/ci.yml` (+ `codecov.yml`; Vitest jobs upload coverage) |
+| `github-actions` | `.github/workflows/ci.yml` (+ `codecov.yml`; Vitest jobs upload coverage). A `ci.yml` that no longer matches the preset is left as-is unless the finding being fixed is the `GitHub Actions` drift itself — your edits are never silently reverted |
 | `gitlab-ci` | `.gitlab-ci.yml` (lint/typecheck/test/build mirrored from GitHub Actions) |
 | `dependabot` | `.github/dependabot.yml` (monthly, grouped: production-minor/dev-minor/major-updates) + the `dependabot-automerge.yml` workflow — see [Dependabot strategy](./dependabot-strategy.md) |
 | `renovate` | `renovate.json` (alternative to Dependabot) |

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -93,7 +93,31 @@ export async function checkCommunityHealth(dir: string): Promise<CheckResult> {
 	}
 }
 
-export async function checkGitHubActions(dir: string): Promise<CheckResult> {
+/**
+ * `org/action@vN`, the only form the generators emit. Same shape as the scan in
+ * tests/cli/generators/action-pins.test.ts — major-only, because that's the
+ * granularity every emitted pin uses.
+ */
+const ACTION_PIN = /\b([a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*)@v(\d+)/g
+
+function actionPins(yaml: string): Map<string, string> {
+	const pins = new Map<string, string>()
+	for (const [, action, major] of yaml.matchAll(ACTION_PIN)) {
+		if (action && major) pins.set(action, major)
+	}
+	return pins
+}
+
+/**
+ * @param preset the ci.yml this repo's generator would render right now, or null
+ * for a language whose CI generator isn't wired up. Supplied by the caller
+ * rather than rendered here: the JS preset needs a ProjectConfig and the Swift
+ * one needs Package.swift, neither of which belongs in a base check.
+ */
+export async function checkGitHubActions(
+	dir: string,
+	preset: string | null = null
+): Promise<CheckResult> {
 	const workflowsDir = path.join(dir, '.github', 'workflows')
 	if (!(await fs.pathExists(workflowsDir))) {
 		return {
@@ -115,6 +139,35 @@ export async function checkGitHubActions(dir: string): Promise<CheckResult> {
 				hint: 'Add a workflow file (e.g. ci.yml) under .github/workflows/',
 			}
 		}
+
+		// "A workflow exists" said nothing about whether it still matches the preset,
+		// so doctor reported ok on a ci.yml that had drifted arbitrarily far — the
+		// blind half of #349/#340. Compare action pins rather than the whole file: a
+		// consuming repo is *expected* to add jobs and steps, so a byte diff is noise
+		// on every customized repo, while a pin major that disagrees with the preset
+		// is exactly the drift that loops (a bump here, a sync there, forever).
+		const ciPath = path.join(workflowsDir, 'ci.yml')
+		if (preset && (await fs.pathExists(ciPath))) {
+			const ours = actionPins(preset)
+			const deltas: string[] = []
+			for (const [action, major] of actionPins(await fs.readFile(ciPath, 'utf-8'))) {
+				const expected = ours.get(action)
+				// Only the intersection is comparable — an action the repo runs but the
+				// preset never emits is the consumer's own business.
+				if (expected && expected !== major) {
+					deltas.push(`${action}@v${major} (preset emits @v${expected})`)
+				}
+			}
+			if (deltas.length > 0) {
+				return {
+					check: 'GitHub Actions',
+					status: 'drift',
+					detail: `ci.yml action pins disagree with the preset: ${deltas.join('; ')}`,
+					hint: 'Run `npx @rtorcato/repo-tooling fix github-actions --diff` to see the delta before overwriting — a pin *ahead* of the preset means regenerating would downgrade it',
+				}
+			}
+		}
+
 		return {
 			check: 'GitHub Actions',
 			status: 'ok',

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,8 +1,12 @@
 import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
+import { renderGitHubWorkflow } from '../../base/ci.js'
+import { githubJobs } from '../../languages/js/ci.js'
+import { inferProjectConfig } from '../../languages/js/fixers.js'
 import { resolveLanguageModule } from '../../languages/registry.js'
 import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../languages/swift/checks.js'
+import { readSwiftPackage, renderSwiftWorkflow } from '../../languages/swift/ci.js'
 import { detectLanguage } from '../utils/detect-language.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
 import { checkGitIdentity } from '../../base/git-identity.js'
@@ -194,6 +198,12 @@ interface BaseCheckOptions {
 	/** Null for a language whose hook convention isn't encoded yet (Python/Perl). */
 	hooks: GitHooksProfile | null
 	badges: { audience: BadgeAudience; fixTarget: string | null }
+	/**
+	 * The ci.yml this module's generator would render right now, so the CI check
+	 * can spot a workflow that has drifted from it (#349). Null for a language
+	 * with no CI generator — nothing to compare against.
+	 */
+	presetWorkflow: string | null
 }
 
 // The language-agnostic checks (src/base): repo hygiene, git hooks, CI,
@@ -214,7 +224,7 @@ async function runBaseChecks(
 		results.push(await checkGitHooks(dir, opts.hooks))
 		results.push(await checkPrePushHook(dir, opts.hooks))
 	}
-	results.push(await checkGitHubActions(dir))
+	results.push(await checkGitHubActions(dir, opts.presetWorkflow))
 	results.push(await checkDependabot(dir))
 	results.push(await checkCodeQL(dir))
 	// GitHub repo-settings drift (branch protection, merge settings, workflow
@@ -255,6 +265,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 			...(await runBaseChecks(targetDir, lock, {
 				hooks: null,
 				badges: { audience: 'public', fixTarget: null },
+				presetWorkflow: null,
 			})),
 		]
 		return demoteDeclined(results, lock)
@@ -275,6 +286,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				// badges always apply. No fixer: `fix badges` derives the block from
 				// package.json name/repository, which a Swift repo hasn't got.
 				badges: { audience: 'public', fixTarget: null },
+				presetWorkflow: renderSwiftWorkflow(await readSwiftPackage(targetDir)),
 			})),
 			...(await runSwiftChecks(targetDir)),
 		]
@@ -328,6 +340,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 		...(await runBaseChecks(targetDir, lock, {
 			hooks: jsGitHooksProfile(pkg),
 			badges: { audience: jsBadgeAudience(pkg), fixTarget: 'badges' },
+			presetWorkflow: renderGitHubWorkflow(githubJobs(inferProjectConfig(pkg))),
 		}))
 	)
 

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -19,7 +19,24 @@ const CODECOV_YML = `coverage:
         threshold: 1%
 `
 
-export async function generateGitHubActions(config: ProjectConfig, targetDir: string) {
+/** Matches the fixer's declared output, so `fix` reports the same path it lists. */
+export const CI_WORKFLOW = '.github/workflows/ci.yml'
+
+/**
+ * @param overwrite Replace a ci.yml that no longer matches the preset. Off by
+ * default: this used to write unconditionally, so a consuming repo's customized
+ * workflow — an extra job, a Dependabot-bumped action pin — was reverted on
+ * every sync with no diff, no prompt and no backup (#349, the mechanism behind
+ * #340). Same self-enforced safe-add as github-workflows.ts, widened to "or is
+ * byte-identical anyway" so a no-op regeneration still reports honestly. Only a
+ * caller that has told the user this workflow itself is drifting passes true.
+ * @returns the files actually written, relative to targetDir.
+ */
+export async function generateGitHubActions(
+	config: ProjectConfig,
+	targetDir: string,
+	{ overwrite = false }: { overwrite?: boolean } = {}
+): Promise<string[]> {
 	const workflowsDir = path.join(targetDir, '.github', 'workflows')
 	await fs.ensureDir(workflowsDir)
 
@@ -30,11 +47,19 @@ export async function generateGitHubActions(config: ProjectConfig, targetDir: st
 	// paths meet at renderGitHubWorkflow() in src/base/ci.ts, which is the seam
 	// that actually matters.
 	const workflow = renderGitHubWorkflow(githubJobs(config))
-	await fs.writeFile(path.join(workflowsDir, 'ci.yml'), workflow)
+	const ciPath = path.join(workflowsDir, 'ci.yml')
+	const existing = (await fs.pathExists(ciPath)) ? await fs.readFile(ciPath, 'utf-8') : null
+	const filesWritten: string[] = []
+	if (overwrite || existing === null || existing === workflow) {
+		await fs.writeFile(ciPath, workflow)
+		filesWritten.push(CI_WORKFLOW)
+	}
 
 	// codecov.yml is the CI's coverage-upload companion — emit it alongside ci.yml
 	// whenever the workflow uploads coverage, so the codecov badge isn't red.
 	if (usesCoverage(config)) {
 		await fs.writeFile(path.join(targetDir, 'codecov.yml'), CODECOV_YML)
+		filesWritten.push('codecov.yml')
 	}
+	return filesWritten
 }

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -9,7 +9,7 @@ import {
 	generateSemanticReleaseConfig,
 } from '../../cli/generators/build.js'
 import { generateHuskyConfig, generatePrePushHook } from '../../cli/generators/git.js'
-import { generateGitHubActions } from '../../cli/generators/github-actions.js'
+import { CI_WORKFLOW, generateGitHubActions } from '../../cli/generators/github-actions.js'
 import { generateGitLabCI } from '../../cli/generators/gitlab-ci.js'
 import { GH_WORKFLOWS, generateGhWorkflow } from '../../cli/generators/github-workflows.js'
 import { generateESLintConfig, generatePrettierConfig } from '../../cli/generators/linting.js'
@@ -45,7 +45,8 @@ import type { ProjectConfig } from '../../cli/commands/setup.js'
 // module (#286) — import it from there.
 import type { Fixer, Pkg } from '../../base/fixers.js'
 
-function inferProjectConfig(pkg: Pkg): ProjectConfig {
+/** Exported so doctor can render the preset ci.yml it compares against (#349). */
+export function inferProjectConfig(pkg: Pkg): ProjectConfig {
 	const deps = {
 		...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
 		...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
@@ -335,12 +336,23 @@ export const FIXERS: Fixer[] = [
 		target: 'github-actions',
 		description: 'Scaffold .github/workflows/ci.yml (+ codecov.yml when tests run)',
 		appliesTo: ['GitHub Actions', 'Coverage upload', 'npm OIDC publish'],
-		outputs: ['.github/workflows/ci.yml', 'codecov.yml'],
+		outputs: [CI_WORKFLOW, 'codecov.yml'],
 		canFixDrift: true,
-		async run({ targetDir, pkg }) {
-			await generateGitHubActions(inferProjectConfig(pkg), targetDir)
-			const filesWritten = ['.github/workflows/ci.yml']
-			if (await fs.pathExists(path.join(targetDir, 'codecov.yml'))) filesWritten.push('codecov.yml')
+		async run({ targetDir, pkg, result }) {
+			// Only a `GitHub Actions` finding means the user was shown that the
+			// workflow itself is wrong (and got the destructive-overwrite prompt).
+			// A sibling finding — Coverage upload, npm OIDC publish — must not take a
+			// customized ci.yml down with it (#349).
+			const filesWritten = await generateGitHubActions(inferProjectConfig(pkg), targetDir, {
+				overwrite: result.check === 'GitHub Actions',
+			})
+			if (!filesWritten.includes(CI_WORKFLOW)) {
+				console.log(
+					chalk.yellow(
+						`   ${CI_WORKFLOW} differs from the preset — left as-is; run \`fix github-actions --diff\` to see the delta`
+					)
+				)
+			}
 			return { filesWritten }
 		},
 	},

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -428,6 +428,34 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'GitHub Actions')?.status).toBe('ok')
 	})
 
+	// #349/#340: "a workflow exists" reported ok on a ci.yml that had drifted
+	// arbitrarily far from the preset, so nothing ever noticed the sync reverting a
+	// consumer's action bump.
+	it('flags ci.yml action pins that disagree with the preset', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'name: ci\njobs:\n  lint:\n    steps:\n      - uses: actions/setup-node@v3\n'
+		)
+		const gha = (await runDoctor(dir)).find((r) => r.check === 'GitHub Actions')
+		expect(gha?.status).toBe('drift')
+		expect(gha?.detail).toMatch(/actions\/setup-node@v3/)
+	})
+
+	it('ignores action pins the preset never emits', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.ensureDir(join(dir, '.github', 'workflows'))
+		await fs.writeFile(
+			join(dir, '.github', 'workflows', 'ci.yml'),
+			'name: ci\njobs:\n  lint:\n    steps:\n      - uses: some-org/some-action@v1\n'
+		)
+		const gha = (await runDoctor(dir)).find((r) => r.check === 'GitHub Actions')
+		expect(gha?.status).toBe('ok')
+	})
+
 	it('reports verify script optional-missing when not in package.json', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
-import { generateGitHubActions } from '../../../src/cli/generators/github-actions.js'
+import { CI_WORKFLOW, generateGitHubActions } from '../../../src/cli/generators/github-actions.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -186,6 +186,41 @@ describe('generateGitHubActions', () => {
 
 		const content = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
 		expect(content).toContain('pnpm check')
+	})
+
+	// #349/#340: this generator used to writeFile unconditionally, so a consuming
+	// repo's Dependabot-bumped pin was reverted on every sync — no diff, no prompt,
+	// no backup — and Dependabot re-opened the identical PR forever.
+	it('leaves a customized ci.yml alone rather than silently overwriting it', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig(), dir)
+		const customized = `${await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')}\n# hand-edited\n`
+		await fs.writeFile(join(dir, WORKFLOW_PATH), customized)
+
+		const written = await generateGitHubActions(baseConfig(), dir)
+
+		expect(written).not.toContain(CI_WORKFLOW)
+		expect(await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')).toBe(customized)
+	})
+
+	it('replaces a customized ci.yml only when the caller opts in', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig(), dir)
+		await fs.writeFile(join(dir, WORKFLOW_PATH), '# hand-edited\n')
+
+		const written = await generateGitHubActions(baseConfig(), dir, { overwrite: true })
+
+		expect(written).toContain(CI_WORKFLOW)
+		expect(await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')).toContain('CI/CD Pipeline')
+	})
+
+	it('rewrites an untouched ci.yml, so a preset change still lands', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(baseConfig(), dir)
+
+		const written = await generateGitHubActions(baseConfig(), dir)
+
+		expect(written).toContain(CI_WORKFLOW)
 	})
 
 	it('uses pnpm lint in lint job when linting tool is eslint', async () => {


### PR DESCRIPTION
Closes #349. Refs #340, #316.

## The two halves of the hole

`src/cli/generators/github-actions.ts` did an unconditional `fs.writeFile` of `.github/workflows/ci.yml`, and `checkGitHubActions` in `src/base/checks.ts` only asserted that *some* `.yml` existed under `.github/workflows/`. Together: `doctor` reports the green tick on a workflow that has drifted arbitrarily far from the preset, and the next `fix` rewrites it from scratch. That is the #340 loop — rtorcato/js-common bumped `actions/setup-node` to v7, the sync put it back, Dependabot reopened the identical PR forever.

#342 and #348 stopped *our own* emitted pins drifting. That protects the pins we emit and does nothing about overwriting a consumer's file.

## 1. `doctor` can now see it — pins, not bytes

`checkGitHubActions` takes the ci.yml the language's generator would render *right now* and compares action pins with the on-disk file. A mismatch is `drift`, and the detail names both majors:

```
ci.yml action pins disagree with the preset: actions/setup-node@v3 (preset emits @v7)
```

**Why pins and not a byte diff.** A consuming repo is *expected* to add jobs, tweak steps, change runner labels — that is what a scaffolded workflow is for. A full-file compare would report drift on essentially every customised repo on day one, and a check that is always yellow gets ignored, which is how we got here. A pin major that disagrees with the preset is narrow, actionable, and is precisely the class of drift that loops: it is the only part of the file both Dependabot and this generator write.

The preset is rendered, not tabulated — there is no new list of "expected pins" that could itself drift. It comes from `renderGitHubWorkflow(githubJobs(...))` for JS and `renderSwiftWorkflow(...)` for Swift, handed to the base check through `BaseCheckOptions`, the same way `hooks` and `badges` already hand in language-shaped evidence (#309). Only the intersection is compared: an action the repo runs but the preset never emits is the consumer's own business.

The hint deliberately mentions the direction, because a pin *ahead* of the preset is the #340 case and regenerating would downgrade it:

> Run `fix github-actions --diff` to see the delta before overwriting — a pin *ahead* of the preset means regenerating would downgrade it

## 2. `fix github-actions` no longer clobbers silently

`generateGitHubActions` now writes ci.yml only when it is absent, byte-identical, or the caller passes `overwrite: true`. That is the self-enforced safe-add already in `github-workflows.ts` (`fs.copy(..., { overwrite: false })`), widened to "or is identical anyway" so an unmodified file still gets preset updates and the fixer still reports honestly. It returns the files it actually wrote instead of `void`.

The `github-actions` fixer opts in only when `result.check === 'GitHub Actions'`. That is the case where `fix` has already shown the user the destructive-overwrite prompt ("user customizations will be lost", defaulting to no) because the check is in `drift`. The fixer's other two `appliesTo` entries — `Coverage upload`, `npm OIDC publish` — were the actual silent path: they made `fix` pick a friendly `optional-missing` prompt defaulting to **yes**, and then rewrote the whole workflow. They no longer touch a customised ci.yml, and say so:

```
   .github/workflows/ci.yml differs from the preset — left as-is; run `fix github-actions --diff` to see the delta
```

`setup` and `fix --resync` pass nothing, so they inherit the safe default — consistent with the resync prompt's own promise that generators preserve existing customizations.

## Tests

Three in `tests/cli/generators/github-actions.test.ts` (leaves a customised file alone / replaces it on explicit opt-in / still rewrites an untouched one, so a preset change lands) and two in `tests/cli/commands/doctor.test.ts` (pin mismatch is drift / an action the preset never emits is not).

Verified they fail against the old behaviour, not just pass against the new one: reverting the write guard and passing `presetWorkflow: null` fails exactly `leaves a customized ci.yml alone rather than silently overwriting it` and `flags ci.yml action pins that disagree with the preset`, with the rest of the suite green.

## Deliberately not in this PR

- **`codecov.yml` is still written unconditionally.** Same fixer, same class of bug, but it is eleven lines of pure preset with no jobs to lose, and #349 is about `ci.yml`. Worth its own issue rather than widening this diff.
- **`fix github-actions --yes` on a genuine `GitHub Actions` drift still overwrites.** `--yes` means yes, `--diff` shows the delta first, and `doctor` now reports the drift before it happens. Refusing even there would make `canFixDrift: true` a lie and leave no way to apply a preset update.
- **No pin carry-forward.** Keeping a consumer's *higher* major across a regeneration would also break the #340 loop, but it is a behaviour change to the generator's output rather than a data-loss fix, and it belongs in the issue that decides whether the preset or the consumer wins.
- **The `swift-ci` fixer still writes `ci.yml` directly.** Its only `appliesTo` is `GitHub Actions`, so it has no sibling-check path to clobber through; it reaches the write only when that check is missing or drifting, where `fix` already gives the destructive prompt. It does get the new drift detection for free.
