### PR TITLE
fix(python): send the git-hooks advisory to stderr, and guard the rule

### DIFF
--- a/src/languages/python/fixers.ts
+++ b/src/languages/python/fixers.ts
@@ -72,7 +72,7 @@ export const PYTHON_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			const { filesWritten, hooksPathSet } = await installPythonGitHooks(targetDir)
-			console.log(
+			console.error(
 				hooksPathSet
 					? chalk.dim(`   git config core.hooksPath ${PYTHON_HOOKS_DIR}`)
 					: chalk.yellow(

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -766,6 +767,27 @@ describe('fix --json', () => {
 			logSpy.mockRestore()
 			errSpy.mockRestore()
 		}
+	})
+
+	// The runtime test above only exercises the advisories a JS fixer happens to
+	// hit. This one is a source guard, because #357 came back within a minute of
+	// being fixed: the Python module (#356) merged 16s before the fix and landed
+	// its own `console.log`, which no behavioural test covered. A new language
+	// module is exactly when this regresses, so check every module's source.
+	it('no fixer module writes to stdout', async () => {
+		const languagesDir = fileURLToPath(new URL('../../../src/languages', import.meta.url))
+		const modules = await fs.readdir(languagesDir)
+		const sources = [
+			fileURLToPath(new URL('../../../src/base/fixers.ts', import.meta.url)),
+			...modules.map((m) => join(languagesDir, m, 'fixers.ts')),
+		]
+		const offenders: string[] = []
+		for (const file of sources) {
+			if (!(await fs.pathExists(file))) continue
+			if (/console\.log\s*\(/.test(await fs.readFile(file, 'utf-8'))) offenders.push(file)
+		}
+		// stdout carries the --json payload; advisories belong on stderr (#357).
+		expect(offenders).toEqual([])
 	})
 
 	it('emits a JSON error payload on unknown target', async () => {


### PR DESCRIPTION
Follow-up to #358, which closed #357. The bug was back on `main` within a minute of being closed.

## What happened

#356 (Python module) merged at 14:50:56 and #358 (the fix) at 14:51:12 — **16 seconds apart**. #356 added `src/languages/python/fixers.ts` with its own `console.log` in a `run()` body, which #358 couldn't have touched because the file didn't exist on its base. I flagged this in #358's description as needing a follow-up; this is it.

Also worth noting: #356's CI run on `main` was **cancelled** by #358's merge (`concurrency: cancel-in-progress` keyed on the ref), so only #358's run reached `release`.

## The change

One word in `src/languages/python/fixers.ts`, matching what JS and Swift already do.

## Why a source guard, not just the fix

#358 recorded the rule as a docstring on `Fixer.run` — the contract every language module implements. That's the right place for a human to read it, and it still didn't stop the regression, because **nothing failed** when a module ignored it.

So this adds a source guard:

```ts
it('no fixer module writes to stdout', async () => { … })
```

It scans `src/base/fixers.ts` and every `src/languages/*/fixers.ts` for `console.log(`. Deliberately a source check rather than a behavioural one: the runtime test from #358 only exercises the advisories a JS fixer happens to hit, and a *new language module* is precisely the moment this regresses — as just demonstrated. It picks up new modules automatically via `readdir`, so #289's Perl module (PR #359, open) is covered the moment it lands.

Verified it bites: reverting the Python site fails the test naming the offending path.

## Verification

`pnpm run verify` green — 704 tests, 51 files.

Re-fixes #357.
