### PR TITLE
fix(cli): send fixer advisories to stderr so --json stays parseable

### DIFF
--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -54,6 +54,12 @@ export interface Fixer {
 	 */
 	riskLevel?: FixRiskLevel
 	canFixDrift?: boolean
+	/**
+	 * Advisories printed from here go to `console.error`, never `console.log`:
+	 * stdout is the `--json` payload's channel and a stray line lands in the
+	 * middle of it, breaking every parser downstream (#357). They're diagnostics,
+	 * not results, so stderr is the right stream regardless of the flag.
+	 */
 	run(ctx: FixerContext): Promise<{ filesWritten: string[] }>
 }
 

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -249,7 +249,7 @@ export const FIXERS: Fixer[] = [
 		async run({ targetDir, pkg }) {
 			const pkgPath = path.join(targetDir, 'package.json')
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const includeTreeshake = await fs.pathExists(
@@ -257,7 +257,7 @@ export const FIXERS: Fixer[] = [
 			)
 			const verify = composeVerifyScriptFromPkg(pkg, { includeTreeshake })
 			if (!verify) {
-				console.log(
+				console.error(
 					chalk.gray(
 						'   not enough tools enabled to compose a verify chain — skipping (need 2+ of typecheck/lint/tests)'
 					)
@@ -287,7 +287,7 @@ export const FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			if (pkg?.private === true) {
-				console.log(chalk.gray('   skipping — package is private'))
+				console.error(chalk.gray('   skipping — package is private'))
 				return { filesWritten: [] }
 			}
 			const filesWritten = await generateSemanticReleaseConfig(targetDir)
@@ -347,7 +347,7 @@ export const FIXERS: Fixer[] = [
 				overwrite: result.check === 'GitHub Actions',
 			})
 			if (!filesWritten.includes(CI_WORKFLOW)) {
-				console.log(
+				console.error(
 					chalk.yellow(
 						`   ${CI_WORKFLOW} differs from the preset — left as-is; run \`fix github-actions --diff\` to see the delta`
 					)
@@ -562,17 +562,17 @@ export const FIXERS: Fixer[] = [
 		canFixDrift: false,
 		async run({ targetDir, pkg }) {
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const workspaceName = (pkg.name as string | undefined) ?? null
 			if (!workspaceName) {
-				console.log(chalk.yellow('   package.json has no `name` — skipping'))
+				console.error(chalk.yellow('   package.json has no `name` — skipping'))
 				return { filesWritten: [] }
 			}
 			const { allCandidates, defaultAllowed } = inferSubpathsFromExports(pkg)
 			if (allCandidates.length < 2 || !defaultAllowed) {
-				console.log(
+				console.error(
 					chalk.yellow(
 						'   package.json does not expose ≥2 subpath exports — tree-shake check needs multiple subpaths to be meaningful. Skipping.'
 					)
@@ -586,7 +586,7 @@ export const FIXERS: Fixer[] = [
 				allowedSubpath,
 				forbiddenSubpaths,
 			})
-			console.log(
+			console.error(
 				chalk.dim(
 					`   Wired '${allowedSubpath}' as allowed; forbidden = [${forbiddenSubpaths.join(', ')}]. Edit apps/treeshake-check/check.mjs to tune.`
 				)
@@ -670,7 +670,7 @@ export const FIXERS: Fixer[] = [
 		async run({ targetDir, pkg }) {
 			const pkgPath = path.join(targetDir, 'package.json')
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const updated = { ...pkg }
@@ -701,7 +701,7 @@ export const FIXERS: Fixer[] = [
 		async run({ targetDir, pkg }) {
 			const pkgPath = path.join(targetDir, 'package.json')
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const updated = { ...pkg }
@@ -731,7 +731,7 @@ export const FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const p = pkg as Record<string, unknown>
@@ -744,7 +744,7 @@ export const FIXERS: Fixer[] = [
 				isPrivate: p.private === true,
 			})
 			if (!block) {
-				console.log(
+				console.error(
 					chalk.yellow('   package.json has no name/repository to build badges from — skipping')
 				)
 				return { filesWritten: [] }
@@ -767,7 +767,7 @@ export const FIXERS: Fixer[] = [
 		async run({ targetDir, pkg }) {
 			const pkgPath = path.join(targetDir, 'package.json')
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const updated = { ...pkg }
@@ -777,7 +777,7 @@ export const FIXERS: Fixer[] = [
 			devDeps['@rtorcato/repo-tooling'] = 'latest'
 			updated.devDependencies = devDeps
 			await fs.writeJson(pkgPath, updated, { spaces: 2 })
-			console.log(chalk.dim('   reminder: run `pnpm install` to install the new dep'))
+			console.error(chalk.dim('   reminder: run `pnpm install` to install the new dep'))
 			return { filesWritten: ['package.json'] }
 		},
 	},
@@ -790,7 +790,7 @@ export const FIXERS: Fixer[] = [
 		canFixDrift: false,
 		async run({ targetDir, pkg }) {
 			if (!pkg) {
-				console.log(chalk.yellow('   no package.json found — skipping'))
+				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
 			const config = inferProjectConfig(pkg)

--- a/src/languages/swift/fixers.ts
+++ b/src/languages/swift/fixers.ts
@@ -102,7 +102,7 @@ export const SWIFT_FIXERS: Fixer[] = [
 			if (await fs.pathExists(path.join(targetDir, file))) return { filesWritten: [] }
 
 			await fs.outputFile(path.join(targetDir, file), doccLandingPage(target))
-			console.log(
+			console.error(
 				chalk.yellow(
 					'   add swift-docc-plugin to Package.swift to build it: .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")'
 				)
@@ -131,7 +131,7 @@ export const SWIFT_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			const { filesWritten, hooksPathSet } = await installSwiftGitHooks(targetDir)
-			console.log(
+			console.error(
 				hooksPathSet
 					? chalk.dim(`   git config core.hooksPath ${SWIFT_HOOKS_DIR}`)
 					: chalk.yellow(

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -747,6 +747,27 @@ describe('fix --json', () => {
 		}
 	})
 
+	// #357: a fixer's own advisory used to go to stdout, landing in the middle of
+	// the payload and breaking every parser downstream (the #315 action included).
+	// Asserting on the *whole* stream, not `.at(-1)`, is the point — taking the
+	// last call is exactly what hid this.
+	it('keeps stdout parseable when a fixer prints an advisory', async () => {
+		const dir = newTmpDir()
+		// No scripts at all, so `verify` has nothing to chain and bails with a note.
+		await seedPackageJson(dir)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			await fixCommand('verify', { directory: dir, json: true })
+			expect(errSpy.mock.calls.join('\n')).toContain('verify chain')
+			expect(logSpy.mock.calls).toHaveLength(1)
+			expect(() => JSON.parse(logSpy.mock.calls.join(''))).not.toThrow()
+		} finally {
+			logSpy.mockRestore()
+			errSpy.mockRestore()
+		}
+	})
+
 	it('emits a JSON error payload on unknown target', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)


### PR DESCRIPTION
Closes #357.

Takes the "likely fix" the issue proposed rather than the `silent`-on-`FixerContext` alternative, because the advisories are diagnostics rather than results — **stderr is the right stream whether or not `--json` is set**, so this isn't a flag workaround that leaves the wrong default in place. On a terminal both streams still interleave, so interactive output is unchanged.

## Scope

17 sites, not the ~21 the issue estimated: `src/languages/python/fixers.ts` doesn't exist on `main` yet.

| file | sites |
|---|---|
| `src/languages/js/fixers.ts` | 15 |
| `src/languages/swift/fixers.ts` | 2 |

**#356 will need the same one-word change** to the Python module's `python-git-hooks` advisory after it merges — it's the reproducer in the issue, and it isn't on this branch to fix.

Checked before changing them: every one of the 17 is a human-facing note (`no package.json found — skipping`, `reminder: run pnpm install`, the `core.hooksPath` note, …), and no test asserts on any of those strings via stdout.

## Not reintroducible

The rule is now recorded on `Fixer.run` in `src/base/fixers.ts`, which is the one contract every fixer in every language module implements — so it's in front of whoever writes the next one.

## The test

```ts
expect(logSpy.mock.calls).toHaveLength(1)
expect(() => JSON.parse(logSpy.mock.calls.join(''))).not.toThrow()
```

Asserting on the **whole** stdout stream is the point. The existing `--json` tests use `logSpy.mock.calls.at(-1)`, which reads the last write and therefore passes happily with an advisory sitting in front of the payload — that's precisely what let this survive.

Verified the test actually catches the bug: reverting a single site back to `console.log` fails it with `expected '' to contain 'verify chain'`, then passes again once restored.

## Verification

`pnpm run verify` green — 650 tests, 48 files.
