### PR TITLE
fix(cli): finish routing fixer advisories off stdout

### DIFF
--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -479,17 +479,22 @@ export function buildGhApplyCommands(state: GhApplyState): GhCommand[] {
  * on skip (no gh/auth/remote, or already compliant), logging the reason. Mirrors
  * the "no package.json found — skipping" fixer pattern. Read-only unless a delta
  * exists, so re-runs (walk-all hits it up to 3×) are safe.
+ *
+ * Reached from the `github-settings` fixer, so its advisories go to
+ * `console.error` for the same reason the fixers' do (#357): stdout carries the
+ * `--json` payload. #358 fixed the fixer files but not this one — it isn't a
+ * fixer file, it's just called by one.
  */
 export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<string[]> {
 	if (!(await fs.pathExists(path.join(dir, '.git')))) {
-		console.log(chalk.gray('   skipped — not a git repository'))
+		console.error(chalk.gray('   skipped — not a git repository'))
 		return []
 	}
 	// Bind gh's cwd to the target dir so its repo resolution honors `-d` (#218).
 	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin, dir))
 	const probe = await probeRepo(gh)
 	if ('skip' in probe) {
-		console.log(chalk.gray(`   skipped — ${probe.skip}`))
+		console.error(chalk.gray(`   skipped — ${probe.skip}`))
 		return []
 	}
 	const { info } = probe
@@ -511,7 +516,9 @@ export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<s
 		const r = await gh(cmd.args, cmd.stdin)
 		if (r.ok) applied.push(cmd.label)
 		else
-			console.log(chalk.yellow(`   could not apply ${cmd.label}: ${r.stderr.trim() || 'gh error'}`))
+			console.error(
+				chalk.yellow(`   could not apply ${cmd.label}: ${r.stderr.trim() || 'gh error'}`)
+			)
 	}
 
 	// Code-scanning ruleset (#269): POST only when CodeQL is on and no active gate
@@ -524,9 +531,10 @@ export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<s
 			CODE_SCANNING_RULESET_BODY
 		)
 		if (r.ok) applied.push(label)
-		else console.log(chalk.yellow(`   could not apply ${label}: ${r.stderr.trim() || 'gh error'}`))
+		else
+			console.error(chalk.yellow(`   could not apply ${label}: ${r.stderr.trim() || 'gh error'}`))
 	}
 
-	if (applied.length === 0) console.log(chalk.gray('   already configured — nothing to apply'))
+	if (applied.length === 0) console.error(chalk.gray('   already configured — nothing to apply'))
 	return applied
 }

--- a/src/languages/python/fixers.ts
+++ b/src/languages/python/fixers.ts
@@ -72,7 +72,7 @@ export const PYTHON_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			const { filesWritten, hooksPathSet } = await installPythonGitHooks(targetDir)
-			console.log(
+			console.error(
 				hooksPathSet
 					? chalk.dim(`   git config core.hooksPath ${PYTHON_HOOKS_DIR}`)
 					: chalk.yellow(

--- a/tests/base/stdout-discipline.test.ts
+++ b/tests/base/stdout-discipline.test.ts
@@ -1,0 +1,51 @@
+import { globSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * stdout belongs to the commands, not the modules underneath them (#357).
+ *
+ * `fix --json` / `doctor --json` promise a parseable payload on stdout, and a
+ * single stray `console.log` from anything they call lands in the middle of it.
+ * #358 fixed the sites it could see by grepping the fixer files — which missed
+ * `src/base/github-settings.ts` (reachable from the `github-settings` fixer but
+ * not a fixer file) and `src/languages/python/fixers.ts` (merged 16 seconds
+ * after it). Both are the same class of miss: an enumeration that has to be
+ * kept in sync by hand.
+ *
+ * So the invariant is stated over the *trees* rather than a file list — a new
+ * language module is covered the day it lands, with no list to update.
+ * Advisories still get printed; they just go to `console.error`, which is where
+ * diagnostics belong whether or not `--json` is set.
+ *
+ * ponytail: a text scan, not a run of every fixer. Reaching each advisory branch
+ * for real would mean constructing a dozen failure states (no package.json, no
+ * git remote, gh unauthenticated); grepping is what a reader would do, and it
+ * generalizes to code nobody thought to test. tests/cli/commands/fix.test.ts
+ * covers the behaviour end to end for one path.
+ */
+
+const repoRoot = path.resolve(import.meta.dirname, '../..')
+
+// src/cli/commands and src/cli/index.ts are the user-facing layer — printing is
+// their job, and they gate it on `silent` themselves. Everything below them is
+// library code with no business writing to stdout.
+const TREES = ['src/base/**/*.ts', 'src/languages/**/*.ts']
+
+const sourceFiles = TREES.flatMap((pattern) => globSync(pattern, { cwd: repoRoot }))
+
+describe('nothing under src/base or src/languages writes to stdout', () => {
+	it('finds files to scan (the scan itself still works)', () => {
+		expect(sourceFiles.length).toBeGreaterThan(5)
+	})
+
+	it('uses console.error for advisories, never console.log', () => {
+		const offenders = sourceFiles.filter((file) =>
+			readFileSync(path.join(repoRoot, file), 'utf8').includes('console.log(')
+		)
+		expect(
+			offenders,
+			'stdout carries the --json payload — send diagnostics to console.error (#357)'
+		).toEqual([])
+	})
+})

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -768,6 +768,27 @@ describe('fix --json', () => {
 		}
 	})
 
+	// The same contract on the Python path. #358 landed 16 seconds after the
+	// Python module (#290) and so never saw its fixer, which shipped the bug the
+	// rest of the CLI had just been cured of.
+	it('keeps stdout parseable when a Python fixer prints an advisory', async () => {
+		const dir = newTmpDir()
+		// pyproject.toml is the marker that dispatches to the Python module, and
+		// the hooks fixer always notes that core.hooksPath is per-clone config.
+		await fs.writeFile(join(dir, 'pyproject.toml'), '[project]\nrequires-python = ">=3.10"\n')
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			await fixCommand('python-git-hooks', { directory: dir, json: true })
+			expect(errSpy.mock.calls.join('\n')).toContain('core.hooksPath')
+			expect(logSpy.mock.calls).toHaveLength(1)
+			expect(() => JSON.parse(logSpy.mock.calls.join(''))).not.toThrow()
+		} finally {
+			logSpy.mockRestore()
+			errSpy.mockRestore()
+		}
+	})
+
 	it('emits a JSON error payload on unknown target', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)


### PR DESCRIPTION
Closes #357 (reopened — #358's fix was incomplete).

#358 routed the fixer advisories to stderr, but two reachable sites kept writing to stdout, so `fix --json` is still unparseable on those paths.

## What was missed, and why

**`src/languages/python/fixers.ts`** — #358 was authored while the Python module (#290) was still in review, and said so explicitly: *"17 sites, not the ~21 the issue estimated: `src/languages/python/fixers.ts` doesn't exist on `main` yet."* Accurate when written. #290 then merged at 14:50:56 and #358 at 14:51:12 — sixteen seconds later — so the new module landed carrying the exact bug the rest of the CLI had just lost.

**`src/base/github-settings.ts`** (5 sites) — `applyGithubSettings` is called from the `github-settings` base fixer's `run()`, so its advisories land in the payload like any fixer's. Out of #358's scope because that grep covered the fixer *files*, and this isn't one; it's just called by one.

Both are the same class of miss — an enumeration kept in sync by hand.

## The guard

So the invariant is stated over the **trees** rather than a file list:

```
nothing under src/base or src/languages writes to stdout
```

A new language module is covered the day it lands, with nothing to remember to update. `src/cli/commands` is deliberately outside it — printing is its job, and it already gates on `silent`.

Advisories still print. They go to stderr, which is where diagnostics belong whether or not `--json` is set — same reasoning #358 gave for preferring this over threading `silent` through `FixerContext`.

## Verification

Mutation-checked the scan rather than trusting it: reverting one site to `console.log` fails it naming the offending file, and it passes again once restored. Two `*/`-inside-a-block-comment typos of mine also got caught along the way — the first made the scan file itself parse as zero tests, which is a good reminder that a green run and a *ran* test aren't the same thing.

Also adds the behavioural test on the Python path, mirroring #358's: `fix python-git-hooks --json` must emit exactly one stdout write that parses.

`check` + `typecheck` + 706 tests + `build-cli` green (pre-push ran the full gate).
