### PR TITLE
feat(python): add src/languages/python module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Orientation for coding agents working with `@rtorcato/repo-tooling`. Human-reada
 
 A one-package JavaScript / TypeScript tooling distribution. Ships every preset (TypeScript, Biome, ESLint, Prettier, Vitest, Jest, Commitlint, semantic-release, tsup, esbuild, Vite, Playwright) plus a CLI to scaffold and audit projects. Consumers get one install.
 
-**Swift** repos (detected via `Package.swift`) are covered end to end: `setup --preset swift-library` scaffolds a SwiftPM package, and `doctor`/`fix` run the language-agnostic checks plus SwiftLint / Periphery / `.gitignore` / `Package.swift`. Python and Perl are audit-only for now. See `src/languages/` — one directory per language module, `src/base/` for what's shared.
+**Swift** repos (detected via `Package.swift`) are covered end to end: `setup --preset swift-library` scaffolds a SwiftPM package, and `doctor`/`fix` run the language-agnostic checks plus SwiftLint / Periphery / `.gitignore` / `Package.swift`. **Python** repos (detected via `pyproject.toml` / `setup.py`) get `doctor`/`fix` — Ruff / mypy / pytest / `.gitignore` / CI / git hooks — but no `setup` preset yet. Perl is audit-only for now. See `src/languages/` — one directory per language module, `src/base/` for what's shared.
 
 ## CLI surface (agent-friendly)
 

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -88,7 +88,7 @@ A universal baseline (`.editorconfig`, `.nvmrc`, `engines.node`, `knip.json`, `.
 :::note Non-JS languages
 The table above is the JavaScript/TypeScript question list. Picking **Swift** asks only for a package name and then scaffolds a SwiftPM library — SwiftLint, Periphery and `swift test` are the standard rather than options. See the [Swift guide](./swift.md).
 
-Python and Perl write nothing and point you at `doctor`, which already audits those repos against the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings). Their presets land with their language modules — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
+Python and Perl write nothing and point you at `doctor`. For **Python** that's now a full audit — Ruff, mypy, pytest, `.gitignore`, CI and git hooks on top of the language-agnostic checks, all fixable with `fix`; only the `setup` preset is still missing. See the [Python reference](../reference/python.md). Perl gets the language-agnostic checks (CI, CodeQL, Dependabot, GitHub repo settings) until its module lands — see [#139](https://github.com/rtorcato/repo-tooling/issues/139).
 :::
 
 ## Non-interactive setup (CI / scripts)

--- a/apps/docs/docs/reference/python.md
+++ b/apps/docs/docs/reference/python.md
@@ -1,0 +1,164 @@
+---
+title: Python
+description: Ruff, mypy and pytest configs, plus the Python checks doctor runs on a pyproject.toml repo.
+---
+
+`doctor` and `fix` detect a Python repo from `pyproject.toml` (or a legacy `setup.py`) and layer Python-specific checks on top of the language-agnostic ones (CI, CodeQL, Dependabot, GitHub repo settings).
+
+The standard here is **Ruff for lint *and* format, mypy for types, pytest for tests** — four tools' worth of coverage from three configs.
+
+:::note No `python-library` preset yet
+`setup --preset` has no Python entry, so this is an audit-and-fix module: point it at an existing repo. Scaffolding a package from scratch is follow-up work, and it's why there's no `python-lockfile` fix target either.
+:::
+
+## Checks
+
+| Check | Status when absent | Fix target |
+|---|---|---|
+| `pyproject.toml` | `missing` | — (package metadata you write) |
+| Ruff | `missing` | `ruff` |
+| mypy | `missing` | `mypy` |
+| pytest | `missing` | `pytest` |
+| Python `.gitignore` | `missing` | `python-gitignore` |
+| Python tests | `missing` | — (write tests, or `python-ci`) |
+| Git hooks | `optional-missing` | `python-git-hooks` |
+| Pre-push hook | `optional-missing` | `python-git-hooks` |
+
+`pyproject.toml` is checked for two things no tool infers for you: a `[project]` table (or Poetry's `[tool.poetry]`), and a `requires-python` floor. Without the floor, pip installs the package on an interpreter it cannot run on and the failure lands on the user at import time. There's no fixer — that content is the project's own metadata.
+
+`Python tests` has two halves: a suite must exist (`tests/`, `test/`, or a root-level `test_*.py`), and some pipeline (`.github/workflows/*` or `.gitlab-ci.yml`) must actually run `pytest`. A `tests/` directory nothing executes reads as covered, which is worse than having none.
+
+Each tool config is accepted in any of its standard homes — `ruff.toml`, `mypy.ini`, `pytest.ini`, `setup.cfg`, `tox.ini`, or the matching `[tool.*]` table in `pyproject.toml`. A repo that already configures them in `pyproject.toml` passes untouched.
+
+## Configs
+
+```bash
+npx @rtorcato/repo-tooling fix ruff     # ruff.toml
+npx @rtorcato/repo-tooling fix mypy     # mypy.ini
+npx @rtorcato/repo-tooling fix pytest   # pytest.ini
+npx @rtorcato/repo-tooling fix python-gitignore
+```
+
+All three are also available via `copy`:
+
+```bash
+npx @rtorcato/repo-tooling copy ruff
+```
+
+They're written as standalone files rather than merged into `pyproject.toml`: that file is the project's own metadata, and merging a table into it needs a TOML round-tripper this CLI doesn't carry.
+
+### Ruff
+
+Ruff is the linter **and** the formatter. **black is deliberately not part of the standard** — Ruff's formatter is black-compatible, and a second *rewriting* formatter fights the first. (Same reasoning as SwiftFormat on the [Swift](./swift.md) side.) `flake8`, `isort` and `pyupgrade` are likewise absent: the `select` list covers all three.
+
+```toml
+line-length = 100
+target-version = "py310"
+
+[lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF"]
+ignore = ["E501"]
+
+[format]
+quote-style = "double"
+indent-style = "space"
+```
+
+`E501` (line too long) is ignored on purpose: it's the formatter's job, and leaving it on makes every long string literal a lint error the formatter isn't allowed to fix.
+
+### mypy
+
+Strict on your own code, lenient on third-party packages that ship no types. Without the second half a single untyped dependency turns every import into an error and the whole run gets ignored.
+
+```ini
+[mypy]
+python_version = 3.10
+strict = True
+warn_unused_configs = True
+warn_unreachable = True
+show_error_codes = True
+```
+
+### pytest
+
+```ini
+[pytest]
+testpaths = tests
+addopts = --strict-markers --strict-config
+filterwarnings =
+    error
+```
+
+`--strict-markers` and `--strict-config` turn a typo'd marker or config key into a failure instead of a silent skip. Warnings are errors for the same reason — a `DeprecationWarning` nobody sees is a bug waiting for the next major release.
+
+### `.gitignore`
+
+The `python-gitignore` fixer **appends** rather than replacing, so project-specific entries survive. It adds only what's absent:
+
+```gitignore
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.venv/
+venv/
+.env
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+```
+
+## Git hooks
+
+Husky is an npm package, so a Python repo can't use it without dragging node into a toolchain that otherwise has none. The node-free equivalent is a committed hooks directory:
+
+```bash
+npx @rtorcato/repo-tooling fix python-git-hooks
+```
+
+| Hook | Runs |
+|---|---|
+| `.githooks/pre-commit` | `ruff format` then `ruff check --fix` |
+| `.githooks/pre-push` | `ruff check`, `mypy .`, `pytest` — the same gate as CI |
+
+The `pre-commit` *framework* (the Python tool of that name) is deliberately not used: it's a second config file, a second pinned-tool source, and a second place to keep the CI commands in sync. The hooks run the tools directly, exactly as CI does.
+
+`core.hooksPath` is per-clone local git config, not a committed file, so `doctor` never reports its absence as drift. Each clone needs it once:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## CI
+
+```bash
+npx @rtorcato/repo-tooling fix python-ci          # .github/workflows/ci.yml
+npx @rtorcato/repo-tooling fix codeql             # .github/workflows/codeql.yml
+npx @rtorcato/repo-tooling fix python-gitlab-ci   # .gitlab-ci.yml
+```
+
+| Job | What it does |
+|---|---|
+| `lint` | `ruff check --output-format=github` + `ruff format --check` |
+| `typecheck` | installs the project, then `mypy .` |
+| `test` | `pytest`, matrixed over the supported interpreters |
+
+The typecheck job installs the project (`pip install -e .`) before running mypy — against bare source, mypy reports every third-party import as missing.
+
+The test matrix is derived from `requires-python` in `pyproject.toml`: **two points, the declared floor and the newest release**, not every minor in between. Breaks show up at the ends of the range (a builtin removed in 3.10, a deprecation added in 3.13); the middle costs runner minutes to re-prove them absent. A repo declaring `requires-python = ">=3.13"` gets a single-entry matrix rather than a version that doesn't exist yet.
+
+CodeQL uses `language: python`, and Dependabot uses `package-ecosystem: pip` — both come from the language registry, so the shared `fix codeql` / `fix dependabot` targets do the right thing on a Python repo.
+
+### GitLab
+
+`.gitlab-ci.yml` runs `ruff` and `pytest` in the official `python:` image, pinned to the newest interpreter the repo supports. No matrix: GitLab's `parallel:matrix` needs a per-job image override, and a mirrored repo is a secondary pipeline — the version sweep lives on the GitHub side.
+
+## What isn't covered yet
+
+- **Scaffolding.** No `setup --preset python-library`, so there's no `python-lockfile` fix target either — writing a fabricated set of JS tool choices into a Python repo's lockfile would be worse than `doctor` reporting it absent, which is true.
+- **README badges.** The check runs, but `fix badges` derives every URL from a package.json `name` + `repository`, which a Python repo hasn't got. `doctor` reports; you add them by hand.
+- **Release automation.** No PyPI publish workflow yet — unlike the Swift module, which checks for a tag-triggered release.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
         'reference/postcss',
         'reference/prettier',
         'reference/publint',
+        'reference/python',
         'reference/release-please',
         'reference/rolldown',
         'reference/rollup',

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
 		"tooling/mcp/mcp.json.example",
 		"tooling/swift/*.yml",
 		"tooling/swift/*.json",
+		"tooling/python/*.toml",
+		"tooling/python/*.ini",
 		"tooling/github-actions/workflows/*.yml",
 		"README.md",
 		"AGENTS.md"

--- a/src/base/git-hooks.ts
+++ b/src/base/git-hooks.ts
@@ -1,0 +1,58 @@
+/**
+ * Committed git hooks for languages that can't use Husky (#309).
+ *
+ * Husky is an npm package, so a repo whose toolchain has no node can't use it.
+ * The node-free equivalent is a committed hooks directory that git is pointed at
+ * with `core.hooksPath` — identical mechanics whatever the language; only the
+ * hook bodies differ. Swift and Python both land here rather than each carrying
+ * their own copy of the write-then-chmod-then-git-config dance.
+ */
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/** The hook bodies a language module supplies. Both are `#!/bin/sh` scripts. */
+export interface HookScripts {
+	preCommit: string
+	prePush: string
+}
+
+/** Best-effort `git config` — a missing git or a non-repo dir is not a failure. */
+function gitConfig(cwd: string, key: string, value: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		execFile('git', ['-C', cwd, 'config', key, value], (err) => resolve(!err))
+	})
+}
+
+/**
+ * Writes both hooks and points git at them. Returns the files written —
+ * `core.hooksPath` is per-clone local config, not a file, so it's reported
+ * separately rather than pretending to be a repo change.
+ */
+export async function installGitHooks(
+	targetDir: string,
+	hooksDirName: string,
+	scripts: HookScripts
+): Promise<{ filesWritten: string[]; hooksPathSet: boolean }> {
+	const hooksDir = path.join(targetDir, hooksDirName)
+	await fs.ensureDir(hooksDir)
+
+	const filesWritten: string[] = []
+	for (const [name, content] of [
+		['pre-commit', scripts.preCommit],
+		['pre-push', scripts.prePush],
+	] as const) {
+		const hookPath = path.join(hooksDir, name)
+		await fs.writeFile(hookPath, content)
+		await fs.chmod(hookPath, 0o755)
+		filesWritten.push(`${hooksDirName}/${name}`)
+	}
+
+	// Guard on .git: `fix --diff` shadow-runs fixers in a temp copy that excludes
+	// .git, and that copy can land inside another repo — an unguarded `git config`
+	// there would rewrite the *parent* repo's hooksPath during a mere preview.
+	const isRepo = await fs.pathExists(path.join(targetDir, '.git'))
+	const hooksPathSet = isRepo ? await gitConfig(targetDir, 'core.hooksPath', hooksDirName) : false
+
+	return { filesWritten, hooksPathSet }
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -198,7 +198,7 @@ function demoteDeclined(results: CheckResult[], lock: Lockfile | null): CheckRes
  * the module hands the shape in rather than forking the check.
  */
 interface BaseCheckOptions {
-	/** Null for a language whose hook convention isn't encoded yet (Python/Perl). */
+	/** Null for a language whose hook convention isn't encoded yet (Perl). */
 	hooks: GitHooksProfile | null
 	badges: { audience: BadgeAudience; fixTarget: string | null }
 	/**
@@ -317,6 +317,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				// repository, which a Python repo hasn't got.
 				badges: { audience: 'public', fixTarget: null },
 				presetWorkflow: renderPythonWorkflow(await readPyproject(targetDir)),
+				language,
 			})),
 			...(await runPythonChecks(targetDir)),
 		]

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -4,6 +4,8 @@ import fs from 'fs-extra'
 import { renderGitHubWorkflow } from '../../base/ci.js'
 import { githubJobs } from '../../languages/js/ci.js'
 import { inferProjectConfig } from '../../languages/js/fixers.js'
+import { PYTHON_GIT_HOOKS, runPythonChecks } from '../../languages/python/checks.js'
+import { readPyproject, renderPythonWorkflow } from '../../languages/python/ci.js'
 import { resolveLanguageModule } from '../../languages/registry.js'
 import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../languages/swift/checks.js'
 import { readSwiftPackage, renderSwiftWorkflow } from '../../languages/swift/ci.js'
@@ -246,10 +248,10 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 
 	// Per-module dispatch (#285): the base checks (repo hygiene, CI, security,
 	// GitHub settings) apply to any repo and run for every language. A supported
-	// module layers its own checks on top; an unsupported one (Swift/Perl/Python
-	// until their modules land) still gets the full base suite instead of the old
-	// wholesale skip. 'unknown' (bare dir mid-setup) resolves to JS so a fresh
-	// repo runs the full suite.
+	// module layers its own checks on top; an unsupported one (Perl, until #289)
+	// still gets the full base suite instead of the old wholesale skip.
+	// 'unknown' (bare dir mid-setup) resolves to JS so a fresh repo runs the
+	// full suite.
 	const language = await detectLanguage(targetDir)
 	const languageModule = resolveLanguageModule(language)
 	if (!languageModule.supported) {
@@ -259,9 +261,9 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				status: 'ok',
 				detail: `detected ${languageModule.label} — running language-agnostic checks; ${languageModule.label}-specific checks land with its module (#139)`,
 			},
-			// hooks: null — nothing here encodes a Python/Perl hook convention yet,
-			// and guessing one would nag every repo with a fix target that doesn't
-			// exist. #289/#290 fill it in.
+			// hooks: null — nothing here encodes a Perl hook convention yet, and
+			// guessing one would nag every repo with a fix target that doesn't
+			// exist. #289 fills it in.
 			...(await runBaseChecks(targetDir, lock, {
 				hooks: null,
 				badges: { audience: 'public', fixTarget: null },
@@ -289,6 +291,28 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				presetWorkflow: renderSwiftWorkflow(await readSwiftPackage(targetDir)),
 			})),
 			...(await runSwiftChecks(targetDir)),
+		]
+		return demoteDeclined(results, lock)
+	}
+
+	// Python suite (#290): same shape as Swift — base checks plus the module's
+	// own, and nothing JS-shaped, because a Python repo has no package.json.
+	if (languageModule.id === 'python') {
+		const results: CheckResult[] = [
+			{
+				check: 'language',
+				status: 'ok',
+				detail: 'detected Python (pyproject.toml / setup.py)',
+			},
+			...(await runBaseChecks(targetDir, lock, {
+				hooks: PYTHON_GIT_HOOKS,
+				// A Python package on PyPI is public by default, so badges apply. No
+				// fixer: `fix badges` derives the block from package.json name and
+				// repository, which a Python repo hasn't got.
+				badges: { audience: 'public', fixTarget: null },
+				presetWorkflow: renderPythonWorkflow(await readPyproject(targetDir)),
+			})),
+			...(await runPythonChecks(targetDir)),
 		]
 		return demoteDeclined(results, lock)
 	}

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -69,11 +69,30 @@ const SWIFT_FIX_TARGETS: Record<string, string> = {
 	// isn't safe. The check's own hint covers both halves.
 }
 
+/** The same shadowing for the Python module (#290). */
+const PYTHON_FIX_TARGETS: Record<string, string> = {
+	'Git hooks': 'python-git-hooks',
+	'Pre-push hook': 'python-git-hooks',
+	'GitHub Actions': 'python-ci',
+	'GitLab CI': 'python-gitlab-ci',
+	Ruff: 'ruff',
+	mypy: 'mypy',
+	pytest: 'pytest',
+	'Python .gitignore': 'python-gitignore',
+	// `pyproject.toml` and `Python tests` are deliberately absent, for the same
+	// reason `Swift tests` is: the fix is content only the project can write
+	// (package metadata, actual tests). Their own hints say what to add.
+	// `lockfile` too — see the note at the top of src/languages/python/fixers.ts.
+}
+
+const FIX_TARGETS_BY_LANGUAGE: Record<string, Record<string, string>> = {
+	swift: SWIFT_FIX_TARGETS,
+	python: PYTHON_FIX_TARGETS,
+}
+
 export function getFixTargetForCheck(checkName: string, language?: string): string | null {
-	if (language === 'swift' && SWIFT_FIX_TARGETS[checkName]) {
-		return SWIFT_FIX_TARGETS[checkName]
-	}
-	return FIX_TARGETS[checkName] ?? null
+	const overrides = language ? FIX_TARGETS_BY_LANGUAGE[language] : undefined
+	return overrides?.[checkName] ?? FIX_TARGETS[checkName] ?? null
 }
 
 /**
@@ -175,6 +194,7 @@ export function lockfilePatchForTarget(
 			return c.commitLint ? null : { commitLint: true }
 		case 'husky':
 		case 'swift-git-hooks':
+		case 'python-git-hooks':
 			return c.gitHooks ? null : { gitHooks: true }
 		case 'semantic-release':
 		case 'swift-release':

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -18,21 +18,27 @@ import { declinedInLock, lockfilePatchForTarget } from './fix-targets.js'
 import { computeFileList } from './setup-presets.js'
 import { BASE_FIXERS, type Fixer, type FixRiskLevel, type Pkg } from '../../base/fixers.js'
 import { FIXERS, readPackageJson } from '../../languages/js/fixers.js'
+import { PYTHON_FIXERS } from '../../languages/python/fixers.js'
 import { SWIFT_FIXERS } from '../../languages/swift/fixers.js'
 import { detectLanguage } from '../utils/detect-language.js'
 
+/** The module-specific fixer set per detected language (#286, #290, #303). */
+const LANGUAGE_FIXERS: Record<string, Fixer[]> = {
+	swift: SWIFT_FIXERS,
+	python: PYTHON_FIXERS,
+}
+
 /**
- * The fixers that apply to a repo, by detected language (#286, #303): the
- * language-agnostic base set plus the module's own. Swift repos get the Swift
- * module; everything else (including a bare dir mid-setup) gets JS, the
- * historical default.
+ * The fixers that apply to a repo, by detected language: the language-agnostic
+ * base set plus the module's own. Anything without a module of its own
+ * (including a bare dir mid-setup) gets JS, the historical default.
  */
 function fixersForLanguage(language: string): Fixer[] {
-	return [...BASE_FIXERS, ...(language === 'swift' ? SWIFT_FIXERS : FIXERS)]
+	return [...BASE_FIXERS, ...(LANGUAGE_FIXERS[language] ?? FIXERS)]
 }
 
 /** Every fixer across every language — for `--list` and the unknown-target hint. */
-const ALL_FIXERS: Fixer[] = [...BASE_FIXERS, ...FIXERS, ...SWIFT_FIXERS]
+const ALL_FIXERS: Fixer[] = [...BASE_FIXERS, ...FIXERS, ...SWIFT_FIXERS, ...PYTHON_FIXERS]
 
 export interface FixOptions {
 	directory?: string

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -268,6 +268,26 @@ const TOOL_CATALOG: ToolCatalogEntry[] = [
 		fixTarget: 'periphery',
 	},
 	{
+		name: 'Ruff',
+		description:
+			'Python linter and formatter in one tool (replaces flake8, isort, pyupgrade, black)',
+		exports: [],
+		fixTarget: 'ruff',
+	},
+	{
+		name: 'mypy',
+		description:
+			'Python static type checker configuration (strict on your code, lenient on untyped deps)',
+		exports: [],
+		fixTarget: 'mypy',
+	},
+	{
+		name: 'pytest',
+		description: 'Python test runner configuration (strict markers and config, warnings as errors)',
+		exports: [],
+		fixTarget: 'pytest',
+	},
+	{
 		name: 'AI Agent Setup',
 		description: 'Scaffold AGENTS.md, CLAUDE.md, Cursor/Copilot rules, Claude skill, MCP example',
 		exports: [],

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -12,6 +12,9 @@ export type PresetName =
 	| 'swiftlint'
 	| 'swift-format'
 	| 'periphery'
+	| 'ruff'
+	| 'mypy'
+	| 'pytest'
 	| 'claude-skill'
 	| 'mcp-example'
 	| 'docusaurus-sync-changelog'
@@ -76,6 +79,21 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/swift/periphery.yml',
 		target: '.periphery.yml',
 		desc: 'Periphery dead-code scan configuration (retains public API)',
+	},
+	ruff: {
+		source: 'tooling/python/ruff.toml',
+		target: 'ruff.toml',
+		desc: 'Ruff configuration (lint + format — replaces flake8, isort, pyupgrade and black)',
+	},
+	mypy: {
+		source: 'tooling/python/mypy.ini',
+		target: 'mypy.ini',
+		desc: 'mypy configuration (strict on your code, lenient on untyped dependencies)',
+	},
+	pytest: {
+		source: 'tooling/python/pytest.ini',
+		target: 'pytest.ini',
+		desc: 'pytest configuration (strict markers and config, warnings as errors)',
 	},
 	'claude-skill': {
 		source: 'tooling/claude/repo-tooling.md',

--- a/src/languages/python/checks.ts
+++ b/src/languages/python/checks.ts
@@ -1,0 +1,268 @@
+/**
+ * Python language module — checks (#290), on the same template as Swift (#286).
+ *
+ * The standard encoded here is ruff (lint *and* format), mypy and pytest.
+ * Deliberately *not* checked:
+ *
+ * - **black** — ruff's formatter is black-compatible and already runs in the
+ *   pre-commit hook and the lint job. A second *rewriting* formatter fights the
+ *   first, which is the same reason the Swift module checks SwiftLint's `--fix`
+ *   rather than SwiftFormat. If a repo wants black instead, it configures black
+ *   in its own pyproject.toml — nothing here objects.
+ * - **flake8 / isort / pyupgrade** — the `select` list in the shipped ruff.toml
+ *   covers all three (E/W, I, UP), so a separate config would be a second place
+ *   to keep the same rules.
+ * - **A pinned interpreter file** (`.python-version`) — the supported range is
+ *   declared once in pyproject's `requires-python`, and CI derives its matrix
+ *   from that. A root file would be a second thing to keep in sync.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+import { type FileCheck, type GitHooksProfile, checkFile } from '../../base/checks.js'
+import type { CheckResult } from '../../base/types.js'
+import { PYTHON_GITIGNORE_SENTINELS } from './gitignore.js'
+import { PYTHON_HOOKS_DIR } from './git-hooks.js'
+
+/**
+ * A Python tool config, which can live in the tool's own file *or* in a table
+ * inside a file that belongs to something else. That split is why this isn't a
+ * plain `FileCheck`: `checkFile` treats "candidate exists but doesn't match" as
+ * drift, and every Python repo has a pyproject.toml. Reporting `pyproject.toml
+ * found but is not a valid Ruff configuration` on a repo that simply keeps its
+ * ruff config in ruff.toml — or hasn't configured ruff at all — is noise.
+ */
+interface PythonToolCheck {
+	/** Files that exist *only* to configure this tool. A bad one is real drift. */
+	dedicated: FileCheck
+	/**
+	 * Files that may carry the tool's table among unrelated config. Their mere
+	 * presence says nothing, so they can only ever upgrade the result to `ok`.
+	 */
+	shared: string[]
+}
+
+const PYTHON_TOOL_CHECKS: PythonToolCheck[] = [
+	{
+		dedicated: {
+			check: 'Ruff',
+			candidates: ['ruff.toml', '.ruff.toml'],
+			expected: 'is a valid Ruff configuration',
+			// `[tool.ruff...]` is the pyproject form; the rest are ruff.toml's own
+			// top-level keys and sections.
+			matcher: /^\[tool\.ruff|^\[(lint|format)\]|^(line-length|target-version)\s*=/m,
+			hint: 'Run `npx @rtorcato/repo-tooling fix ruff` to scaffold (or add a `[tool.ruff]` table to pyproject.toml)',
+		},
+		shared: ['pyproject.toml'],
+	},
+	{
+		dedicated: {
+			check: 'mypy',
+			candidates: ['mypy.ini', '.mypy.ini'],
+			expected: 'is a valid mypy configuration',
+			// `[mypy]` in mypy.ini/setup.cfg, `[tool.mypy]` in pyproject.
+			matcher: /^\[(tool\.)?mypy\]/m,
+			hint: 'Run `npx @rtorcato/repo-tooling fix mypy` to scaffold (or add a `[tool.mypy]` table to pyproject.toml)',
+		},
+		shared: ['setup.cfg', 'pyproject.toml'],
+	},
+	{
+		dedicated: {
+			check: 'pytest',
+			candidates: ['pytest.ini'],
+			expected: 'is a valid pytest configuration',
+			// `[pytest]` in pytest.ini/tox.ini, `[tool:pytest]` in setup.cfg,
+			// `[tool.pytest.ini_options]` in pyproject.
+			matcher: /^\[(pytest|tool:pytest|tool\.pytest\.ini_options)\]/m,
+			hint: 'Run `npx @rtorcato/repo-tooling fix pytest` to scaffold (or add a `[tool.pytest.ini_options]` table to pyproject.toml)',
+		},
+		shared: ['tox.ini', 'setup.cfg', 'pyproject.toml'],
+	},
+]
+
+async function checkPythonTool(dir: string, spec: PythonToolCheck): Promise<CheckResult> {
+	const result = await checkFile(dir, spec.dedicated)
+	// A dedicated file that exists takes precedence over any shared table — all
+	// three tools read it first — so `ok` and `drift` are both final answers.
+	if (result.status !== 'missing') return result
+
+	for (const candidate of spec.shared) {
+		const filepath = path.join(dir, candidate)
+		if (!(await fs.pathExists(filepath))) continue
+		if (spec.dedicated.matcher.test(await fs.readFile(filepath, 'utf-8'))) {
+			return {
+				check: spec.dedicated.check,
+				status: 'ok',
+				detail: `${candidate} ${spec.dedicated.expected}`,
+			}
+		}
+	}
+	return result
+}
+
+export async function checkPythonGitignore(dir: string): Promise<CheckResult> {
+	const check = 'Python .gitignore'
+	const filepath = path.join(dir, '.gitignore')
+	if (!(await fs.pathExists(filepath))) {
+		return {
+			check,
+			status: 'missing',
+			detail: 'no .gitignore',
+			hint: 'Run `npx @rtorcato/repo-tooling fix python-gitignore` to scaffold the Python template',
+		}
+	}
+
+	const contents = await fs.readFile(filepath, 'utf-8')
+	const missing = PYTHON_GITIGNORE_SENTINELS.filter((entry) => !contents.includes(entry))
+	if (missing.length > 0) {
+		return {
+			check,
+			status: 'drift',
+			detail: `.gitignore missing Python artefacts: ${missing.join(', ')}`,
+			hint: 'Run `npx @rtorcato/repo-tooling fix python-gitignore` to append the missing entries',
+		}
+	}
+
+	return {
+		check,
+		status: 'ok',
+		detail: `.gitignore covers ${PYTHON_GITIGNORE_SENTINELS.join(', ')}`,
+	}
+}
+
+/**
+ * pyproject.toml hygiene, the Python shape of the `Package.swift` check. Both
+ * signals are things no tool infers for you: without a metadata table there is
+ * nothing to build or publish, and without a `requires-python` floor pip will
+ * happily install the package on an interpreter it cannot run on — the failure
+ * lands on the user, at import time.
+ */
+export async function checkPyproject(dir: string): Promise<CheckResult> {
+	const check = 'pyproject.toml'
+	const filepath = path.join(dir, 'pyproject.toml')
+
+	if (!(await fs.pathExists(filepath))) {
+		// detect-language also accepts setup.py, so a repo can reach this module
+		// without a pyproject at all. That's drift rather than "not a Python repo".
+		const legacy = await fs.pathExists(path.join(dir, 'setup.py'))
+		return {
+			check,
+			status: 'missing',
+			detail: legacy ? 'setup.py only — no pyproject.toml' : 'no pyproject.toml',
+			hint: 'Add a PEP 621 pyproject.toml with a `[project]` table — setup.py is legacy and no longer the packaging standard',
+		}
+	}
+
+	const contents = await fs.readFile(filepath, 'utf-8')
+	// PEP 621 `[project]` or Poetry's `[tool.poetry]` — the two forms in the wild.
+	const poetry = /^\[tool\.poetry\]/m.test(contents)
+	if (!/^\[project\]/m.test(contents) && !poetry) {
+		return {
+			check,
+			status: 'drift',
+			detail: 'pyproject.toml declares no `[project]` (or `[tool.poetry]`) metadata',
+			hint: 'Add a `[project]` table with `name`, `version` and `requires-python` — see PEP 621',
+		}
+	}
+
+	// Poetry spells the same constraint `python = "^3.11"` under its dependencies.
+	const hasFloor = poetry
+		? /^\s*python\s*=/m.test(contents)
+		: /^requires-python\s*=/m.test(contents)
+	if (!hasFloor) {
+		return {
+			check,
+			status: 'drift',
+			detail: `pyproject.toml declares no ${poetry ? '`python` constraint' : '`requires-python`'}`,
+			hint: 'Add `requires-python = ">=3.10"` — without it pip installs the package on interpreters it cannot run on',
+		}
+	}
+
+	return {
+		check,
+		status: 'ok',
+		detail: `pyproject.toml declares ${poetry ? 'Poetry' : 'PEP 621'} metadata and a Python floor`,
+	}
+}
+
+/** CI files that could be running the test suite, most likely first. */
+async function ciFiles(dir: string): Promise<string[]> {
+	const candidates: string[] = ['.gitlab-ci.yml', '.gitlab-ci.yaml']
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (await fs.pathExists(workflowsDir)) {
+		const files = (await fs.readdir(workflowsDir)).filter(
+			(f) => f.endsWith('.yml') || f.endsWith('.yaml')
+		)
+		candidates.unshift(...files.map((f) => path.join('.github', 'workflows', f)))
+	}
+	return candidates
+}
+
+/** `tests/`, `test/`, or a root-level `test_*.py` — the three layouts pytest finds. */
+async function hasTestFiles(dir: string): Promise<string | null> {
+	for (const candidate of ['tests', 'test']) {
+		if (await fs.pathExists(path.join(dir, candidate))) return `${candidate}/`
+	}
+	try {
+		const found = (await fs.readdir(dir)).find((f) => /^test_.*\.py$/.test(f))
+		return found ?? null
+	} catch {
+		return null
+	}
+}
+
+/**
+ * The test setup. Same two halves as the Swift version: a suite has to exist,
+ * and CI has to run it. A green pipeline over a repo with no tests proves
+ * nothing, and a tests/ directory nothing executes is worse than none at all —
+ * it reads as covered.
+ */
+export async function checkPythonTests(dir: string): Promise<CheckResult> {
+	const check = 'Python tests'
+	const tests = await hasTestFiles(dir)
+	if (!tests) {
+		return {
+			check,
+			status: 'missing',
+			detail: 'no tests/ directory or test_*.py files',
+			hint: 'Add a `tests/` directory — the shipped pytest.ini sets `testpaths = tests`',
+		}
+	}
+
+	for (const candidate of await ciFiles(dir)) {
+		const filepath = path.join(dir, candidate)
+		if (!(await fs.pathExists(filepath))) continue
+		if (/\bpytest\b/.test(await fs.readFile(filepath, 'utf-8'))) {
+			return { check, status: 'ok', detail: `${tests} found and run by ${candidate}` }
+		}
+	}
+
+	return {
+		check,
+		status: 'drift',
+		detail: `${tests} found but no CI job runs pytest`,
+		hint: 'Run `npx @rtorcato/repo-tooling fix python-ci` to regenerate a workflow that runs pytest',
+	}
+}
+
+/**
+ * The Python shape of the base `Git hooks` / `Pre-push hook` checks (#309).
+ * `install` is null for the same reason Swift's is: the wiring —
+ * `git config core.hooksPath` — is per-clone local state that nothing commits,
+ * so flagging its absence would fail every fresh CI checkout.
+ */
+export const PYTHON_GIT_HOOKS: GitHooksProfile = {
+	dir: PYTHON_HOOKS_DIR,
+	install: null,
+	verifyCommand: 'pytest',
+	fixTarget: 'python-git-hooks',
+}
+
+/** The Python module's suite, layered on top of the base checks by doctor. */
+export async function runPythonChecks(dir: string): Promise<CheckResult[]> {
+	return [
+		await checkPyproject(dir),
+		...(await Promise.all(PYTHON_TOOL_CHECKS.map((spec) => checkPythonTool(dir, spec)))),
+		await checkPythonGitignore(dir),
+		await checkPythonTests(dir),
+	]
+}

--- a/src/languages/python/ci.ts
+++ b/src/languages/python/ci.ts
@@ -1,0 +1,174 @@
+/**
+ * Python CI generation (#290), built on the language-agnostic skeleton in
+ * `src/base/ci.ts`. No `setup-node`, no `pnpm` — the Python path runs on Linux
+ * with `actions/setup-python` and pip.
+ *
+ * Like the Swift path there's no `ProjectConfig` to read: the one fact CI needs
+ * beyond the fixed job shapes — which interpreters to test on — is declared in
+ * pyproject.toml, so the matrix is derived from the repo itself.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+import { type CiJob, type GitLabSpec, renderGitHubWorkflow, renderGitLabCI } from '../../base/ci.js'
+
+/**
+ * The newest interpreter the emitted matrix tests against, and the one the
+ * single-interpreter jobs (lint, typecheck) run on.
+ *
+ * ponytail: a constant, bumped by hand once a year when CPython ships a minor.
+ * Resolving "latest" at generation time would need a network call from a
+ * generator whose whole job is emitting text.
+ */
+const LATEST_PYTHON = '3.13'
+
+/** The oldest interpreter to assume when pyproject declares no floor. */
+const DEFAULT_FLOOR = '3.10'
+
+export interface PythonProject {
+	/**
+	 * Interpreter versions for the test matrix, oldest first. Two points — the
+	 * declared floor and the newest release — rather than every minor between:
+	 * breaks show up at the ends of the range (a removed 3.9 builtin, a new 3.13
+	 * deprecation), and the middle costs runner minutes to re-prove them absent.
+	 */
+	pythonVersions: string[]
+}
+
+const minorOf = (version: string): number => Number.parseInt(version.split('.')[1] ?? '0', 10)
+
+/**
+ * Pull the supported-Python floor out of a pyproject.toml. A regex rather than
+ * a TOML parser: this is one key, and a parser is a dependency the CLI would
+ * carry solely to read it.
+ */
+export function parsePyproject(contents: string): PythonProject {
+	// PEP 621 `requires-python = ">=3.10"`, or Poetry's
+	// `python = "^3.11"` under [tool.poetry.dependencies].
+	const constraint =
+		contents.match(/^requires-python\s*=\s*["']([^"']+)["']/m)?.[1] ??
+		contents.match(/^\s*python\s*=\s*["']([^"']+)["']/m)?.[1] ??
+		''
+	const floor = constraint.match(/(\d+\.\d+)/)?.[1] ?? DEFAULT_FLOOR
+
+	// A floor at or above the newest release we know about collapses the matrix
+	// to one entry rather than emitting a version that doesn't exist yet.
+	const versions = minorOf(floor) >= minorOf(LATEST_PYTHON) ? [floor] : [floor, LATEST_PYTHON]
+	return { pythonVersions: versions }
+}
+
+export async function readPyproject(dir: string): Promise<PythonProject> {
+	const filepath = path.join(dir, 'pyproject.toml')
+	if (!(await fs.pathExists(filepath))) return { pythonVersions: [DEFAULT_FLOOR, LATEST_PYTHON] }
+	return parsePyproject(await fs.readFile(filepath, 'utf-8'))
+}
+
+/** Checkout + interpreter. `cache: pip` keys off the manifests pip resolves from. */
+function pythonSetup(version: string): string {
+	return `      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🐍 Set up Python ${version}
+        uses: actions/setup-python@v6
+        with:
+          python-version: '${version}'
+          cache: pip`
+}
+
+export function pythonGithubJobs(project: PythonProject): CiJob[] {
+	return [
+		{
+			id: 'lint',
+			steps: `${pythonSetup(LATEST_PYTHON)}
+
+      - name: 📦 Install Ruff
+        run: pip install ruff
+
+      - name: 🔍 ruff check
+        run: ruff check --output-format=github
+
+      - name: 🎨 ruff format --check
+        run: ruff format --check`,
+		},
+		{
+			id: 'typecheck',
+			// mypy needs the package's own dependencies importable to resolve their
+			// types — running it against bare source reports every third-party import
+			// as missing.
+			steps: `${pythonSetup(LATEST_PYTHON)}
+
+      - name: 📦 Install project and mypy
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+          pip install mypy
+
+      - name: 🔎 mypy
+        run: mypy .`,
+		},
+		{
+			id: 'test',
+			extra: `    name: pytest \${{ matrix.python-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+${project.pythonVersions.map((v) => `          - '${v}'`).join('\n')}`,
+			steps: `      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🐍 Set up Python \${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: \${{ matrix.python-version }}
+          cache: pip
+
+      - name: 📦 Install project and pytest
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: 🧪 pytest
+        run: pytest`,
+		},
+	]
+}
+
+export function renderPythonWorkflow(project: PythonProject): string {
+	return renderGitHubWorkflow(pythonGithubJobs(project))
+}
+
+/**
+ * GitLab runs the same three commands in the official Python image. The matrix
+ * is dropped: GitLab's `parallel:matrix` would need a per-job image override,
+ * and a mirrored repo is a secondary pipeline — the version sweep lives on the
+ * GitHub side.
+ */
+function pythonGitlabSpec(project: PythonProject): GitLabSpec {
+	const image = `python:${project.pythonVersions.at(-1) ?? LATEST_PYTHON}`
+	return {
+		image,
+		preamble: `variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
+cache:
+  paths:
+    - .cache/pip`,
+		jobs: [
+			{
+				id: 'lint',
+				stage: 'lint',
+				script: ['pip install ruff', 'ruff check', 'ruff format --check'],
+			},
+			{
+				id: 'test',
+				stage: 'test',
+				script: ['pip install -e .', 'pip install pytest', 'pytest'],
+			},
+		],
+	}
+}
+
+export function renderPythonGitLabCI(project: PythonProject): string {
+	return renderGitLabCI(pythonGitlabSpec(project))
+}

--- a/src/languages/python/fixers.ts
+++ b/src/languages/python/fixers.ts
@@ -1,0 +1,112 @@
+/**
+ * Python language module — fixers (#290). One per check in ./checks.ts.
+ *
+ * ponytail: no `python-lockfile` fixer. Swift's writes the config that
+ * `setup --preset swift-library` would have produced, and there is no
+ * `python-library` preset yet (the Swift one landed in its own issue, #288).
+ * Inventing a ProjectConfig here just to have something to record would put a
+ * fabricated set of JS tool choices in a Python repo's lockfile — worse than
+ * doctor saying the lockfile is absent, which is true.
+ */
+import path from 'node:path'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import type { Fixer } from '../../base/fixers.js'
+import { copyPreset } from '../../cli/utils/copy-preset.js'
+import { readPyproject, renderPythonGitLabCI, renderPythonWorkflow } from './ci.js'
+import { PYTHON_HOOKS_DIR, installPythonGitHooks } from './git-hooks.js'
+import { ensurePythonGitignore } from './gitignore.js'
+
+export const PYTHON_FIXERS: Fixer[] = [
+	{
+		target: 'ruff',
+		description: 'Scaffold ruff.toml (lint + format — the linter and the formatter in one tool)',
+		appliesTo: ['Ruff'],
+		outputs: ['ruff.toml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('ruff', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'mypy',
+		description: 'Scaffold mypy.ini (strict on your code, lenient on untyped dependencies)',
+		appliesTo: ['mypy'],
+		outputs: ['mypy.ini'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('mypy', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'pytest',
+		description: 'Scaffold pytest.ini (strict markers and config, warnings as errors)',
+		appliesTo: ['pytest'],
+		outputs: ['pytest.ini'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const result = await copyPreset('pytest', targetDir)
+			return { filesWritten: [result.target] }
+		},
+	},
+	{
+		target: 'python-gitignore',
+		description:
+			'Add the Python artefacts (__pycache__, .venv, tool caches, build output) to .gitignore',
+		appliesTo: ['Python .gitignore'],
+		// Appends what's missing; never clobbers a project's own entries.
+		riskLevel: 'safe-merge',
+		outputs: ['.gitignore'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await ensurePythonGitignore(targetDir) }
+		},
+	},
+	{
+		target: 'python-git-hooks',
+		description: `Scaffold ${PYTHON_HOOKS_DIR}/pre-commit + pre-push (ruff, mypy, pytest) and point git at them via core.hooksPath`,
+		appliesTo: ['Git hooks', 'Pre-push hook'],
+		outputs: [`${PYTHON_HOOKS_DIR}/pre-commit`, `${PYTHON_HOOKS_DIR}/pre-push`],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const { filesWritten, hooksPathSet } = await installPythonGitHooks(targetDir)
+			console.log(
+				hooksPathSet
+					? chalk.dim(`   git config core.hooksPath ${PYTHON_HOOKS_DIR}`)
+					: chalk.yellow(
+							`   run \`git config core.hooksPath ${PYTHON_HOOKS_DIR}\` once per clone — it's local git config, not a committed file`
+						)
+			)
+			return { filesWritten }
+		},
+	},
+	{
+		target: 'python-ci',
+		description:
+			'Scaffold .github/workflows/ci.yml for Python (ruff, mypy, pytest across the supported interpreters)',
+		appliesTo: ['GitHub Actions'],
+		outputs: ['.github/workflows/ci.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const workflowsDir = path.join(targetDir, '.github', 'workflows')
+			await fs.ensureDir(workflowsDir)
+			const workflow = renderPythonWorkflow(await readPyproject(targetDir))
+			await fs.writeFile(path.join(workflowsDir, 'ci.yml'), workflow)
+			return { filesWritten: ['.github/workflows/ci.yml'] }
+		},
+	},
+	{
+		target: 'python-gitlab-ci',
+		description: 'Scaffold .gitlab-ci.yml for Python (ruff + pytest on the official Python image)',
+		appliesTo: ['GitLab CI'],
+		outputs: ['.gitlab-ci.yml'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			const ci = renderPythonGitLabCI(await readPyproject(targetDir))
+			await fs.writeFile(path.join(targetDir, '.gitlab-ci.yml'), ci)
+			return { filesWritten: ['.gitlab-ci.yml'] }
+		},
+	},
+]

--- a/src/languages/python/git-hooks.ts
+++ b/src/languages/python/git-hooks.ts
@@ -1,0 +1,41 @@
+/**
+ * Python git hooks (#290). Same shape as the Swift ones (#309) and for the same
+ * reason: Husky is an npm package, and a Python repo has no node on the path to
+ * run it. The committed `.githooks/` directory plus `core.hooksPath` is the
+ * node-free equivalent; the mechanics live in `src/base/git-hooks.ts`.
+ *
+ * Deliberately *not* `pre-commit` (the Python framework of that name): it is a
+ * second config file, a second pinned-tool source, and a second place the CI
+ * commands have to be kept in sync with. The hooks run ruff/mypy/pytest
+ * directly, exactly as CI does.
+ */
+import { installGitHooks } from '../../base/git-hooks.js'
+
+export const PYTHON_HOOKS_DIR = '.githooks'
+
+// `ruff format` before `ruff check --fix` so the lint pass sees final layout.
+// Neither rewrites anything the other undoes — one tool owns both jobs.
+const PYTHON_PRE_COMMIT = `#!/bin/sh
+set -e
+ruff format
+ruff check --fix
+`
+
+// mypy before pytest: a type error is cheaper to surface than a test run.
+const PYTHON_PRE_PUSH = `#!/bin/sh
+set -e
+echo "🔍 Running pre-push verify..."
+ruff check
+mypy .
+pytest
+echo "✅ Verify passed — pushing."
+`
+
+export function installPythonGitHooks(
+	targetDir: string
+): Promise<{ filesWritten: string[]; hooksPathSet: boolean }> {
+	return installGitHooks(targetDir, PYTHON_HOOKS_DIR, {
+		preCommit: PYTHON_PRE_COMMIT,
+		prePush: PYTHON_PRE_PUSH,
+	})
+}

--- a/src/languages/python/gitignore.ts
+++ b/src/languages/python/gitignore.ts
@@ -1,0 +1,61 @@
+/**
+ * The Python .gitignore block, shared by the `python-gitignore` fixer and the
+ * check that reports it. Its own module for the same reason Swift's is (#286):
+ * nothing else in the module has to import from `fixers.ts` to reuse it.
+ */
+import path from 'node:path'
+import fs from 'fs-extra'
+
+/**
+ * The Python artefacts that must stay out of git. Appended to an existing
+ * .gitignore rather than replacing it — a Python repo's ignore file usually
+ * carries project-specific entries worth keeping.
+ */
+const PYTHON_GITIGNORE_BLOCK = `# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+
+# Environments
+.venv/
+venv/
+.env
+
+# Tool caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+`
+
+/**
+ * Entries whose presence means the block (or an equivalent) is already there.
+ * `__pycache__` and `.venv` are the expensive ones — either committed by
+ * accident buries the diff — and a tool cache stands in for the rest.
+ */
+export const PYTHON_GITIGNORE_SENTINELS = ['__pycache__', '.venv', '.pytest_cache']
+
+export async function ensurePythonGitignore(targetDir: string): Promise<string[]> {
+	const filepath = path.join(targetDir, '.gitignore')
+	if (!(await fs.pathExists(filepath))) {
+		await fs.writeFile(filepath, PYTHON_GITIGNORE_BLOCK)
+		return ['.gitignore']
+	}
+
+	const existing = await fs.readFile(filepath, 'utf-8')
+	const missing = PYTHON_GITIGNORE_SENTINELS.filter((entry) => !existing.includes(entry))
+	if (missing.length === 0) return []
+
+	// Append only what's absent, so a repo that already ignores __pycache__
+	// doesn't get a duplicate entry for it.
+	const additions = PYTHON_GITIGNORE_BLOCK.split('\n').filter(
+		(line) => line.length > 0 && !existing.includes(line)
+	)
+	const separator = existing.endsWith('\n') ? '' : '\n'
+	await fs.writeFile(filepath, `${existing}${separator}\n${additions.join('\n')}\n`)
+	return ['.gitignore']
+}

--- a/src/languages/registry.ts
+++ b/src/languages/registry.ts
@@ -23,8 +23,8 @@ export interface LanguageModule {
 	 */
 	dependabotEcosystem: string | null
 	/**
-	 * Whether repo-tooling's doctor/fix suite covers this language yet. Only JS
-	 * today; Swift/Python/Perl flip to `true` as their modules land (#286/#290/#289).
+	 * Whether repo-tooling's doctor/fix suite covers this language yet. JS, Swift
+	 * and Python today; Perl flips to `true` when its module lands (#289).
 	 * The coarse doctor gate keys off this until per-module dispatch (#285).
 	 */
 	supported: boolean
@@ -50,7 +50,7 @@ export const LANGUAGES: Record<LanguageModule['id'], LanguageModule> = {
 		label: 'Python',
 		codeqlLanguages: ['python'],
 		dependabotEcosystem: 'pip',
-		supported: false,
+		supported: true,
 	},
 	perl: {
 		id: 'perl',

--- a/src/languages/swift/git-hooks.ts
+++ b/src/languages/swift/git-hooks.ts
@@ -2,16 +2,15 @@
  * Swift git hooks (#309). Husky is an npm package, so a SwiftPM repo can't use
  * it without dragging node into a toolchain that otherwise has none. The
  * node-free equivalent is a committed `.githooks/` directory that git is pointed
- * at with `core.hooksPath`.
+ * at with `core.hooksPath` — the mechanics live in `src/base/git-hooks.ts`; only
+ * the hook bodies are Swift's.
  *
  * The hooks run the tools directly rather than a `verify` indirection: SwiftPM
  * has no scripts field, and inventing a Makefile target would be a third place
  * to keep the CI commands in sync (they already live in .github/workflows/ci.yml
  * and .swiftlint.yml).
  */
-import { execFile } from 'node:child_process'
-import path from 'node:path'
-import fs from 'fs-extra'
+import { installGitHooks } from '../../base/git-hooks.js'
 
 export const SWIFT_HOOKS_DIR = '.githooks'
 
@@ -32,42 +31,11 @@ swiftlint lint --strict
 echo "✅ Verify passed — pushing."
 `
 
-/** Best-effort `git config` — a missing git or a non-repo dir is not a failure. */
-function gitConfig(cwd: string, key: string, value: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		execFile('git', ['-C', cwd, 'config', key, value], (err) => resolve(!err))
-	})
-}
-
-/**
- * Writes both hooks and points git at them. Returns the files written —
- * `core.hooksPath` is per-clone local config, not a file, so it's reported
- * separately rather than pretending to be a repo change.
- */
-export async function installSwiftGitHooks(
+export function installSwiftGitHooks(
 	targetDir: string
 ): Promise<{ filesWritten: string[]; hooksPathSet: boolean }> {
-	const hooksDir = path.join(targetDir, SWIFT_HOOKS_DIR)
-	await fs.ensureDir(hooksDir)
-
-	const filesWritten: string[] = []
-	for (const [name, content] of [
-		['pre-commit', SWIFT_PRE_COMMIT],
-		['pre-push', SWIFT_PRE_PUSH],
-	] as const) {
-		const hookPath = path.join(hooksDir, name)
-		await fs.writeFile(hookPath, content)
-		await fs.chmod(hookPath, 0o755)
-		filesWritten.push(`${SWIFT_HOOKS_DIR}/${name}`)
-	}
-
-	// Guard on .git: `fix --diff` shadow-runs fixers in a temp copy that excludes
-	// .git, and that copy can land inside another repo — an unguarded `git config`
-	// there would rewrite the *parent* repo's hooksPath during a mere preview.
-	const isRepo = await fs.pathExists(path.join(targetDir, '.git'))
-	const hooksPathSet = isRepo
-		? await gitConfig(targetDir, 'core.hooksPath', SWIFT_HOOKS_DIR)
-		: false
-
-	return { filesWritten, hooksPathSet }
+	return installGitHooks(targetDir, SWIFT_HOOKS_DIR, {
+		preCommit: SWIFT_PRE_COMMIT,
+		prePush: SWIFT_PRE_PUSH,
+	})
 }

--- a/tests/languages/python/checks.test.ts
+++ b/tests/languages/python/checks.test.ts
@@ -1,0 +1,224 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import {
+	checkPyproject,
+	checkPythonGitignore,
+	checkPythonTests,
+	runPythonChecks,
+} from '../../../src/languages/python/checks.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const VALID_PYPROJECT = `[project]
+name = "demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+`
+
+describe('checkPyproject', () => {
+	it('is missing without a pyproject.toml', async () => {
+		expect((await checkPyproject(newTmpDir())).status).toBe('missing')
+	})
+
+	// detect-language accepts setup.py, so the module runs on a repo with no
+	// pyproject at all — that's drift from the packaging standard, not "not Python".
+	it('names setup.py when that is all the repo has', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'setup.py'), 'from setuptools import setup\n')
+		const result = await checkPyproject(dir)
+		expect(result.status).toBe('missing')
+		expect(result.detail).toContain('setup.py')
+	})
+
+	it('passes a PEP 621 manifest with a requires-python floor', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pyproject.toml'), VALID_PYPROJECT)
+		const result = await checkPyproject(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('PEP 621')
+	})
+
+	it('flags a pyproject with no project metadata at all', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pyproject.toml'), '[tool.ruff]\nline-length = 100\n')
+		const result = await checkPyproject(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('[project]')
+	})
+
+	it('flags a PEP 621 manifest with no requires-python', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pyproject.toml'), '[project]\nname = "demo"\nversion = "0.1"\n')
+		const result = await checkPyproject(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('requires-python')
+	})
+
+	// Poetry spells the same two facts differently; both forms are in the wild.
+	it('accepts a Poetry manifest', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(
+			join(dir, 'pyproject.toml'),
+			'[tool.poetry]\nname = "demo"\n\n[tool.poetry.dependencies]\npython = "^3.11"\n'
+		)
+		const result = await checkPyproject(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('Poetry')
+	})
+
+	it('flags a Poetry manifest with no python constraint', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pyproject.toml'), '[tool.poetry]\nname = "demo"\n')
+		expect((await checkPyproject(dir)).status).toBe('drift')
+	})
+})
+
+describe('checkPythonGitignore', () => {
+	it('is missing without a .gitignore', async () => {
+		expect((await checkPythonGitignore(newTmpDir())).status).toBe('missing')
+	})
+
+	it('passes when the artefacts are covered', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '__pycache__/\n.venv/\n.pytest_cache/\n')
+		expect((await checkPythonGitignore(dir)).status).toBe('ok')
+	})
+
+	it('names the entries that are missing', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '__pycache__/\n')
+		const result = await checkPythonGitignore(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('.venv')
+		expect(result.detail).toContain('.pytest_cache')
+		expect(result.detail).not.toContain('__pycache__,')
+	})
+})
+
+describe('checkPythonTests', () => {
+	const CI = 'jobs:\n  test:\n    steps:\n      - run: pytest\n'
+
+	it('is missing with no tests anywhere', async () => {
+		expect((await checkPythonTests(newTmpDir())).status).toBe('missing')
+	})
+
+	// A tests/ directory nothing executes reads as covered, which is worse than
+	// having none at all — the failure mode this half exists for.
+	it('drifts when tests exist but no CI runs pytest', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(join(dir, 'tests/test_demo.py'), 'def test_x():\n    assert True\n')
+		await fs.outputFile(join(dir, '.github/workflows/ci.yml'), 'jobs:\n  build:\n    steps: []\n')
+		const result = await checkPythonTests(dir)
+		expect(result.status).toBe('drift')
+		expect(result.hint).toContain('fix python-ci')
+	})
+
+	it('passes when a workflow runs pytest', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(join(dir, 'tests/test_demo.py'), '')
+		await fs.outputFile(join(dir, '.github/workflows/ci.yml'), CI)
+		expect((await checkPythonTests(dir)).status).toBe('ok')
+	})
+
+	// GitLab is the only pipeline on a repo mirrored off GitHub.
+	it('accepts .gitlab-ci.yml as the runner', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(join(dir, 'tests/test_demo.py'), '')
+		await fs.writeFile(join(dir, '.gitlab-ci.yml'), 'test:\n  script:\n    - pytest\n')
+		expect((await checkPythonTests(dir)).status).toBe('ok')
+	})
+
+	it('accepts a root-level test_*.py as the suite', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'test_demo.py'), '')
+		await fs.outputFile(join(dir, '.github/workflows/ci.yml'), CI)
+		expect((await checkPythonTests(dir)).status).toBe('ok')
+	})
+})
+
+describe('runPythonChecks', () => {
+	it('covers the manifest, tools, ignore file and tests', async () => {
+		const names = (await runPythonChecks(newTmpDir())).map((r) => r.check)
+		expect(names).toEqual([
+			'pyproject.toml',
+			'Ruff',
+			'mypy',
+			'pytest',
+			'Python .gitignore',
+			'Python tests',
+		])
+	})
+
+	it('treats every tool config as required', async () => {
+		const byName = Object.fromEntries(
+			(await runPythonChecks(newTmpDir())).map((r) => [r.check, r.status])
+		)
+		expect(byName.Ruff).toBe('missing')
+		expect(byName.mypy).toBe('missing')
+		expect(byName.pytest).toBe('missing')
+	})
+
+	// The three tools can all be configured from pyproject.toml instead of their
+	// own files, and that has to count.
+	it('accepts the pyproject form of every tool config', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(
+			join(dir, 'pyproject.toml'),
+			`${VALID_PYPROJECT}\n[tool.ruff]\nline-length = 100\n\n[tool.mypy]\nstrict = true\n\n[tool.pytest.ini_options]\ntestpaths = ["tests"]\n`
+		)
+		const byName = Object.fromEntries(
+			(await runPythonChecks(dir)).map((r) => [r.check, r.status])
+		)
+		expect(byName.Ruff).toBe('ok')
+		expect(byName.mypy).toBe('ok')
+		expect(byName.pytest).toBe('ok')
+	})
+
+	// setup.cfg / tox.ini are the pre-pyproject homes for the same two tools.
+	it('accepts the setup.cfg and tox.ini forms', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'setup.cfg'), '[mypy]\nstrict = True\n\n[tool:pytest]\n')
+		const byName = Object.fromEntries(
+			(await runPythonChecks(dir)).map((r) => [r.check, r.status])
+		)
+		expect(byName.mypy).toBe('ok')
+		expect(byName.pytest).toBe('ok')
+	})
+
+	it('flags a ruff.toml that carries no recognisable config', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'ruff.toml'), '# TODO: fill this in\n')
+		const results = await runPythonChecks(dir)
+		expect(results.find((r) => r.check === 'Ruff')?.status).toBe('drift')
+	})
+
+	// Every Python repo has a pyproject.toml. Reading its mere presence as a
+	// broken tool config would report drift on every unconfigured repo — the
+	// tools simply aren't set up, which is `missing`.
+	it('does not read a bare pyproject.toml as a broken tool config', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pyproject.toml'), VALID_PYPROJECT)
+		const byName = Object.fromEntries(
+			(await runPythonChecks(dir)).map((r) => [r.check, r.status])
+		)
+		expect(byName.Ruff).toBe('missing')
+		expect(byName.mypy).toBe('missing')
+		expect(byName.pytest).toBe('missing')
+	})
+
+	// The dedicated file wins at runtime (ruff reads ruff.toml before pyproject),
+	// so a broken one stays drift even when the pyproject table is fine.
+	it('lets a broken dedicated config outrank a valid pyproject table', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'ruff.toml'), '# TODO: fill this in\n')
+		await fs.writeFile(join(dir, 'pyproject.toml'), '[tool.ruff]\nline-length = 100\n')
+		const results = await runPythonChecks(dir)
+		expect(results.find((r) => r.check === 'Ruff')?.status).toBe('drift')
+	})
+})

--- a/tests/languages/python/ci.test.ts
+++ b/tests/languages/python/ci.test.ts
@@ -1,0 +1,113 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import {
+	parsePyproject,
+	pythonGithubJobs,
+	readPyproject,
+	renderPythonGitLabCI,
+	renderPythonWorkflow,
+} from '../../../src/languages/python/ci.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+describe('parsePyproject', () => {
+	it('tests the declared floor and the newest interpreter', () => {
+		expect(parsePyproject('requires-python = ">=3.10"\n').pythonVersions).toEqual(['3.10', '3.13'])
+	})
+
+	it('reads the Poetry spelling of the same constraint', () => {
+		expect(
+			parsePyproject('[tool.poetry.dependencies]\npython = "^3.11"\n').pythonVersions
+		).toEqual(['3.11', '3.13'])
+	})
+
+	it('falls back to a floor when the manifest declares none', () => {
+		expect(parsePyproject('[project]\nname = "demo"\n').pythonVersions).toEqual(['3.10', '3.13'])
+	})
+
+	// Emitting a matrix entry for an interpreter older than the floor would fail
+	// CI on a repo that correctly declared it doesn't support that version.
+	it('collapses to one entry when the floor is the newest release', () => {
+		expect(parsePyproject('requires-python = ">=3.13"\n').pythonVersions).toEqual(['3.13'])
+	})
+
+	it('collapses when the floor is newer than anything we know about', () => {
+		expect(parsePyproject('requires-python = ">=3.14"\n').pythonVersions).toEqual(['3.14'])
+	})
+})
+
+describe('readPyproject', () => {
+	it('falls back to the default range with no manifest', async () => {
+		expect((await readPyproject(newTmpDir())).pythonVersions).toEqual(['3.10', '3.13'])
+	})
+
+	it('reads the floor off disk', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'pyproject.toml'), '[project]\nrequires-python = ">=3.12"\n')
+		expect((await readPyproject(dir)).pythonVersions).toEqual(['3.12', '3.13'])
+	})
+})
+
+describe('pythonGithubJobs', () => {
+	const jobs = pythonGithubJobs({ pythonVersions: ['3.10', '3.13'] })
+
+	it('lints, typechecks and tests', () => {
+		expect(jobs.map((j) => j.id)).toEqual(['lint', 'typecheck', 'test'])
+	})
+
+	it('runs both halves of ruff — the linter and the formatter', () => {
+		const lint = jobs.find((j) => j.id === 'lint')?.steps ?? ''
+		expect(lint).toContain('ruff check --output-format=github')
+		expect(lint).toContain('ruff format --check')
+	})
+
+	// mypy against bare source reports every third-party import as missing.
+	it('installs the project before typechecking it', () => {
+		const typecheck = jobs.find((j) => j.id === 'typecheck')?.steps ?? ''
+		expect(typecheck).toContain('pip install -e .')
+		expect(typecheck).toContain('mypy .')
+	})
+
+	it('matrixes the test job over the supported interpreters', () => {
+		const test = jobs.find((j) => j.id === 'test')
+		expect(test?.extra).toContain("- '3.10'")
+		expect(test?.extra).toContain("- '3.13'")
+		expect(test?.steps).toContain('pytest')
+	})
+})
+
+describe('renderPythonWorkflow', () => {
+	const workflow = renderPythonWorkflow({ pythonVersions: ['3.11', '3.13'] })
+
+	it('wraps the jobs in the shared skeleton', () => {
+		expect(workflow).toContain('check-skip:')
+		expect(workflow).toMatch(/^name: 🚀 CI\/CD Pipeline/)
+	})
+
+	it('satisfies the Python tests check it is generated for', () => {
+		expect(workflow).toMatch(/\bpytest\b/)
+	})
+
+	it('runs on Linux — nothing here needs a mac runner', () => {
+		expect(workflow).not.toContain('macos')
+	})
+})
+
+describe('renderPythonGitLabCI', () => {
+	const ci = renderPythonGitLabCI({ pythonVersions: ['3.10', '3.13'] })
+
+	it('pins the image to the newest supported interpreter', () => {
+		expect(ci).toContain('image: python:3.13')
+	})
+
+	it('derives its stages from the jobs', () => {
+		expect(ci).toContain('stages:\n  - lint\n  - test')
+	})
+
+	it('runs ruff and pytest', () => {
+		expect(ci).toContain('ruff check')
+		expect(ci).toContain('- pytest')
+	})
+})

--- a/tests/languages/python/fixers.test.ts
+++ b/tests/languages/python/fixers.test.ts
@@ -1,0 +1,168 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { BASE_FIXERS } from '../../../src/base/fixers.js'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import { FIXERS } from '../../../src/languages/js/fixers.js'
+import { checkPythonGitignore, runPythonChecks } from '../../../src/languages/python/checks.js'
+import { PYTHON_FIXERS } from '../../../src/languages/python/fixers.js'
+import { ensurePythonGitignore } from '../../../src/languages/python/gitignore.js'
+import { SWIFT_FIXERS } from '../../../src/languages/swift/fixers.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+function fixer(target: string) {
+	const found = PYTHON_FIXERS.find((f) => f.target === target)
+	if (!found) throw new Error(`no python fixer: ${target}`)
+	return found
+}
+
+const ctx = (targetDir: string) => ({
+	targetDir,
+	pkg: null,
+	result: { check: 'x', status: 'missing' as const, detail: '' },
+	lock: null,
+})
+
+/** The marker that makes detectLanguage resolve the Python module. */
+async function pythonRepo(dir: string): Promise<string> {
+	await fs.writeFile(join(dir, 'pyproject.toml'), '[project]\nrequires-python = ">=3.10"\n')
+	return dir
+}
+
+describe('python fixers', () => {
+	// A fixer whose appliesTo doesn't match a real check name is dead code: `fix`
+	// looks fixers up by check, so it would simply never run.
+	it('every fixer resolves a check doctor actually emits for a Python repo', async () => {
+		const dir = await pythonRepo(newTmpDir())
+		const emitted = new Set((await runDoctor(dir)).map((r) => r.check))
+		for (const f of PYTHON_FIXERS) {
+			for (const check of f.appliesTo) {
+				expect(emitted, `${f.target} → ${check}`).toContain(check)
+			}
+		}
+	})
+
+	it('uses target names that do not collide with the other fixer sets', () => {
+		// `fix --list` shows every language's fixers in one list.
+		const taken = new Set([...FIXERS, ...BASE_FIXERS, ...SWIFT_FIXERS].map((f) => f.target))
+		for (const f of PYTHON_FIXERS) expect(taken).not.toContain(f.target)
+	})
+
+	// #303, in the Python shape: doctor reports the base findings, so `fix` has to
+	// have a fixer for them rather than returning `unsupported` for every one.
+	it('base + Python fixers cover every check doctor emits for a Python repo', async () => {
+		const dir = await pythonRepo(newTmpDir())
+		const fixable = new Set([...BASE_FIXERS, ...PYTHON_FIXERS].flatMap((f) => f.appliesTo))
+		const uncovered = (await runDoctor(dir))
+			.map((r) => r.check)
+			.filter((check) => !fixable.has(check))
+		// `language` is informational. `Git identity` is unfixable by design
+		// (#328) — only the operator knows their own address. `README badges` and
+		// `Coverage upload` need a package.json to build from, which a Python repo
+		// hasn't got. `lockfile` has no Python preset to record yet (see the note
+		// atop src/languages/python/fixers.ts). `pyproject.toml` and `Python
+		// tests` are content only the project can write.
+		expect(uncovered).toEqual([
+			'language',
+			'lockfile',
+			'Git identity',
+			'README badges',
+			'Coverage upload',
+			'pyproject.toml',
+			'Python tests',
+		])
+	})
+
+	it('ruff writes a config the Ruff check accepts', async () => {
+		const dir = newTmpDir()
+		const { filesWritten } = await fixer('ruff').run(ctx(dir))
+		expect(filesWritten).toEqual(['ruff.toml'])
+		expect(
+			(await runPythonChecks(dir)).find((r) => r.check === 'Ruff')?.status
+		).toBe('ok')
+	})
+
+	it('mypy writes a config the mypy check accepts', async () => {
+		const dir = newTmpDir()
+		const { filesWritten } = await fixer('mypy').run(ctx(dir))
+		expect(filesWritten).toEqual(['mypy.ini'])
+		expect((await runPythonChecks(dir)).find((r) => r.check === 'mypy')?.status).toBe('ok')
+	})
+
+	it('pytest writes a config the pytest check accepts', async () => {
+		const dir = newTmpDir()
+		const { filesWritten } = await fixer('pytest').run(ctx(dir))
+		expect(filesWritten).toEqual(['pytest.ini'])
+		expect((await runPythonChecks(dir)).find((r) => r.check === 'pytest')?.status).toBe('ok')
+	})
+
+	it('python-ci writes a workflow that satisfies the Python tests check', async () => {
+		const dir = await pythonRepo(newTmpDir())
+		await fs.outputFile(join(dir, 'tests/test_demo.py'), '')
+		const { filesWritten } = await fixer('python-ci').run(ctx(dir))
+		expect(filesWritten).toEqual(['.github/workflows/ci.yml'])
+		const results = await runPythonChecks(dir)
+		expect(results.find((r) => r.check === 'Python tests')?.status).toBe('ok')
+	})
+
+	it('python-gitlab-ci writes a pipeline that runs the suite', async () => {
+		const dir = await pythonRepo(newTmpDir())
+		const { filesWritten } = await fixer('python-gitlab-ci').run(ctx(dir))
+		expect(filesWritten).toEqual(['.gitlab-ci.yml'])
+		expect(await fs.readFile(join(dir, '.gitlab-ci.yml'), 'utf-8')).toContain('pytest')
+	})
+
+	it('python-git-hooks writes hooks the base Git hooks / Pre-push checks accept', async () => {
+		const dir = await pythonRepo(newTmpDir())
+		const { filesWritten } = await fixer('python-git-hooks').run(ctx(dir))
+		expect(filesWritten).toEqual(['.githooks/pre-commit', '.githooks/pre-push'])
+		expect(await fs.readFile(join(dir, '.githooks/pre-push'), 'utf-8')).toContain('pytest')
+		// Executable, or git silently ignores the hook.
+		expect((await fs.stat(join(dir, '.githooks/pre-commit'))).mode & 0o111).toBeTruthy()
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Git hooks')?.status).toBe('ok')
+		expect(results.find((r) => r.check === 'Pre-push hook')?.status).toBe('ok')
+	})
+
+	// No .git in the temp dir: an unguarded `git config` would walk up and
+	// rewrite whatever repo the tmp dir happens to sit inside.
+	it('python-git-hooks does not touch git config outside a repo', async () => {
+		const dir = newTmpDir()
+		await expect(fixer('python-git-hooks').run(ctx(dir))).resolves.toBeTruthy()
+	})
+})
+
+describe('ensurePythonGitignore', () => {
+	it('creates the file when absent and satisfies the check', async () => {
+		const dir = newTmpDir()
+		expect(await ensurePythonGitignore(dir)).toEqual(['.gitignore'])
+		expect((await checkPythonGitignore(dir)).status).toBe('ok')
+	})
+
+	it('appends to an existing .gitignore without dropping its entries', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), 'secrets.env\n')
+		await ensurePythonGitignore(dir)
+		const contents = await fs.readFile(join(dir, '.gitignore'), 'utf-8')
+		expect(contents).toContain('secrets.env')
+		expect((await checkPythonGitignore(dir)).status).toBe('ok')
+	})
+
+	it('does not duplicate an entry the repo already ignores', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '__pycache__/\nnotes.md\n')
+		await ensurePythonGitignore(dir)
+		const contents = await fs.readFile(join(dir, '.gitignore'), 'utf-8')
+		expect(contents.match(/^__pycache__\/$/gm)).toHaveLength(1)
+		expect((await checkPythonGitignore(dir)).status).toBe('ok')
+	})
+
+	it('is a no-op when everything is already covered', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.gitignore'), '__pycache__/\n.venv/\n.pytest_cache/\n')
+		expect(await ensurePythonGitignore(dir)).toEqual([])
+	})
+})

--- a/tests/languages/python/fixers.test.ts
+++ b/tests/languages/python/fixers.test.ts
@@ -58,15 +58,16 @@ describe('python fixers', () => {
 		const uncovered = (await runDoctor(dir))
 			.map((r) => r.check)
 			.filter((check) => !fixable.has(check))
-		// `language` is informational. `Git identity` is unfixable by design
-		// (#328) — only the operator knows their own address. `README badges` and
-		// `Coverage upload` need a package.json to build from, which a Python repo
-		// hasn't got. `lockfile` has no Python preset to record yet (see the note
-		// atop src/languages/python/fixers.ts). `pyproject.toml` and `Python
-		// tests` are content only the project can write.
+		// `language` and `Monorepo` are informational. `Git identity` is unfixable
+		// by design (#328) — only the operator knows their own address. `README
+		// badges` and `Coverage upload` need a package.json to build from, which a
+		// Python repo hasn't got. `lockfile` has no Python preset to record yet
+		// (see the note atop src/languages/python/fixers.ts). `pyproject.toml` and
+		// `Python tests` are content only the project can write.
 		expect(uncovered).toEqual([
 			'language',
 			'lockfile',
+			'Monorepo',
 			'Git identity',
 			'README badges',
 			'Coverage upload',

--- a/tests/languages/registry.test.ts
+++ b/tests/languages/registry.test.ts
@@ -10,11 +10,11 @@ describe('resolveLanguageModule', () => {
 		expect(resolveLanguageModule(id).id).toBe(id)
 	})
 
-	it('JS and Swift carry modules; Python and Perl gate out until theirs land', () => {
+	it('JS, Swift and Python carry modules; Perl gates out until its lands', () => {
 		expect(LANGUAGES.js.supported).toBe(true)
-		// Swift flipped with its module (#286).
+		// Swift flipped with its module (#286), Python with its own (#290).
 		expect(LANGUAGES.swift.supported).toBe(true)
-		expect(LANGUAGES.python.supported).toBe(false)
+		expect(LANGUAGES.python.supported).toBe(true)
 		expect(LANGUAGES.perl.supported).toBe(false)
 	})
 

--- a/tooling/python/mypy.ini
+++ b/tooling/python/mypy.ini
@@ -1,0 +1,21 @@
+; mypy.ini — @rtorcato/repo-tooling Python preset
+;
+; Strict-by-default on your own code, lenient on third-party packages that ship
+; no type information. Without the second half, a single untyped dependency
+; turns every import into an error and the whole run gets ignored.
+
+[mypy]
+python_version = 3.10
+strict = True
+warn_unused_configs = True
+warn_unreachable = True
+show_error_codes = True
+exclude = (^|/)(build|dist|\.venv)/
+
+; Tests exercise deliberately-wrong inputs, so full strictness there costs more
+; than it catches.
+[mypy-tests.*]
+disallow_untyped_defs = False
+
+[mypy-tests.*.*]
+disallow_untyped_defs = False

--- a/tooling/python/pytest.ini
+++ b/tooling/python/pytest.ini
@@ -1,0 +1,15 @@
+; pytest.ini — @rtorcato/repo-tooling Python preset
+;
+; A standalone file rather than [tool.pytest.ini_options] in pyproject.toml:
+; pyproject is the project's own metadata, and merging a table into it needs a
+; TOML round-tripper this CLI does not carry. pytest reads pytest.ini first.
+
+[pytest]
+testpaths = tests
+; Fail on an unregistered marker or an unknown config key — both are typos that
+; otherwise silently skip tests.
+addopts = --strict-markers --strict-config
+; A warning that nobody ever sees is a bug waiting for a major version bump.
+filterwarnings =
+    error
+    ignore::DeprecationWarning:pkg_resources.*

--- a/tooling/python/ruff.toml
+++ b/tooling/python/ruff.toml
@@ -1,0 +1,32 @@
+# ruff.toml — @rtorcato/repo-tooling Python preset
+#
+# Ruff is both the linter and the formatter here. Its formatter is
+# black-compatible, so a separate black config would be a second rewriting
+# formatter fighting the first — see src/languages/python/checks.ts.
+
+line-length = 100
+target-version = "py310"
+
+exclude = [
+  ".venv",
+  "build",
+  "dist",
+]
+
+[lint]
+# E/W pycodestyle, F pyflakes, I isort, UP pyupgrade, B bugbear,
+# SIM simplify, RUF ruff-specific. The set flake8 + isort + pyupgrade would
+# have given you, minus the four extra dependencies.
+select = ["E", "W", "F", "I", "UP", "B", "SIM", "RUF"]
+
+# E501 is the formatter's job — leaving it on makes every long string a lint
+# error the formatter is not allowed to fix.
+ignore = ["E501"]
+
+[lint.per-file-ignores]
+# Test files legitimately shadow names and use bare asserts.
+"tests/**" = ["S101"]
+
+[format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
Closes #290.

Python language module on the Swift template (#286): `doctor`/`fix` dispatch to it for any repo with a `pyproject.toml` or `setup.py`, and `python` flips to `supported: true` in the registry.

## What lands

| Check | Absent | Fix target |
|---|---|---|
| `pyproject.toml` | `missing` | — (project metadata) |
| Ruff | `missing` | `ruff` |
| mypy | `missing` | `mypy` |
| pytest | `missing` | `pytest` |
| Python `.gitignore` | `missing` | `python-gitignore` |
| Python tests | `missing` | — (write tests, or `python-ci`) |
| Git hooks / Pre-push | `optional-missing` | `python-git-hooks` |

Plus `python-ci` (ruff / mypy / pytest, matrixed over the interpreters `requires-python` declares) and `python-gitlab-ci`. CodeQL `language: python` and Dependabot `package-ecosystem: pip` already came from the registry — the shared `fix codeql` / `fix dependabot` targets needed no change.

Three presets under `tooling/python/`: `ruff.toml`, `mypy.ini`, `pytest.ini`, all reachable via `copy` too.

## Two deliberate deviations from the issue

**No black.** The issue lists "ruff + black". Ruff's formatter is black-compatible and already runs in the pre-commit hook and the lint job; a second *rewriting* formatter fights the first. That's the same call the Swift module already makes about SwiftFormat, so this follows existing precedent rather than inventing one. flake8 / isort / pyupgrade are likewise absent — the shipped `select` list covers all three. Documented in the module header and the docs page. Say the word and I'll add black as an optional slot the way `swift-format` is.

**No `python-lockfile` fixer.** Swift's writes the config `setup --preset swift-library` would have produced, and there's no `python-library` preset (the Swift one was its own issue, #288). Fabricating a `ProjectConfig` here would put invented JS tool choices in a Python repo's lockfile — worse than doctor reporting the lockfile absent, which is true. So `lockfile` shows as uncovered for Python; the test asserts that explicitly.

## Two things worth a look

**The tool-config check isn't a plain `FileCheck`.** Every Python repo has a `pyproject.toml`, and `checkFile` reads "candidate exists but doesn't match" as drift — so a repo that simply hasn't configured ruff reported `pyproject.toml found but is not a valid Ruff configuration`. Caught it in the end-to-end smoke run, not the unit tests. Now dedicated files (`ruff.toml`, `mypy.ini`, `pytest.ini`) can produce drift; shared files (`pyproject.toml`, `setup.cfg`, `tox.ini`) can only upgrade the result to `ok`. Dedicated wins on precedence, matching what the tools actually do at runtime.

**Shared hooks installer.** Swift and Python want the same write-chmod-`git config core.hooksPath` dance, so it moved to `src/base/git-hooks.ts` and Swift now calls it. Net -48 lines in the Swift module, no behaviour change.

## Verification

`check` + `typecheck` + 697 tests + `build-cli` all green (pre-push ran the full gate). Also smoke-tested the built CLI end to end against a scratch Python repo: `doctor` → `fix --yes` → `doctor` leaves only `lockfile` and `README badges`, both documented as uncovered.

## Follow-up filed separately

`fix --json` output is corrupted whenever a fixer prints an advisory to stdout — `console.log` inside `run()` isn't gated on `silent`. Pre-existing across ~21 sites in the JS and Swift modules; the Python hooks fixer follows the same pattern rather than diverging in one place. Filed on its own.
