### PR TITLE
docs(ci): record why ci.yml is generated rather than a reusable workflow

### DIFF
--- a/apps/docs/docs/reference/github-actions.md
+++ b/apps/docs/docs/reference/github-actions.md
@@ -71,6 +71,35 @@ libraries) out of the box. Beyond that, repo-tooling ships **optional deploy
 workflows** you add on demand — they're too deploy-target-specific to scaffold
 by default, so the setup wizard never prompts for them.
 
+### Why `ci.yml` is generated, not a reusable workflow
+
+The alternative was for consumers to call one shared workflow instead of owning
+a file:
+
+```yaml
+jobs:
+  ci:
+    uses: rtorcato/repo-tooling/.github/workflows/ci.yml@main
+```
+
+One source of truth, upgrades landing automatically. It was rejected:
+
+- **It only works on GitHub.** repo-tooling also generates GitLab CI, which has
+  no equivalent — so those repos would need the generated file regardless, and
+  the family would run two different models.
+- **The consumer stops owning its CI.** Adding a job, a matrix entry or a deploy
+  step means either abandoning the shared workflow or growing an input for every
+  knob anyone might want.
+- **It pins every consumer to a ref of this repo.** `@main` runs whatever lands
+  here on their runners; the generated file has no such surface.
+
+The one thing it was meant to solve — a generated `ci.yml` drifting from the
+preset with nobody noticing — is now covered by the audit instead. `doctor`
+compares the workflow's action pins against the preset and reports the
+disagreement, `fix github-actions --diff` shows the delta before anything is
+overwritten, and the composite action above turns that into a CI gate. Drift is
+visible and reconcilable, which was the only real gap in owning the file.
+
 ## Optional deploy workflows
 
 Add any of these to an existing repo with `fix`:


### PR DESCRIPTION
Closes #316.

#316 asked for a decision, not code: does repo-tooling keep generating a `ci.yml` per consumer, or ship a reusable workflow they call? It was explicitly gated on #315, which has since shipped (`action.yml`). So the call can be made, and it's **keep the generated file** — recorded in the CI reference doc rather than left in the issue tracker.

**Why the reusable workflow loses**

- GitHub-only, while repo-tooling also generates GitLab CI — those repos need the generated file regardless, so the family would run two models.
- The consumer stops owning its CI: any extra job, matrix entry or deploy step means abandoning the shared workflow or growing an input for every knob.
- It pins every consumer to a ref of this repo, so `@main` runs whatever lands here on their runners.

**Why its one advantage no longer applies**

Silent drift was the generated model's real weakness, and it's now covered by the audit: `doctor` compares the workflow's action pins against the preset (#349), `fix github-actions --diff` shows the delta before overwriting (#352), and the composite action gates CI on the result (#315).

Docs-only — 29 lines added to `apps/docs/docs/reference/github-actions.md`, no source changes.