### PR TITLE
fix(biome): honour .gitignore and track the installed schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ npx @rtorcato/repo-tooling copy oxlint       # → .oxlintrc.json
 npx @rtorcato/repo-tooling copy claude-skill # → .claude/skills/repo-tooling.md
 ```
 
+The Biome preset honours your `.gitignore`, so build output stays unlinted. One
+known gap: Biome cannot parse Tailwind CSS v4 stylesheets (`@theme`, `@source`,
+`@custom-variant`, `@apply`) and reports a parse error on them. If you use
+Tailwind v4, exclude your stylesheet in `biome.json`:
+
+```jsonc
+{
+  "extends": ["@rtorcato/repo-tooling/biome"],
+  // `includes` replaces the preset's list rather than extending it — restate
+  // the exclusions you still want alongside the CSS one.
+  "files": { "includes": ["**", "!**/node_modules", "!**/dist", "!**/*.css"] }
+}
+```
+
 **Already have a project?** Don't rerun `setup` — use `doctor` + `fix`:
 
 ```bash

--- a/apps/docs/docs/guides/docs-site.md
+++ b/apps/docs/docs/guides/docs-site.md
@@ -78,8 +78,9 @@ Add each module to the sidebar's API Reference category:
 { type: 'doc', id: 'api/kv/index', label: 'kv' }
 ```
 
-`docs/api/` is generated — gitignore it, and have biome ignore it (enable
-`vcs.useIgnoreFile` in your root `biome.json` so it isn't linted).
+`docs/api/` is generated — gitignore it, and biome skips it too: the preset
+enables `vcs.enabled` alongside `vcs.useIgnoreFile`, so your `.gitignore` is
+the one list you have to keep.
 
 ## 2. Deploy workflow
 

--- a/src/cli/generators/linting.ts
+++ b/src/cli/generators/linting.ts
@@ -44,6 +44,50 @@ export const BIOME_CONFIG = 'biome.json'
 export const BIOME_LEGACY_CONFIG = 'biome.jsonc'
 
 /**
+ * Used when nothing in the target repo says which Biome will read the config —
+ * a bare directory mid-`setup`, before `pnpm install` has run. Matches the
+ * `$schema` the shipped preset carries.
+ */
+const BIOME_SCHEMA_FALLBACK = '2.5.0'
+
+async function readJsonOrNull(filepath: string): Promise<Record<string, unknown> | null> {
+	try {
+		return (await fs.readJson(filepath)) as Record<string, unknown>
+	} catch {
+		return null
+	}
+}
+
+/**
+ * The Biome version the scaffolded `$schema` URL should name (#363).
+ *
+ * A hardcoded version drifts the moment the consumer's Biome moves, and Biome
+ * reports the mismatch on *every* invocation ("The configuration schema version
+ * does not match the CLI version 2.5.7") — noise on a file the consumer never
+ * wrote. The installed package wins because it is literally the binary that
+ * will parse the file and emit that warning; the declared range is the next
+ * best statement of intent when node_modules isn't populated yet.
+ */
+export async function resolveBiomeSchemaVersion(targetDir: string): Promise<string> {
+	const installed = await readJsonOrNull(
+		path.join(targetDir, 'node_modules', '@biomejs', 'biome', 'package.json')
+	)
+	const pkg = await readJsonOrNull(path.join(targetDir, 'package.json'))
+	const deps = {
+		...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
+		...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
+	}
+
+	// Both an exact version ("2.5.7") and a range ("^2.5.0") carry the x.y.z we
+	// need, so one pattern covers every source.
+	for (const candidate of [installed?.version, deps['@biomejs/biome']]) {
+		const match = typeof candidate === 'string' ? /(\d+\.\d+\.\d+)/.exec(candidate) : null
+		if (match?.[1]) return match[1]
+	}
+	return BIOME_SCHEMA_FALLBACK
+}
+
+/**
  * The thin pointer config — the same shape this repo dogfoods. `fix biome` used
  * to copy the whole preset inline instead, which meant the scaffolded file
  * carried no `@rtorcato/repo-tooling/biome` reference for doctor's Biome check
@@ -54,8 +98,9 @@ export async function generateBiomeConfig(targetDir: string): Promise<string> {
 	// file globs via `files.includes`; emitting the old 1.x `include`/`ignore`
 	// keys here forced consumers to run `biome migrate` before `biome check`
 	// would run at all.
+	const version = await resolveBiomeSchemaVersion(targetDir)
 	const biomeConfig = {
-		$schema: 'https://biomejs.dev/schemas/2.5.0/schema.json',
+		$schema: `https://biomejs.dev/schemas/${version}/schema.json`,
 		extends: ['@rtorcato/repo-tooling/biome'],
 	}
 

--- a/tests/cli/generators/linting.test.ts
+++ b/tests/cli/generators/linting.test.ts
@@ -7,6 +7,7 @@ import {
 	BIOME_CONFIG,
 	generateBiomeConfig,
 	generateLintingConfigs,
+	resolveBiomeSchemaVersion,
 } from '../../../src/cli/generators/linting.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -115,6 +116,45 @@ describe('generateLintingConfigs', () => {
 		expect(computeFileList(baseConfig({ linting: { tool: 'biome' } }))).toContain(BIOME_CONFIG)
 		const contents = await fs.readFile(join(dir, BIOME_CONFIG), 'utf-8')
 		expect(contents).toMatch(/@rtorcato\/repo-tooling\/biome/)
+	})
+
+	// #363: `useIgnoreFile` does nothing while `vcs.enabled` is false, so the
+	// preset linted build output — 1477 errors from .next/ on a Next.js app.
+	it('ships a preset whose .gitignore setting is actually switched on', async () => {
+		const preset = await fs.readJson(
+			join(import.meta.dirname, '../../../tooling/biome/biome.json')
+		)
+		expect(preset.vcs).toMatchObject({ enabled: true, clientKind: 'git', useIgnoreFile: true })
+	})
+
+	// #363: a hardcoded 2.5.0 made Biome print a schema-version warning on every
+	// single run once the consumer's CLI moved past it.
+	it('derives $schema from the installed Biome, not a hardcoded version', async () => {
+		const dir = newTmpDir()
+		const biomePkg = join(dir, 'node_modules', '@biomejs', 'biome')
+		await fs.ensureDir(biomePkg)
+		await fs.writeJson(join(biomePkg, 'package.json'), { name: '@biomejs/biome', version: '2.9.3' })
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			devDependencies: { '@biomejs/biome': '^2.5.0' },
+		})
+
+		await generateBiomeConfig(dir)
+
+		const biome = await fs.readJson(join(dir, BIOME_CONFIG))
+		expect(biome.$schema).toBe('https://biomejs.dev/schemas/2.9.3/schema.json')
+	})
+
+	it('falls back to the declared range, then to the preset version', async () => {
+		const withRange = newTmpDir()
+		await fs.writeJson(join(withRange, 'package.json'), {
+			name: 'demo',
+			devDependencies: { '@biomejs/biome': '^2.7.1' },
+		})
+		expect(await resolveBiomeSchemaVersion(withRange)).toBe('2.7.1')
+
+		// Bare directory mid-setup — nothing installed, nothing declared.
+		expect(await resolveBiomeSchemaVersion(newTmpDir())).toBe('2.5.0')
 	})
 
 	it('skips .oxlintrc.json when oxlint flag is unset', async () => {

--- a/tooling/biome/biome.json
+++ b/tooling/biome/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
 		"useIgnoreFile": true
 	},


### PR DESCRIPTION
Closes #363.

> **Stacked on #366** (issue #365). Base is `fix/biome-config-filename-365`, not `main` — this builds on the single-write-path change. Rebase onto `main` after #366 merges.

## 1. `.gitignore` was never read

The preset shipped `vcs.enabled: false` with `useIgnoreFile: true`. The second key does nothing without the first, so Biome linted build output. On a Next.js app with a `.next/` directory: 1477 errors, 1577 warnings, nearly all generated files. Same repo with the flag on: 32 errors.

That failure mode is worse than a plain misconfiguration — it reads as "this codebase is catastrophically broken", which invites either mass auto-fixing generated files or dropping Biome.

## 2. `$schema` drifted from the installed CLI

The scaffolded config hardcoded `2.5.0`, so a consumer on 2.5.7 got a `deserialize` warning on **every** `biome check`, on a file they never wrote. `$schema` is now derived from the installed `@biomejs/biome`, falling back to the declared range, then to the preset version for a bare directory mid-`setup`.

The shipped preset keeps its `2.5.0` `$schema` deliberately: it is the floor advertised in `peerDependencies`, and raising it would make doctor's own `Config schema versions` check fire on this repo.

## Not fixed: Tailwind v4 CSS

Biome still can't parse `@theme` / `@source` / `@custom-variant` / `@apply`. Excluding `*.css` in the preset would cost every non-Tailwind consumer their CSS formatting, and a child `files.includes` **replaces** the parent's array rather than extending it — so a naive override would silently drop the `node_modules`/`dist` exclusions too. The README now documents the opt-out with that caveat spelled out. Say the word if you'd rather ship the exclusion by default.

## Verification

- `tests/cli/generators/linting.test.ts` — the preset's `vcs` block is asserted switched on; `$schema` resolution is covered for installed / declared / neither.
- Full suite: 780 passed. `pnpm run check` and typecheck clean.