### PR TITLE
fix(husky): give commit-msg to the target that installs commitlint

### DIFF
--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -83,16 +83,22 @@ export const BASE_FIXERS: Fixer[] = [
 	},
 	{
 		target: 'commitlint',
-		description: 'Scaffold commitlint.config.mjs exporting the preset',
+		description:
+			'Scaffold commitlint.config.mjs + the husky commit-msg hook, and install @commitlint/cli',
 		// Conventional Commits is a repo convention, not a JS one (#309) — the
 		// config is identical in any repo. Running commitlint still needs node on
 		// PATH, which is why the Swift hooks don't wire a commit-msg hook.
 		appliesTo: ['Commitlint'],
-		outputs: ['commitlint.config.mjs'],
+		outputs: ['commitlint.config.mjs', '.husky/commit-msg', 'package.json (devDependencies)'],
+		// safe-merge: only missing devDependencies are added, existing ranges stand.
+		riskLevel: 'safe-merge',
 		canFixDrift: true,
 		async run({ targetDir }) {
-			await generateCommitlintConfig(targetDir)
-			return { filesWritten: ['commitlint.config.mjs'] }
+			const filesWritten = await generateCommitlintConfig(targetDir)
+			if (filesWritten.includes('package.json')) {
+				console.error(chalk.dim('   reminder: run `pnpm install` to install commitlint'))
+			}
+			return { filesWritten }
 		},
 	},
 	{

--- a/src/cli/generators/git.ts
+++ b/src/cli/generators/git.ts
@@ -50,14 +50,10 @@ export async function generateHuskyConfig(config: ProjectConfig, targetDir: stri
 		}
 	}
 
-	// Commit-msg hook (if commitlint is enabled). husky v10 format — no v9
-	// bootstrap. $1 is still the commit-message file path git passes through.
-	if (config.commitLint) {
-		const commitMsgPath = path.join(huskyDir, 'commit-msg')
-		const commitMsgContent = 'npx --no -- commitlint --edit $1\n'
-		await fs.writeFile(commitMsgPath, commitMsgContent)
-		await fs.chmod(commitMsgPath, 0o755)
-	}
+	// The commit-msg hook is NOT written here (#362). It runs commitlint via
+	// `npx --no`, which refuses to install a missing binary, so emitting it
+	// without also installing @commitlint/cli rejected every commit in the repo.
+	// It belongs to generateCommitlintConfig, which owns both halves.
 
 	// lint-staged configuration in package.json
 	const packageJsonPath = path.join(targetDir, 'package.json')
@@ -85,13 +81,80 @@ export async function generatePrePushHook(targetDir: string) {
 	await fs.chmod(prePushPath, 0o755)
 }
 
-export async function generateCommitlintConfig(targetDir: string) {
-	const commitlintConfigPath = path.join(targetDir, 'commitlint.config.mjs')
+/** Package versions the commit-msg hook needs on disk to run at all. */
+export const COMMITLINT_DEPS: Record<string, string> = {
+	'@commitlint/cli': '^20.0.0',
+	'@commitlint/config-conventional': '^20.0.0',
+}
 
-	const commitlintConfig = `export { default } from '@rtorcato/repo-tooling/commitlint/config'
-`
+/** True when husky owns this repo's hooks — the only case where .husky/commit-msg runs. */
+async function usesHusky(targetDir: string): Promise<boolean> {
+	if (await fs.pathExists(path.join(targetDir, '.husky'))) return true
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (!(await fs.pathExists(pkgPath))) return false
+	const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+	const deps = {
+		...((pkg.dependencies as Record<string, string> | undefined) ?? {}),
+		...((pkg.devDependencies as Record<string, string> | undefined) ?? {}),
+	}
+	return 'husky' in deps
+}
 
-	await fs.writeFile(commitlintConfigPath, commitlintConfig)
+/**
+ * commitlint's config *and* the hook that runs it, as one unit (#362).
+ *
+ * These used to be split across two targets: `fix husky` wrote
+ * `.husky/commit-msg`, `fix commitlint` wrote the config, and neither installed
+ * `@commitlint/cli`. Since the hook body is `npx --no -- commitlint --edit $1`
+ * and `--no` refuses to install anything, a repo that ran only `fix husky` had
+ * every `git commit` rejected — discovered at the worst possible moment, and
+ * looking like a broken repo rather than a missing opt-in.
+ *
+ * The hook is only written when husky owns the repo's hooks. The Swift path
+ * uses `core.hooksPath` and deliberately wires no commit-msg hook, so a
+ * `.husky/` file there would simply never run.
+ *
+ * @returns the files written, relative to targetDir.
+ */
+export async function generateCommitlintConfig(targetDir: string): Promise<string[]> {
+	const filesWritten = ['commitlint.config.mjs']
+	await fs.writeFile(
+		path.join(targetDir, 'commitlint.config.mjs'),
+		`export { default } from '@rtorcato/repo-tooling/commitlint/config'\n`
+	)
+
+	if (await usesHusky(targetDir)) {
+		// husky v10 format — no v9 bootstrap. $1 is the commit-message file path
+		// git passes through.
+		const huskyDir = path.join(targetDir, '.husky')
+		await fs.ensureDir(huskyDir)
+		const commitMsgPath = path.join(huskyDir, 'commit-msg')
+		await fs.writeFile(commitMsgPath, 'npx --no -- commitlint --edit $1\n')
+		await fs.chmod(commitMsgPath, 0o755)
+		filesWritten.push('.husky/commit-msg')
+	}
+
+	// @commitlint/cli is an *optional* peer of repo-tooling, so it never arrives
+	// transitively — without this the hook we just wrote cannot run.
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (await fs.pathExists(pkgPath)) {
+		const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+		const devDeps = { ...((pkg.devDependencies as Record<string, string> | undefined) ?? {}) }
+		let added = false
+		for (const [name, range] of Object.entries(COMMITLINT_DEPS)) {
+			if (!devDeps[name]) {
+				devDeps[name] = range
+				added = true
+			}
+		}
+		if (added) {
+			pkg.devDependencies = devDeps
+			await fs.writeJson(pkgPath, pkg, { spaces: 2 })
+			filesWritten.push('package.json')
+		}
+	}
+
+	return filesWritten
 }
 
 async function generateGitignore(config: ProjectConfig, targetDir: string) {

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -217,7 +217,8 @@ export const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'husky',
-		description: 'Set up Husky + lint-staged (and a `pnpm verify` pre-push hook)',
+		description:
+			'Set up Husky + lint-staged (and a `pnpm verify` pre-push hook). Commit-message linting is `fix commitlint`.',
 		appliesTo: ['Git hooks', 'lint-staged', 'Pre-push hook'],
 		outputs: ['.husky/pre-commit', '.husky/pre-push', 'package.json (lint-staged field)'],
 		riskLevel: 'safe-merge',

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -701,6 +701,44 @@ describe('fix targeted', () => {
 		expect(pkg.scripts.treeshake).toBe('pnpm --filter=*treeshake-check run check')
 	})
 
+	// #362: `fix husky` used to emit a commit-msg hook running `npx --no --
+	// commitlint`, without installing commitlint. `--no` refuses to install a
+	// missing binary, so every `git commit` in the repo was rejected.
+	it('fix husky --yes leaves no commit-msg hook it cannot make work', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('husky', { directory: dir, yes: true })
+
+		expect(await fs.pathExists(join(dir, '.husky', 'pre-commit'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.husky', 'commit-msg'))).toBe(false)
+	})
+
+	it('fix commitlint --yes ships the hook, the config and the dependency together', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('husky', { directory: dir, yes: true })
+		await fixCommand('commitlint', { directory: dir, yes: true })
+
+		const hook = await fs.readFile(join(dir, '.husky', 'commit-msg'), 'utf-8')
+		expect(hook).toContain('commitlint --edit')
+		const config = await fs.readFile(join(dir, 'commitlint.config.mjs'), 'utf-8')
+		expect(config).toContain('@rtorcato/repo-tooling/commitlint/config')
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.devDependencies['@commitlint/cli']).toBeTruthy()
+		expect(pkg.devDependencies['@commitlint/config-conventional']).toBeTruthy()
+	})
+
+	// Swift and Perl repos drive hooks through core.hooksPath, so a .husky file
+	// there would sit on disk and never run.
+	it('fix commitlint --yes writes no husky hook when husky does not own the hooks', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('commitlint', { directory: dir, yes: true })
+
+		expect(await fs.pathExists(join(dir, 'commitlint.config.mjs'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.husky', 'commit-msg'))).toBe(false)
+	})
+
 	it('fix husky --yes skips the pre-push hook when no verify script exists', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)


### PR DESCRIPTION
Closes #362.

`fix husky` wrote `.husky/commit-msg` containing `npx --no -- commitlint --edit $1` — but never installed `@commitlint/cli`, never scaffolded `commitlint.config.mjs`, and never warned. `npx --no` explicitly refuses to install a missing binary, and `@commitlint/cli` is only an *optional* peer of this package, so it doesn't arrive transitively either.

Result: a repo that ran only `fix husky` had **every `git commit` rejected**, discovered at the first commit.

## Approach

Option 2 from the issue — each `fix` target owns a complete, working unit.

- `generateHuskyConfig` no longer writes `commit-msg`.
- `generateCommitlintConfig` writes the config, the hook, *and* adds `@commitlint/cli` + `@commitlint/config-conventional` to devDependencies. It prints the usual `pnpm install` reminder to stderr when it touches `package.json`.
- The hook is written only where husky owns the hooks (`.husky/` present, or `husky` in deps). Swift/Perl repos drive hooks through `core.hooksPath`, so a `.husky` file there would sit on disk and never run.
- Target descriptions and `outputs` updated so `fix --list` reflects who owns what; `commitlint` is now `safe-merge` since it only fills in missing devDependencies.

The `setup` path is unchanged in effect: `generateGitConfigs` calls husky then commitlint, so `.husky/commit-msg` still lands, and `generatePackageJson` already declared the deps.

## Verification

- `tests/cli/commands/fix.test.ts` — three new cases: `fix husky` alone leaves no commit-msg hook; `fix commitlint` ships hook + config + deps together; `fix commitlint` writes no husky hook when husky doesn't own the hooks.
- Existing `generateGitConfigs` tests still assert the commit-msg hook lands via the setup path.
- Full suite: 778 passed. `pnpm run check` and typecheck clean.