### PR TITLE
feat(doctor): report the languages a monorepo audit skips

### DIFF
--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -1,7 +1,34 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import { BADGE_START, hasPublicOnlyBadges } from '../cli/generators/badges.js'
+import { type DetectedLanguage, detectNestedLanguages } from '../cli/utils/detect-language.js'
 import type { CheckResult } from './types.js'
+
+/**
+ * Root-only detection is the decision (#317), not an oversight — but it used to
+ * be a *silent* one: a Swift repo with a TypeScript docs app audited as Swift
+ * and never mentioned the half it skipped. This says so.
+ *
+ * Always `ok`. Nesting a second language is a legitimate repo shape, so failing
+ * on it would break every monorepo's CI to report a limitation of ours.
+ */
+export async function checkNestedLanguages(
+	dir: string,
+	rootLanguage: DetectedLanguage
+): Promise<CheckResult> {
+	const check = 'Monorepo'
+	const nested = await detectNestedLanguages(dir, rootLanguage)
+	if (nested.length === 0) {
+		return { check, status: 'ok', detail: 'single-language repo' }
+	}
+	const summary = nested.map((n) => `${n.dir} (${n.language})`).join(', ')
+	return {
+		check,
+		status: 'ok',
+		detail: `auditing the root only — ${summary} ${nested.length === 1 ? 'is' : 'are'} not audited`,
+		hint: 'Run doctor with `--directory <path>` to audit a nested project on its own',
+	}
+}
 
 /**
  * "Is one of these files present, and does it look like ours?" — the shape most

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -7,7 +7,7 @@ import { inferProjectConfig } from '../../languages/js/fixers.js'
 import { resolveLanguageModule } from '../../languages/registry.js'
 import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../languages/swift/checks.js'
 import { readSwiftPackage, renderSwiftWorkflow } from '../../languages/swift/ci.js'
-import { detectLanguage } from '../utils/detect-language.js'
+import { type DetectedLanguage, detectLanguage } from '../utils/detect-language.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
 import { checkGitIdentity } from '../../base/git-identity.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
@@ -25,6 +25,7 @@ import {
 	checkGitHooks,
 	checkGitHubActions,
 	checkGitLabCI,
+	checkNestedLanguages,
 	checkPrePushHook,
 	checkReadmeBadges,
 	COMMITLINT_FILE_CHECK,
@@ -204,6 +205,8 @@ interface BaseCheckOptions {
 	 * with no CI generator — nothing to compare against.
 	 */
 	presetWorkflow: string | null
+	/** The root's detected language, so the monorepo notice can name what it skips (#317). */
+	language: DetectedLanguage
 }
 
 // The language-agnostic checks (src/base): repo hygiene, git hooks, CI,
@@ -217,6 +220,7 @@ async function runBaseChecks(
 ): Promise<CheckResult[]> {
 	const results: CheckResult[] = []
 	results.push(checkLockfile(lock))
+	results.push(await checkNestedLanguages(dir, opts.language))
 	results.push(await checkGitIdentity(dir))
 	results.push(await checkEditorConfig(dir))
 	results.push(await checkFile(dir, COMMITLINT_FILE_CHECK))
@@ -266,6 +270,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				hooks: null,
 				badges: { audience: 'public', fixTarget: null },
 				presetWorkflow: null,
+				language,
 			})),
 		]
 		return demoteDeclined(results, lock)
@@ -287,6 +292,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				// package.json name/repository, which a Swift repo hasn't got.
 				badges: { audience: 'public', fixTarget: null },
 				presetWorkflow: renderSwiftWorkflow(await readSwiftPackage(targetDir)),
+				language,
 			})),
 			...(await runSwiftChecks(targetDir)),
 		]
@@ -341,6 +347,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 			hooks: jsGitHooksProfile(pkg),
 			badges: { audience: jsBadgeAudience(pkg), fixTarget: 'badges' },
 			presetWorkflow: renderGitHubWorkflow(githubJobs(inferProjectConfig(pkg))),
+			language,
 		}))
 	)
 

--- a/src/cli/utils/detect-language.ts
+++ b/src/cli/utils/detect-language.ts
@@ -5,8 +5,9 @@ export type DetectedLanguage = 'js' | 'swift' | 'perl' | 'python' | 'unknown'
 
 /**
  * Marker files that identify a repo's language, checked in order — first match
- * wins. One language per repo root; multi-language monorepos are out of scope
- * for v1 (see #139). A dir with no marker → 'unknown' (base checks only).
+ * wins. One language per repo root; multi-language monorepos stay out of scope
+ * (#139, reaffirmed in #317 — the audit is root-only, but says so via
+ * `detectNestedLanguages`). A dir with no marker → 'unknown' (base checks only).
  */
 const MARKERS: ReadonlyArray<[DetectedLanguage, readonly string[]]> = [
 	['js', ['package.json']],
@@ -22,4 +23,48 @@ export async function detectLanguage(dir: string): Promise<DetectedLanguage> {
 		}
 	}
 	return 'unknown'
+}
+
+/** Never worth descending into, and expensive when we do. */
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'target', 'vendor', '.build'])
+
+/**
+ * Sub-project dirs whose language marker disagrees with the root's, as
+ * `{ dir, language }` sorted by dir. Depth-2 scan — enough for the shapes that
+ * exist (`apps/docs`, `packages/*`, a top-level `docs/`) and cheap enough to run
+ * on every doctor.
+ *
+ * Deliberately *not* driven by the workspace manifest: the case #317 is about is
+ * a Swift or Perl root with a JS docs app, and such a repo has no
+ * `pnpm-workspace.yaml` to read. Walking the tree finds it either way, and needs
+ * no glob dependency.
+ */
+export async function detectNestedLanguages(
+	dir: string,
+	rootLanguage: DetectedLanguage
+): Promise<Array<{ dir: string; language: DetectedLanguage }>> {
+	const found: Array<{ dir: string; language: DetectedLanguage }> = []
+
+	const scan = async (relative: string, depth: number): Promise<void> => {
+		let entries: string[]
+		try {
+			entries = await fs.readdir(path.join(dir, relative))
+		} catch {
+			return // unreadable dir is the caller's problem, not the audit's
+		}
+		for (const entry of entries) {
+			if (entry.startsWith('.') || SKIP_DIRS.has(entry)) continue
+			const child = relative ? `${relative}/${entry}` : entry
+			if (!(await fs.stat(path.join(dir, child)).catch(() => null))?.isDirectory()) continue
+			const language = await detectLanguage(path.join(dir, child))
+			if (language !== 'unknown' && language !== rootLanguage) {
+				found.push({ dir: child, language })
+				continue // a package's own subdirs belong to it, not to the root
+			}
+			if (depth > 1) await scan(child, depth - 1)
+		}
+	}
+
+	await scan('', 2)
+	return found.sort((a, b) => a.dir.localeCompare(b.dir))
 }

--- a/tests/cli/utils/detect-language.test.ts
+++ b/tests/cli/utils/detect-language.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
-import { detectLanguage } from '../../../src/cli/utils/detect-language.js'
+import { detectLanguage, detectNestedLanguages } from '../../../src/cli/utils/detect-language.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -30,5 +30,54 @@ describe('detectLanguage', () => {
 		await fs.writeFile(join(dir, 'package.json'), '{}')
 		await fs.writeFile(join(dir, 'pyproject.toml'), '')
 		expect(await detectLanguage(dir)).toBe('js')
+	})
+})
+
+/** Writes `marker` inside `dir/relative`, creating the path. */
+async function seed(dir: string, relative: string, marker: string): Promise<void> {
+	await fs.outputFile(join(dir, relative, marker), '')
+}
+
+describe('detectNestedLanguages', () => {
+	it('finds a JS docs app under a Swift root — the #317 case', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '')
+		await seed(dir, 'apps/docs', 'package.json')
+		expect(await detectNestedLanguages(dir, 'swift')).toEqual([{ dir: 'apps/docs', language: 'js' }])
+	})
+
+	it('stays quiet when every package matches the root language', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'package.json'), '{}')
+		await seed(dir, 'apps/docs', 'package.json')
+		await seed(dir, 'packages/core', 'package.json')
+		expect(await detectNestedLanguages(dir, 'js')).toEqual([])
+	})
+
+	it('reports every differing package, sorted', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'package.json'), '{}')
+		await seed(dir, 'packages/scraper', 'pyproject.toml')
+		await seed(dir, 'apps/mobile', 'Package.swift')
+		expect(await detectNestedLanguages(dir, 'js')).toEqual([
+			{ dir: 'apps/mobile', language: 'swift' },
+			{ dir: 'packages/scraper', language: 'python' },
+		])
+	})
+
+	it('ignores node_modules and dot dirs', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '')
+		await seed(dir, 'node_modules/left-pad', 'package.json')
+		await seed(dir, '.venv/lib', 'package.json')
+		expect(await detectNestedLanguages(dir, 'swift')).toEqual([])
+	})
+
+	it('does not descend into a package it has already reported', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '')
+		await seed(dir, 'docs', 'package.json')
+		await seed(dir, 'docs/api', 'pyproject.toml')
+		expect(await detectNestedLanguages(dir, 'swift')).toEqual([{ dir: 'docs', language: 'js' }])
 	})
 })

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -67,9 +67,11 @@ describe('swift fixers', () => {
 		// `Git identity` is unfixable by design (#328) — only the operator knows
 		// their own address, so there is nothing for a fixer to write. `Swift
 		// tests` is the same shape as `Package.swift`: half of it is a manifest
-		// edit (#311).
+		// edit (#311). `Monorepo` states the audit's own root-only scope (#317) —
+		// there is no drift for a fixer to close.
 		expect(uncovered).toEqual([
 			'language',
+			'Monorepo',
 			'Git identity',
 			'README badges',
 			'Coverage upload',


### PR DESCRIPTION
Settles #317 and implements the answer it flagged as cheapest.

## The decision

**Root-only stays. Say so loudly.** Taking the issue's four questions in order:

1. **Does `doctor` walk workspace members?** No. It stays root-only and announces it.
2. **Unit of a language module — repo or package?** Moot. Nothing walks packages, so nothing needs re-homing. Repo-level checks (CODEOWNERS, branch protection, Dependabot) keep running exactly once, which was the risk in walking.
3. **How does the lockfile represent per-package config?** It doesn't. `.repo-tooling.json` stays one file, one shape, `LOCKFILE_VERSION` unchanged.
4. **What does `fix` do?** Unchanged. It converges the root, same as today.

The issue's own read was right: the failure mode was that root-only was **silent**, not that it was root-only. A Swift repo with a TypeScript docs app audited as Swift and never mentioned the half it skipped. That is what this fixes; no design debt is taken on.

## The change

`detectNestedLanguages(dir, rootLanguage)` — a depth-2 scan for sub-project dirs whose marker file disagrees with the root's — surfaced by `checkNestedLanguages` as a `Monorepo` check.

Against a Swift root with `apps/docs/package.json`:

```
  ✅ language — ok
     detected Swift (Package.swift)
  ✅ Monorepo — ok
     auditing the root only — apps/docs (js) is not audited
     hint: Run doctor with `--directory <path>` to audit a nested project on its own
```

Two deliberate calls, both commented in place:

- **Not driven by the workspace manifest.** The motivating case is a Swift or Perl root with a JS docs app, and such a repo has no `pnpm-workspace.yaml` to read. Walking the tree finds it either way and needs no glob dependency.
- **Always `ok`, never `drift`.** Nesting a second language is a legitimate repo shape. Failing on it would break every monorepo's CI to report a limitation of ours. The existing per-package escape hatch (`doctor --directory <path>`) is in the hint.

## Verification

`pnpm run verify` green — 631 tests. Five new unit tests cover the #317 scenario, the quiet single-language case, multiple differing packages, `node_modules`/dot-dir exclusion, and not descending into a package already reported. The Swift fixer-coverage test picks up `Monorepo` as informational-and-unfixable, alongside `language` and `Git identity`.

Confirmed end to end against a fixture repo (output above).

Closes #317
