### PR TITLE
feat(swift): add DocC, swift-format and test-configuration checks

### DIFF
--- a/apps/docs/docs/guides/swift.md
+++ b/apps/docs/docs/guides/swift.md
@@ -90,7 +90,8 @@ not having. Concretely:
 | Manifest | `package.json` | `Package.swift` |
 | Build | tsup/esbuild/Vite/Rollup | `swift build` |
 | Test | Vitest/Jest/Playwright/Cypress | `swift test` (XCTest) |
-| Lint + format | Biome or ESLint + Prettier | SwiftLint (both jobs) |
+| Lint + format | Biome or ESLint + Prettier | SwiftLint (both jobs), or swift-format for the formatter half |
+| API docs | TypeDoc | DocC |
 | Dead code | knip | Periphery |
 | Install step | `pnpm install` | none — SwiftPM resolves on build |
 | Git hooks | Husky + lint-staged (`.husky/`) | committed `.githooks/` + `core.hooksPath` |
@@ -134,6 +135,8 @@ scaffolder and would overwrite your manifest. Use `doctor` and `fix` instead:
 npx @rtorcato/repo-tooling doctor              # audit
 npx @rtorcato/repo-tooling fix swiftlint       # .swiftlint.yml
 npx @rtorcato/repo-tooling fix periphery       # .periphery.yml
+npx @rtorcato/repo-tooling fix swift-format    # .swift-format (optional formatter)
+npx @rtorcato/repo-tooling fix docc            # Sources/<Target>/<Target>.docc
 npx @rtorcato/repo-tooling fix swift-gitignore  # append build artefacts
 npx @rtorcato/repo-tooling fix swift-git-hooks  # .githooks/ + core.hooksPath
 npx @rtorcato/repo-tooling fix swift-ci         # .github/workflows/ci.yml

--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -18,12 +18,21 @@ The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-
 | `Package.swift` | `missing` | — (run `swift package init`) |
 | SwiftLint | `missing` | `swiftlint` |
 | Periphery | `optional-missing` | `periphery` |
+| swift-format | `optional-missing` | `swift-format` |
 | Swift `.gitignore` | `missing` | `swift-gitignore` |
+| Swift tests | `missing` | — (manifest edit, or `swift-ci`) |
+| DocC | `optional-missing` | `docc` |
 | Release automation | `optional-missing` | `swift-release` |
 | Git hooks | `optional-missing` | `swift-git-hooks` |
 | Pre-push hook | `optional-missing` | `swift-git-hooks` |
 
 `Package.swift` is checked for two things SwiftPM will not infer: a `// swift-tools-version:` comment (without it the manifest doesn't parse) and an explicit `platforms:` clause (without it SwiftPM assumes its oldest supported deployment target, which rejects modern APIs at build time). There's no fixer — rewriting someone's manifest isn't safe, so `doctor` reports and you edit.
+
+`Swift tests` has two halves: the manifest must declare a `.testTarget(`, and
+some pipeline (`.github/workflows/*` or `.gitlab-ci.yml`) must actually run
+`swift test`. A green pipeline over a package with no test target proves
+nothing. There's no single fix target because the first half is a manifest edit;
+`fix swift-ci` covers the second.
 
 `Git hooks` and `Pre-push hook` are language-agnostic checks (they run on a JS repo too, against `.husky/`); the Swift module only supplies the shape — `.githooks/` and `swift test`.
 
@@ -55,12 +64,13 @@ There's no `commit-msg` hook: commitlint is an npm package and needs node on `PA
 ## Configs
 
 ```bash
-npx @rtorcato/repo-tooling fix swiftlint    # .swiftlint.yml
-npx @rtorcato/repo-tooling fix periphery    # .periphery.yml
+npx @rtorcato/repo-tooling fix swiftlint      # .swiftlint.yml
+npx @rtorcato/repo-tooling fix periphery      # .periphery.yml
+npx @rtorcato/repo-tooling fix swift-format   # .swift-format (optional)
 npx @rtorcato/repo-tooling fix swift-gitignore
 ```
 
-`swiftlint` and `periphery` are also available via `copy`:
+`swiftlint`, `swift-format` and `periphery` are also available via `copy`:
 
 ```bash
 npx @rtorcato/repo-tooling copy swiftlint
@@ -68,7 +78,7 @@ npx @rtorcato/repo-tooling copy swiftlint
 
 ### SwiftLint
 
-Formatting is SwiftLint's job here — `swiftlint --fix` in a pre-commit hook, `swiftlint lint --strict` in CI. **SwiftFormat is deliberately not part of the standard**; a second formatter would fight the first.
+Formatting is SwiftLint's job by default — `swiftlint --fix` in a pre-commit hook, `swiftlint lint --strict` in CI. **SwiftFormat (the Nick Lockwood one) is deliberately not part of the standard**; a second rewriting formatter would fight the first. Apple's `swift-format` is available as an opt-in slot — see [swift-format](#swift-format) below.
 
 ```yaml
 disabled_rules:
@@ -105,6 +115,55 @@ retain_public: true
 ```
 
 Periphery is best run as an informational CI job (`continue-on-error: true`) until a codebase is clean, then promoted to blocking.
+
+### swift-format
+
+Apple's `swift-format` — shipped with the toolchain since Swift 6 as `swift
+format` — is the *formatter* slot, the Biome/Prettier equivalent. It's optional
+because SwiftLint's `--fix` already formats: a repo runs one or the other, and
+the check only reports what it finds.
+
+```bash
+npx @rtorcato/repo-tooling fix swift-format   # .swift-format
+```
+
+```json
+{
+  "version": 1,
+  "lineLength": 120,
+  "indentation": { "spaces": 4 },
+  "respectsExistingLineBreaks": true,
+  "lineBreakBeforeEachArgument": false,
+  "prioritizeKeepingFunctionOutputTogether": true
+}
+```
+
+This is not a second *lint* gate — SwiftLint stays the linter either way, and
+nothing in the generated CI runs `swift format lint` unless you add it.
+
+### DocC
+
+The Swift equivalent of the TypeDoc check. Two halves have to line up: a `.docc`
+catalogue under `Sources/<Target>/` holds the prose, and `swift-docc-plugin` in
+`Package.swift` is what makes `swift package generate-documentation` exist.
+Either alone is drift — docs nobody can build, or a build command with nothing
+to say.
+
+```bash
+npx @rtorcato/repo-tooling fix docc   # Sources/<Target>/<Target>.docc/<Target>.md
+```
+
+The fixer writes the catalogue into the library product's target and stops
+there; adding the plugin dependency is a `Package.swift` edit, and this module
+doesn't rewrite manifests. It prints the line to paste:
+
+```swift
+.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")
+```
+
+Re-running it never overwrites an existing landing page — the catalogue is prose
+someone wrote, and the check stays in drift until the manifest half lands, so a
+re-run is the normal case rather than the exception.
 
 ### `.gitignore`
 
@@ -183,4 +242,4 @@ GitLab runs Swift in the official Linux image (`swift:6.0`), which has no Xcode 
 ## What isn't covered yet
 
 - **README badges.** The `README badges` check runs on a Swift repo, but there's no fixer: `fix badges` derives every badge URL from a package.json `name` + `repository`, which a SwiftPM repo hasn't got. `doctor` reports; you add the badges by hand.
-- **DocC, swift-format and test configuration.** Tracked in [#311](https://github.com/rtorcato/repo-tooling/issues/311).
+- **A `swift-docc-plugin` fixer.** `fix docc` writes the catalogue but not the manifest dependency it needs — rewriting someone's `Package.swift` isn't safe, so the check reports drift and prints the line to add.

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 		"tooling/claude/*.md",
 		"tooling/mcp/mcp.json.example",
 		"tooling/swift/*.yml",
+		"tooling/swift/*.json",
 		"tooling/github-actions/workflows/*.yml",
 		"README.md",
 		"AGENTS.md"

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -62,6 +62,11 @@ const SWIFT_FIX_TARGETS: Record<string, string> = {
 	Periphery: 'periphery',
 	'Swift .gitignore': 'swift-gitignore',
 	'Release automation': 'swift-release',
+	'swift-format': 'swift-format',
+	DocC: 'docc',
+	// `Swift tests` is deliberately absent: when it fails for the manifest half
+	// (no `.testTarget(`) there's nothing to run, and rewriting Package.swift
+	// isn't safe. The check's own hint covers both halves.
 }
 
 export function getFixTargetForCheck(checkName: string, language?: string): string | null {

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -10,6 +10,7 @@ export type PresetName =
 	| 'oxlint'
 	| 'tsconfig'
 	| 'swiftlint'
+	| 'swift-format'
 	| 'periphery'
 	| 'claude-skill'
 	| 'mcp-example'
@@ -65,6 +66,11 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/swift/swiftlint.yml',
 		target: '.swiftlint.yml',
 		desc: 'SwiftLint configuration (lint + --fix; the standard swift-common runs)',
+	},
+	'swift-format': {
+		source: 'tooling/swift/swift-format.json',
+		target: '.swift-format',
+		desc: "Apple swift-format configuration (4-space, 120 columns — matches the module's .editorconfig)",
 	},
 	periphery: {
 		source: 'tooling/swift/periphery.yml',

--- a/src/languages/swift/checks.ts
+++ b/src/languages/swift/checks.ts
@@ -5,8 +5,10 @@
  * (lint + `--fix` in pre-commit, `--strict` in CI) and Periphery for dead code.
  * Deliberately *not* checked:
  *
- * - SwiftFormat — SwiftLint's `--fix` does the formatting; a second formatter
- *   would fight it.
+ * - SwiftFormat (the Nick Lockwood one) — SwiftLint's `--fix` does the
+ *   formatting; a second *rewriting* formatter would fight it. Apple's
+ *   `swift-format` is checked as of #311, but only as an optional slot: a repo
+ *   that opts into it runs it *instead of* `swiftlint --fix`.
  * - `.swift-version` — the toolchain is pinned in CI (`setup-xcode`) and the
  *   package declares `// swift-tools-version:`, so a root file would be a third
  *   place to keep in sync.
@@ -34,6 +36,17 @@ const SWIFT_FILE_CHECKS: FileCheck[] = [
 		matcher: /^(retain_public|project|schemes|targets|index_exclude):/m,
 		optional: true,
 		hint: 'Run `npx @rtorcato/repo-tooling fix periphery` to scaffold a dead-code scan config',
+	},
+	{
+		// Apple's swift-format, the formatter slot (#311) — not a second linter.
+		// Optional because SwiftLint's `--fix` already formats: a repo runs one,
+		// the other, or both, so its absence is a choice rather than drift.
+		check: 'swift-format',
+		candidates: ['.swift-format', '.swift-format.json'],
+		expected: 'is a valid swift-format configuration',
+		matcher: /"(version|lineLength|indentation|rules)"\s*:/,
+		optional: true,
+		hint: 'Run `npx @rtorcato/repo-tooling fix swift-format` to scaffold one (SwiftLint `--fix` formats without it)',
 	},
 ]
 
@@ -117,6 +130,109 @@ export async function checkPackageSwift(dir: string): Promise<CheckResult> {
 }
 
 /**
+ * Directory names under `Sources/`. For a SwiftPM package these are the target
+ * names — a target's sources and its DocC catalogue live in the same folder,
+ * so this is where both the check and the `docc` fixer have to look.
+ */
+export async function swiftSourceTargets(dir: string): Promise<string[]> {
+	try {
+		const entries = await fs.readdir(path.join(dir, 'Sources'), { withFileTypes: true })
+		return entries.filter((e) => e.isDirectory()).map((e) => e.name)
+	} catch {
+		return []
+	}
+}
+
+async function findDoccCatalogue(dir: string): Promise<string | null> {
+	for (const target of await swiftSourceTargets(dir)) {
+		const entries = await fs.readdir(path.join(dir, 'Sources', target))
+		const catalogue = entries.find((e) => e.endsWith('.docc'))
+		if (catalogue) return `Sources/${target}/${catalogue}`
+	}
+	return null
+}
+
+/**
+ * DocC, the Swift shape of the TypeDoc check (#311). Two halves have to line
+ * up: a `.docc` catalogue holds the prose, and `swift-docc-plugin` is what
+ * makes `swift package generate-documentation` exist — either alone is docs
+ * that nobody can build, or a build command with nothing to say.
+ */
+export async function checkDocC(dir: string): Promise<CheckResult> {
+	const check = 'DocC'
+	const hint = 'Run `npx @rtorcato/repo-tooling fix docc` to scaffold a DocC catalogue'
+	const manifest = path.join(dir, 'Package.swift')
+	const contents = (await fs.pathExists(manifest)) ? await fs.readFile(manifest, 'utf-8') : ''
+	const hasPlugin = contents.includes('swift-docc-plugin')
+	const catalogue = await findDoccCatalogue(dir)
+
+	if (catalogue && hasPlugin) {
+		return { check, status: 'ok', detail: `${catalogue} with swift-docc-plugin declared` }
+	}
+	if (catalogue) {
+		return {
+			check,
+			status: 'drift',
+			detail: `${catalogue} found but Package.swift declares no swift-docc-plugin`,
+			hint: 'Add `.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")` to Package.swift',
+		}
+	}
+	if (hasPlugin) {
+		return {
+			check,
+			status: 'drift',
+			detail: 'swift-docc-plugin declared but no .docc catalogue under Sources/',
+			hint,
+		}
+	}
+	return { check, status: 'optional-missing', detail: 'DocC not configured', hint }
+}
+
+/**
+ * The test setup (#311). SwiftPM has no test-runner config file to check — the
+ * suite is declared in the manifest and run by `swift test` — so the two facts
+ * worth asserting are that a test target exists at all and that CI runs it. A
+ * green pipeline over a package with no `.testTarget(` proves nothing.
+ */
+export async function checkSwiftTests(dir: string): Promise<CheckResult> {
+	const check = 'Swift tests'
+	const manifest = path.join(dir, 'Package.swift')
+	if (!(await fs.pathExists(manifest))) {
+		return { check, status: 'missing', detail: 'no Package.swift' }
+	}
+	if (!/\.testTarget\(/.test(await fs.readFile(manifest, 'utf-8'))) {
+		return {
+			check,
+			status: 'missing',
+			detail: 'Package.swift declares no `.testTarget(`',
+			hint: 'Add a `.testTarget(name: "<Target>Tests", dependencies: ["<Target>"])` to Package.swift',
+		}
+	}
+
+	const candidates: string[] = ['.gitlab-ci.yml', '.gitlab-ci.yaml']
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (await fs.pathExists(workflowsDir)) {
+		const files = (await fs.readdir(workflowsDir)).filter(
+			(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+		)
+		candidates.unshift(...files.map((f) => path.join('.github', 'workflows', f)))
+	}
+	for (const candidate of candidates) {
+		const filepath = path.join(dir, candidate)
+		if (!(await fs.pathExists(filepath))) continue
+		if (/\bswift\s+test\b/.test(await fs.readFile(filepath, 'utf-8'))) {
+			return { check, status: 'ok', detail: `test target declared and run by ${candidate}` }
+		}
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: 'test target declared but no CI job runs `swift test`',
+		hint: 'Run `npx @rtorcato/repo-tooling fix swift-ci` to regenerate a workflow that runs `swift test`',
+	}
+}
+
+/**
  * Release automation for a SwiftPM package (#310). There is no publish step to
  * look for — a release *is* a semver git tag consumers resolve with
  * `.package(url:from:)` — so "configured" means a workflow that fires on a tag
@@ -177,6 +293,8 @@ export async function runSwiftChecks(dir: string): Promise<CheckResult[]> {
 		await checkPackageSwift(dir),
 		...(await Promise.all(SWIFT_FILE_CHECKS.map((spec) => checkFile(dir, spec)))),
 		await checkSwiftGitignore(dir),
+		await checkSwiftTests(dir),
+		await checkDocC(dir),
 		await checkSwiftRelease(dir),
 	]
 }

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -8,6 +8,7 @@ import type { Fixer } from '../../base/fixers.js'
 import { buildPresetConfig } from '../../cli/commands/setup-presets.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
+import { swiftSourceTargets } from './checks.js'
 import {
 	readSwiftPackage,
 	renderSwiftGitLabCI,
@@ -16,6 +17,30 @@ import {
 } from './ci.js'
 import { SWIFT_HOOKS_DIR, installSwiftGitHooks } from './git-hooks.js'
 import { ensureSwiftGitignore } from './gitignore.js'
+
+/**
+ * A DocC module page. The heading is a symbol link (double backticks) because
+ * that's what binds the article to the module — a plain `# Name` heading makes
+ * DocC treat the file as a standalone article instead.
+ */
+function doccLandingPage(target: string): string {
+	return `# \`\`${target}\`\`
+
+Summary line for ${target} — replace this with what the module is for.
+
+## Overview
+
+Write the prose documentation for ${target} here. Anything else in this
+catalogue (articles, tutorials, resources) is picked up automatically.
+
+Build it with \`swift package generate-documentation\`, or preview it with
+\`swift package --disable-sandbox preview-documentation --target ${target}\`.
+
+## Topics
+
+### Essentials
+`
+}
 
 export const SWIFT_FIXERS: Fixer[] = [
 	{
@@ -38,6 +63,51 @@ export const SWIFT_FIXERS: Fixer[] = [
 		async run({ targetDir }) {
 			const result = await copyPreset('periphery', targetDir)
 			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'swift-format',
+		description: 'Scaffold .swift-format (Apple swift-format, the optional formatter slot)',
+		appliesTo: ['swift-format'],
+		outputs: ['.swift-format'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('swift-format', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'docc',
+		description: 'Scaffold a DocC catalogue (Sources/<Target>/<Target>.docc) for the first target',
+		appliesTo: ['DocC'],
+		// Path depends on the target name, so `fix --dry-run` shows no diff for
+		// this one — the file it writes isn't knowable without reading Sources/.
+		outputs: ['Sources/<Target>/<Target>.docc/<Target>.md'],
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			// The library product's target first — that's the API consumers read
+			// docs for — falling back to whatever single target the package has.
+			const targets = await swiftSourceTargets(targetDir)
+			const { products } = await readSwiftPackage(targetDir)
+			const target = products.find((p) => targets.includes(p)) ?? targets[0]
+			if (!target) {
+				throw new Error('no Sources/<Target>/ directory to put a DocC catalogue in')
+			}
+
+			const file = `Sources/${target}/${target}.docc/${target}.md`
+			// safe-add: the catalogue is prose someone wrote, so a re-run (DocC
+			// also drifts when the manifest lacks the plugin, which this fixer
+			// can't repair) must not overwrite it.
+			if (await fs.pathExists(path.join(targetDir, file))) return { filesWritten: [] }
+
+			await fs.outputFile(path.join(targetDir, file), doccLandingPage(target))
+			console.log(
+				chalk.yellow(
+					'   add swift-docc-plugin to Package.swift to build it: .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")'
+				)
+			)
+			return { filesWritten: [file] }
 		},
 	},
 	{

--- a/tests/languages/swift/checks.test.ts
+++ b/tests/languages/swift/checks.test.ts
@@ -2,9 +2,11 @@ import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
+	checkDocC,
 	checkPackageSwift,
 	checkSwiftGitignore,
 	checkSwiftRelease,
+	checkSwiftTests,
 	runSwiftChecks,
 } from '../../../src/languages/swift/checks.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -88,6 +90,86 @@ describe('checkSwiftGitignore', () => {
 	})
 })
 
+describe('checkSwiftTests', () => {
+	const CI = 'jobs:\n  build:\n    steps:\n      - run: swift test\n'
+
+	it('is missing without a manifest', async () => {
+		expect((await checkSwiftTests(newTmpDir())).status).toBe('missing')
+	})
+
+	it('is missing when the manifest declares no test target', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), VALID_MANIFEST)
+		const result = await checkSwiftTests(dir)
+		expect(result.status).toBe('missing')
+		expect(result.detail).toContain('.testTarget(')
+	})
+
+	// A test target nothing runs is the failure mode this half exists for.
+	it('drifts when a test target exists but no CI runs swift test', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), `${VALID_MANIFEST}\n// .testTarget(name: "T")\n`)
+		await fs.outputFile(join(dir, '.github/workflows/ci.yml'), 'jobs:\n  build:\n    steps: []\n')
+		const result = await checkSwiftTests(dir)
+		expect(result.status).toBe('drift')
+		expect(result.hint).toContain('fix swift-ci')
+	})
+
+	it('passes when a workflow runs swift test', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), `${VALID_MANIFEST}\n// .testTarget(name: "T")\n`)
+		await fs.outputFile(join(dir, '.github/workflows/ci.yml'), CI)
+		expect((await checkSwiftTests(dir)).status).toBe('ok')
+	})
+
+	// GitLab is the only pipeline on a repo mirrored off GitHub.
+	it('accepts .gitlab-ci.yml as the runner', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), `${VALID_MANIFEST}\n// .testTarget(name: "T")\n`)
+		await fs.writeFile(join(dir, '.gitlab-ci.yml'), 'test:\n  script:\n    - swift test\n')
+		expect((await checkSwiftTests(dir)).status).toBe('ok')
+	})
+})
+
+describe('checkDocC', () => {
+	const PLUGIN = '.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")'
+
+	const withCatalogue = async (dir: string) =>
+		fs.outputFile(join(dir, 'Sources/Demo/Demo.docc/Demo.md'), '# ``Demo``\n')
+
+	it('is optional-missing with neither catalogue nor plugin', async () => {
+		const result = await checkDocC(newTmpDir())
+		expect(result.status).toBe('optional-missing')
+		expect(result.hint).toContain('fix docc')
+	})
+
+	it('passes with a catalogue and the plugin declared', async () => {
+		const dir = newTmpDir()
+		await withCatalogue(dir)
+		await fs.writeFile(join(dir, 'Package.swift'), `${VALID_MANIFEST}\n// ${PLUGIN}\n`)
+		const result = await checkDocC(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('Sources/Demo/Demo.docc')
+	})
+
+	// Docs nobody can build.
+	it('drifts on a catalogue with no plugin', async () => {
+		const dir = newTmpDir()
+		await withCatalogue(dir)
+		await fs.writeFile(join(dir, 'Package.swift'), VALID_MANIFEST)
+		const result = await checkDocC(dir)
+		expect(result.status).toBe('drift')
+		expect(result.hint).toContain('swift-docc-plugin')
+	})
+
+	// A build command with nothing to say.
+	it('drifts on a plugin with no catalogue', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), `${VALID_MANIFEST}\n// ${PLUGIN}\n`)
+		expect((await checkDocC(dir)).status).toBe('drift')
+	})
+})
+
 describe('checkSwiftRelease', () => {
 	const workflow = (triggers: string) =>
 		`name: x\n\non:\n${triggers}\njobs:\n  release:\n    runs-on: macos-latest\n`
@@ -130,22 +212,26 @@ describe('checkSwiftRelease', () => {
 })
 
 describe('runSwiftChecks', () => {
-	it('covers Package.swift, SwiftLint, Periphery, the gitignore and releases', async () => {
+	it('covers the manifest, tools, tests, docs and releases', async () => {
 		const names = (await runSwiftChecks(newTmpDir())).map((r) => r.check)
 		expect(names).toEqual([
 			'Package.swift',
 			'SwiftLint',
 			'Periphery',
+			'swift-format',
 			'Swift .gitignore',
+			'Swift tests',
+			'DocC',
 			'Release automation',
 		])
 	})
 
-	it('treats Periphery as optional but SwiftLint as required', async () => {
+	it('treats Periphery and swift-format as optional but SwiftLint as required', async () => {
 		const results = await runSwiftChecks(newTmpDir())
 		const byName = Object.fromEntries(results.map((r) => [r.check, r.status]))
 		expect(byName.SwiftLint).toBe('missing')
 		expect(byName.Periphery).toBe('optional-missing')
+		expect(byName['swift-format']).toBe('optional-missing')
 	})
 
 	it('accepts the configs the swiftlint/periphery fixers write', async () => {

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it } from 'vitest'
 import { runDoctor } from '../../../src/cli/commands/doctor.js'
 import { BASE_FIXERS } from '../../../src/base/fixers.js'
 import { FIXERS } from '../../../src/languages/js/fixers.js'
-import { checkSwiftGitignore, checkSwiftRelease } from '../../../src/languages/swift/checks.js'
+import {
+	checkDocC,
+	checkSwiftGitignore,
+	checkSwiftRelease,
+	runSwiftChecks,
+} from '../../../src/languages/swift/checks.js'
 import { SWIFT_FIXERS } from '../../../src/languages/swift/fixers.js'
 import { ensureSwiftGitignore } from '../../../src/languages/swift/gitignore.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -60,13 +65,16 @@ describe('swift fixers', () => {
 		// generator satisfies; `README badges` needs a package.json name/repository
 		// to build the block from, which a Swift repo hasn't got (#309).
 		// `Git identity` is unfixable by design (#328) — only the operator knows
-		// their own address, so there is nothing for a fixer to write.
+		// their own address, so there is nothing for a fixer to write. `Swift
+		// tests` is the same shape as `Package.swift`: half of it is a manifest
+		// edit (#311).
 		expect(uncovered).toEqual([
 			'language',
 			'Git identity',
 			'README badges',
 			'Coverage upload',
 			'Package.swift',
+			'Swift tests',
 		])
 	})
 
@@ -83,6 +91,44 @@ describe('swift fixers', () => {
 		const dir = newTmpDir()
 		await fixer('periphery').run(ctx(dir))
 		expect(await fs.readFile(join(dir, '.periphery.yml'), 'utf-8')).toContain('retain_public: true')
+	})
+
+	it('swift-format writes a config the swift-format check accepts', async () => {
+		const dir = newTmpDir()
+		const { filesWritten } = await fixer('swift-format').run(ctx(dir))
+		expect(filesWritten).toEqual(['.swift-format'])
+		const results = await runSwiftChecks(dir)
+		expect(results.find((r) => r.check === 'swift-format')?.status).toBe('ok')
+	})
+
+	it('docc writes the catalogue into the library product’s target', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(
+			join(dir, 'Package.swift'),
+			'// swift-tools-version: 5.9\nproducts: [.library(name: "Demo", targets: ["Demo"])]\n'
+		)
+		await fs.outputFile(join(dir, 'Sources/Helpers/Helpers.swift'), '')
+		await fs.outputFile(join(dir, 'Sources/Demo/Demo.swift'), '')
+
+		const { filesWritten } = await fixer('docc').run(ctx(dir))
+		expect(filesWritten).toEqual(['Sources/Demo/Demo.docc/Demo.md'])
+		// Symbol-link heading, or DocC treats the page as a standalone article.
+		expect(await fs.readFile(join(dir, filesWritten[0] as string), 'utf-8')).toContain('# ``Demo``')
+		// Still drift, not ok: the plugin is a manifest edit the fixer won't make.
+		expect((await checkDocC(dir)).status).toBe('drift')
+	})
+
+	// DocC drifts again when the manifest lacks the plugin, so a re-run is the
+	// normal case — it must not overwrite prose someone wrote.
+	it('docc leaves an existing catalogue page alone', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(join(dir, 'Sources/Demo/Demo.docc/Demo.md'), '# ``Demo``\n\nMine.\n')
+		expect((await fixer('docc').run(ctx(dir))).filesWritten).toEqual([])
+		expect(await fs.readFile(join(dir, 'Sources/Demo/Demo.docc/Demo.md'), 'utf-8')).toContain('Mine.')
+	})
+
+	it('docc refuses a package with no Sources/ directory', async () => {
+		await expect(fixer('docc').run(ctx(newTmpDir()))).rejects.toThrow(/Sources/)
 	})
 
 	it('swift-release writes a workflow the Release automation check accepts', async () => {

--- a/tests/languages/swift/scaffold.test.ts
+++ b/tests/languages/swift/scaffold.test.ts
@@ -76,14 +76,21 @@ describe('generateSwiftProject', () => {
 		expect(manifest).not.toMatch(/,\s*\n\s*\]/)
 	})
 
-	it('leaves the whole Swift doctor suite green', async () => {
+	// Everything the scaffold claims to wire is green. `swift-format` and `DocC`
+	// are opt-in slots it deliberately doesn't write (SwiftLint `--fix` is the
+	// formatter, and DocC needs a plugin dependency in the manifest), exactly as
+	// a fresh JS scaffold leaves TypeDoc unconfigured.
+	it('leaves the whole Swift doctor suite green bar the opt-in slots', async () => {
 		const dir = await scaffold()
 		const results = await runSwiftChecks(dir)
 		expect(results.map((r) => `${r.check}: ${r.status}`)).toEqual([
 			'Package.swift: ok',
 			'SwiftLint: ok',
 			'Periphery: ok',
+			'swift-format: optional-missing',
 			'Swift .gitignore: ok',
+			'Swift tests: ok',
+			'DocC: optional-missing',
 			'Release automation: ok',
 		])
 	})

--- a/tooling/swift/swift-format.json
+++ b/tooling/swift/swift-format.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "lineLength": 120,
+  "indentation": {
+    "spaces": 4
+  },
+  "respectsExistingLineBreaks": true,
+  "lineBreakBeforeEachArgument": false,
+  "prioritizeKeepingFunctionOutputTogether": true
+}


### PR DESCRIPTION
Closes #311

Follows #351 (issue #310), which merged while this was in progress — this branch
is rebased onto `main` on top of it, so the diff is #311's changes only.

## What

Three parity gaps against the JS module, grouped as the issue asked because
each is small and they all land in the same file.

### DocC

The Swift shape of `checkTypedoc`. Two halves have to line up — a `.docc`
catalogue under `Sources/<Target>/` holds the prose, `swift-docc-plugin` in the
manifest is what makes `swift package generate-documentation` exist — so either
alone is `drift`: docs nobody can build, or a build command with nothing to say.

`fix docc` writes `Sources/<Target>/<Target>.docc/<Target>.md` into the library
product's target, with the symbol-link heading DocC needs to bind the article to
the module. It does **not** touch `Package.swift` — the module's standing rule —
and prints the dependency line to paste instead. It's `safe-add`: re-running
never overwrites the page, which matters because the check *stays* in drift
until the manifest half lands, so a re-run is the normal case.

### swift-format

Apple's `swift-format` (shipped with the toolchain since Swift 6 as `swift
format`), in the *formatter* slot — not a second lint gate, and nothing in the
generated CI runs `swift format lint` unless you add it. Optional because
SwiftLint's `--fix` already formats: a repo runs one or the other, so its
absence is a choice, not drift.

This is a `FileCheck` entry plus a `copy`/`fix` preset rather than a new
`formatting.tool` enum value. Adding `swift-format` to `ProjectConfig` would
mean touching the config schema, the setup wizard and the JS generators for a
field nothing on the Swift path reads — the check has the file itself as
evidence, which is what every other Swift check uses.

### Swift tests

The two facts SwiftPM leaves implicit: the manifest declares a `.testTarget(`,
and some pipeline (`.github/workflows/*` or `.gitlab-ci.yml`) actually runs
`swift test`. A green pipeline over a package with no test target proves
nothing. No fix target — the first half is a manifest edit, and `fix swift-ci`
covers the second from the check's own hint.

## Verification

- `pnpm run verify` on the rebased branch — biome clean, tsc clean, 644 tests
  passed (48 files), build ok.
- `node scripts/integration/preset-lifecycle.mjs swift-library` — `swift build`,
  `swift test` and `swiftlint lint --strict` (0 violations) green.
- End to end against a real scaffold: `fix swift-format` then `fix docc`, then
  `doctor` reports `swift-format: ok` and `DocC: drift` (catalogue present,
  plugin not) with the paste-able hint.
- `swift format lint --configuration .swift-format --recursive Sources` against
  the scaffolded package, with the toolchain's own swift-format 6.3.0: exit 0,
  no diagnostics. The emitted config is one the real tool accepts.

## Left out

A fresh `swift-library` scaffold still leaves `DocC` and `swift-format` as
`optional-missing`, deliberately: DocC would need a plugin dependency in every
generated manifest (and a network fetch on the first `swift build`), and
swift-format would be a second formatter nobody asked for. A fresh JS scaffold
leaves TypeDoc unconfigured for the same reason.