### PR TITLE
fix(ci): make the generated workflow pass on the repo that generated it

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import { renderGitHubWorkflow } from '../../base/ci.js'
-import { githubJobs } from '../../languages/js/ci.js'
+import { githubJobs, scriptsOf } from '../../languages/js/ci.js'
 import { inferProjectConfig } from '../../languages/js/fixers.js'
 import { PERL_GIT_HOOKS, runPerlChecks } from '../../languages/perl/checks.js'
 import { readPerlProject, renderPerlWorkflow } from '../../languages/perl/ci.js'
@@ -52,6 +52,7 @@ import {
 	checkSemanticRelease,
 	checkSizeLimit,
 	checkTailwind,
+	checkBuildApprovals,
 	checkPnpmWorkspace,
 	checkTreeshakeSetup,
 	checkTurborepo,
@@ -387,6 +388,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkPublint(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 	results.push(await checkPnpmWorkspace(targetDir, pkg))
+	results.push(await checkBuildApprovals(targetDir, pkg))
 	// Turborepo is monorepo-only — only surface the check when a workspace exists.
 	if (await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))) {
 		results.push(await checkTurborepo(targetDir))
@@ -405,7 +407,11 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 		...(await runBaseChecks(targetDir, lock, {
 			hooks: jsGitHooksProfile(pkg),
 			badges: { audience: jsBadgeAudience(pkg), fixTarget: 'badges' },
-			presetWorkflow: renderGitHubWorkflow(githubJobs(inferProjectConfig(pkg))),
+			// Same `scripts` gating the fixer applies, or the workflow doctor
+			// compares against would reference steps the fixer never writes (#364).
+			presetWorkflow: renderGitHubWorkflow(
+				githubJobs(inferProjectConfig(pkg), { scripts: scriptsOf(pkg) })
+			),
 			language,
 			codeqlLanguages: languageModule.codeqlLanguages,
 		}))

--- a/src/cli/generators/github-actions.ts
+++ b/src/cli/generators/github-actions.ts
@@ -30,12 +30,15 @@ export const CI_WORKFLOW = '.github/workflows/ci.yml'
  * #340). Same self-enforced safe-add as github-workflows.ts, widened to "or is
  * byte-identical anyway" so a no-op regeneration still reports honestly. Only a
  * caller that has told the user this workflow itself is drifting passes true.
+ * @param scripts The target's package.json scripts, so the workflow only calls
+ * commands that exist (#364). Omit on the `setup` path, which writes the
+ * scripts itself as part of the same scaffold.
  * @returns the files actually written, relative to targetDir.
  */
 export async function generateGitHubActions(
 	config: ProjectConfig,
 	targetDir: string,
-	{ overwrite = false }: { overwrite?: boolean } = {}
+	{ overwrite = false, scripts }: { overwrite?: boolean; scripts?: Record<string, string> } = {}
 ): Promise<string[]> {
 	const workflowsDir = path.join(targetDir, '.github', 'workflows')
 	await fs.ensureDir(workflowsDir)
@@ -46,7 +49,7 @@ export async function generateGitHubActions(
 	// shared entry point would mean inventing a fake config to pass in. Both
 	// paths meet at renderGitHubWorkflow() in src/base/ci.ts, which is the seam
 	// that actually matters.
-	const workflow = renderGitHubWorkflow(githubJobs(config))
+	const workflow = renderGitHubWorkflow(githubJobs(config, { scripts }))
 	const ciPath = path.join(workflowsDir, 'ci.yml')
 	const existing = (await fs.pathExists(ciPath)) ? await fs.readFile(ciPath, 'utf-8') : null
 	const filesWritten: string[] = []

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -1,6 +1,13 @@
+import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 import fs from 'fs-extra'
 import type { ProjectConfig } from '../commands/setup.js'
+
+/**
+ * Only used when pnpm isn't on PATH to ask. corepack requires an exact
+ * `pnpm@x.y.z` — a range is rejected — so this has to be a concrete version.
+ */
+export const PNPM_FALLBACK_VERSION = '11.1.3'
 
 const EDITORCONFIG_CONTENT = `root = true
 
@@ -210,6 +217,51 @@ export async function ensureEnginesNode(
 	if (engines.node) return 'already-set'
 
 	pkg.engines = { ...engines, node: version }
+	await fs.writeJson(pkgPath, pkg, { spaces: 2 })
+	return 'added'
+}
+
+/** The pnpm this machine runs, or null when pnpm isn't on PATH. */
+export function detectPnpmVersion(): string | null {
+	try {
+		const out = execFileSync('pnpm', ['--version'], {
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		})
+		return /^\s*(\d+\.\d+\.\d+)/.exec(out)?.[1] ?? null
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Pin `packageManager` so `pnpm/action-setup` has a version to resolve (#364).
+ *
+ * The generated workflow uses `pnpm/action-setup` with no `version:` input,
+ * which is correct *provided* something declares the version. Nothing in the
+ * `fix` path did, so every scaffolded pipeline died at setup with "No pnpm
+ * version is specified" — before a single check ran.
+ *
+ * The value is detected from the pnpm actually running, not hardcoded: this is
+ * a public CLI and a baked-in version would pin strangers' repos to whatever
+ * was current when this file was last touched. `PNPM_FALLBACK_VERSION` is only
+ * for a machine with no pnpm on PATH, and corepack will fetch it either way.
+ *
+ * @returns 'added' | 'already-set' | 'no-package-json'
+ */
+export async function ensurePackageManager(
+	targetDir: string,
+	version = detectPnpmVersion() ?? PNPM_FALLBACK_VERSION
+): Promise<EnsureEnginesResult> {
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (!(await fs.pathExists(pkgPath))) return 'no-package-json'
+
+	const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+	if (typeof pkg.packageManager === 'string' && pkg.packageManager.trim() !== '') {
+		return 'already-set'
+	}
+
+	pkg.packageManager = `pnpm@${version}`
 	await fs.writeJson(pkgPath, pkg, { spaces: 2 })
 	return 'added'
 }

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -1,11 +1,7 @@
 import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
-
-// Exact pnpm version for the `packageManager` field — corepack requires a
-// pinned `pnpm@x.y.z` (not a range), and it's the single source of truth for
-// pnpm/action-setup, so the generated workflows drop their `version:` inputs.
-const PNPM_VERSION = '11.1.3'
+import { PNPM_FALLBACK_VERSION, detectPnpmVersion } from './misc.js'
 
 export async function generatePackageJson(config: ProjectConfig, targetDir: string) {
 	const packageJsonPath = path.join(targetDir, 'package.json')
@@ -22,7 +18,9 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 		version: '0.1.0',
 		description: '',
 		type: 'module',
-		packageManager: `pnpm@${PNPM_VERSION}`,
+		// The single source of truth for pnpm/action-setup, which is why the
+		// generated workflows carry no `version:` input (#364).
+		packageManager: `pnpm@${detectPnpmVersion() ?? PNPM_FALLBACK_VERSION}`,
 		...existingPackageJson,
 		scripts: {
 			...getScripts(config, { includeTreeshake }),
@@ -182,6 +180,38 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 	return scripts
 }
 
+/**
+ * Add any of `scripts` the package.json doesn't already define, leaving every
+ * existing value alone. Returns true when something was written.
+ *
+ * A `fix` target that scaffolds a tool's config but no way to run it leaves the
+ * repo half-wired: the generated CI called `pnpm check`, and `fix verify`
+ * refused to compose a chain, both because no target ever created that script
+ * (#364).
+ */
+export async function ensureScripts(
+	targetDir: string,
+	scripts: Record<string, string>
+): Promise<boolean> {
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (!(await fs.pathExists(pkgPath))) return false
+
+	const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+	const existing = { ...((pkg.scripts as Record<string, string> | undefined) ?? {}) }
+	let added = false
+	for (const [name, command] of Object.entries(scripts)) {
+		if (!existing[name]) {
+			existing[name] = command
+			added = true
+		}
+	}
+	if (!added) return false
+
+	pkg.scripts = existing
+	await fs.writeJson(pkgPath, pkg, { spaces: 2 })
+	return true
+}
+
 export function composeVerifyScript(
 	config: ProjectConfig,
 	opts: { includeTreeshake?: boolean } = {}
@@ -230,6 +260,9 @@ export function composeVerifyScriptFromPkg(
 	if (deps.vitest) cmds.push('pnpm exec vitest run')
 	else if (deps.jest) cmds.push('pnpm test --ci')
 	else if (deps['@playwright/test'] || deps.cypress) cmds.push('pnpm test:e2e')
+	// A repo can run tests without any runner we recognise — `node --test`, for
+	// one. Its `test` script is still the thing verify should call (#364).
+	else if (scripts.test) cmds.push('pnpm test')
 	if (opts.includeTreeshake) cmds.push('pnpm treeshake')
 	if (deps.publint || scripts.publint) cmds.push('pnpm publint')
 	return cmds.length >= 2 ? cmds.join(' && ') : null

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -941,6 +941,90 @@ export async function checkPnpmWorkspace(dir: string, pkg: Pkg | null): Promise<
 	}
 }
 
+/** The lifecycle scripts pnpm refuses to run until the package is approved. */
+const BUILD_LIFECYCLE_SCRIPTS = ['preinstall', 'install', 'postinstall'] as const
+
+/**
+ * Package names that already have a build decision recorded — approved or
+ * declined, both count. `allowBuilds` is a map (pnpm 11); the older
+ * `onlyBuiltDependencies` / `ignoredBuiltDependencies` lists are still read so
+ * a repo that hasn't migrated isn't nagged about choices it already made.
+ */
+export function decidedBuilds(yaml: string): Set<string> {
+	const decided = new Set<string>()
+	const lines = yaml.split('\n')
+	let inBlock = false
+	for (const line of lines) {
+		if (/^(allowBuilds|onlyBuiltDependencies|ignoredBuiltDependencies):/.test(line)) {
+			inBlock = true
+			continue
+		}
+		if (/^\S/.test(line)) {
+			inBlock = false
+			continue
+		}
+		if (!inBlock) continue
+		// `  esbuild: true` (map) or `  - esbuild` (list).
+		const name = /^\s*-?\s*['"]?(@?[\w./-]+?)['"]?\s*:?\s*(?:true|false)?\s*$/.exec(line)?.[1]
+		if (name) decided.add(name)
+	}
+	return decided
+}
+
+/**
+ * Direct dependencies whose install would run a build script (#364).
+ *
+ * pnpm 11 turned undecided build scripts into a hard error, so
+ * `pnpm install --frozen-lockfile` exits non-zero with ERR_PNPM_IGNORED_BUILDS
+ * — a guaranteed CI failure. Locally the same message reads as advisory, which
+ * is exactly why it gets missed until the pipeline goes red.
+ *
+ * Only direct dependencies are inspected: reaching transitive ones means
+ * walking node_modules/.pnpm, and the packages that trip this in practice
+ * (better-sqlite3, @prisma/client, esbuild) are ones the repo asked for by
+ * name. A transitive offender is a false negative, never a false positive.
+ */
+export async function checkBuildApprovals(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const check = 'pnpm build approvals'
+	const deps = allDeps(pkg)
+	const modulesDir = path.join(dir, 'node_modules')
+	if (Object.keys(deps).length === 0 || !(await fs.pathExists(modulesDir))) {
+		// Nothing installed to inspect — the manifest alone can't say which
+		// packages ship an install script.
+		return { check, status: 'ok', detail: 'no installed dependencies to inspect' }
+	}
+
+	const yamlPath = path.join(dir, WORKSPACE_FILE)
+	const decided = decidedBuilds(
+		(await fs.pathExists(yamlPath)) ? await fs.readFile(yamlPath, 'utf-8') : ''
+	)
+
+	const undecided: string[] = []
+	for (const name of Object.keys(deps)) {
+		if (decided.has(name)) continue
+		const depPkgPath = path.join(modulesDir, name, 'package.json')
+		if (!(await fs.pathExists(depPkgPath))) continue
+		let scripts: Record<string, string> = {}
+		try {
+			const depPkg = (await fs.readJson(depPkgPath)) as Record<string, unknown>
+			scripts = (depPkg.scripts as Record<string, string> | undefined) ?? {}
+		} catch {
+			continue
+		}
+		if (BUILD_LIFECYCLE_SCRIPTS.some((s) => scripts[s])) undecided.push(name)
+	}
+
+	if (undecided.length === 0) {
+		return { check, status: 'ok', detail: 'every dependency with a build script has a decision' }
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: `${undecided.length} dependenc${undecided.length === 1 ? 'y' : 'ies'} with undecided build scripts: ${undecided.join(', ')}`,
+		hint: `Record a decision per package under \`allowBuilds:\` in ${WORKSPACE_FILE} (\`name: true\` to run it, \`false\` to skip). pnpm 11 fails \`pnpm install --frozen-lockfile\` outright while any is undecided, so CI cannot pass until each is answered.`,
+	}
+}
+
 /** The docs app dir (apps/docs or apps/doc) if a Docusaurus config lives there. */
 export async function findDocsAppDir(dir: string): Promise<string | null> {
 	for (const app of ['apps/docs', 'apps/doc']) {

--- a/src/languages/js/ci.ts
+++ b/src/languages/js/ci.ts
@@ -14,10 +14,13 @@ export function usesCoverage(config: ProjectConfig): boolean {
 	return config.testing.framework === 'vitest'
 }
 
+/** The package.json script the lint job runs — `check` under Biome, else `lint`. */
+function lintScript(config: ProjectConfig): string {
+	return config.linting.tool === 'biome' || config.linting.tool === 'both' ? 'check' : 'lint'
+}
+
 function lintCommand(config: ProjectConfig): string {
-	return config.linting.tool === 'biome' || config.linting.tool === 'both'
-		? 'pnpm check'
-		: 'pnpm lint'
+	return `pnpm ${lintScript(config)}`
 }
 
 /**
@@ -78,41 +81,84 @@ const DEPENDENCIES_JOB: CiJob = {
 }
 
 /**
+ * The repo's `package.json` scripts, when we have a real one to read (#364).
+ *
+ * `setup` renders a workflow for a project it is about to *create*, so every
+ * script it references is one it also writes. `fix github-actions` renders one
+ * for a project that already exists and may have none of them: the generated
+ * pipeline called `pnpm check`, `pnpm knip` and `pnpm coverage` on repos where
+ * no target had created those scripts, and died with ERR_PNPM_RECURSIVE_EXEC.
+ *
+ * Undefined means "assume the setup shape" — omitting the steps there would
+ * drop them from a project whose scripts simply don't exist yet.
+ */
+export interface JobOptions {
+	scripts?: Record<string, string>
+}
+
+/**
+ * `JobOptions.scripts` for a real repo. A package.json with no `scripts` block
+ * yields `{}` — "this repo has no scripts", which gates every step off —
+ * whereas no package.json at all yields undefined, the setup shape.
+ */
+export function scriptsOf(pkg: Record<string, unknown> | null): Record<string, string> | undefined {
+	if (!pkg) return undefined
+	return (pkg.scripts as Record<string, string> | undefined) ?? {}
+}
+
+/** Emit a step only when the script it runs exists (or we can't know yet). */
+function stepFor(opts: JobOptions, script: string, step: string): string | null {
+	return !opts.scripts || script in opts.scripts ? step : null
+}
+
+/** Join the steps that survived gating onto the shared setup preamble. */
+function jobSteps(steps: (string | null)[]): string | null {
+	const kept = steps.filter((s): s is string => s !== null)
+	return kept.length > 0 ? [SETUP_STEPS, ...kept].join('\n\n') : null
+}
+
+/**
  * The GitHub Actions jobs for a JS repo, in workflow order. The `release` job
  * needs the ids of everything that ran before it, so the list is assembled
  * rather than filtered from a fixed shape.
  */
-export function githubJobs(config: ProjectConfig): CiJob[] {
+export function githubJobs(config: ProjectConfig, opts: JobOptions = {}): CiJob[] {
 	const hasTypeScript = config.typescript.enabled
 	const hasTests = config.testing.framework !== 'none'
 	const hasBuild = config.bundler !== 'none'
 	const isLibrary = config.projectType === 'library'
 	const hasCoverage = usesCoverage(config)
 
-	const jobs: CiJob[] = [
-		DEPENDENCIES_JOB,
-		{
-			id: 'lint',
-			needs: ['dependencies'],
-			steps: `${SETUP_STEPS}
+	const jobs: CiJob[] = [DEPENDENCIES_JOB]
 
-      - name: 🔍 Run linting
-        run: ${lintCommand(config)}
-
-      - name: 🧹 Check for unused files, exports, and dependencies
-        run: pnpm knip`,
-		},
-	]
+	const lintSteps = jobSteps([
+		stepFor(
+			opts,
+			lintScript(config),
+			`      - name: 🔍 Run linting
+        run: ${lintCommand(config)}`
+		),
+		stepFor(
+			opts,
+			'knip',
+			`      - name: 🧹 Check for unused files, exports, and dependencies
+        run: pnpm knip`
+		),
+	])
+	if (lintSteps) {
+		jobs.push({ id: 'lint', needs: ['dependencies'], steps: lintSteps })
+	}
 
 	if (hasTypeScript) {
-		jobs.push({
-			id: 'typecheck',
-			needs: ['dependencies'],
-			steps: `${SETUP_STEPS}
-
-      - name: 🔍 Type check
-        run: pnpm typecheck`,
-		})
+		const steps = jobSteps([
+			stepFor(
+				opts,
+				'typecheck',
+				`      - name: 🔍 Type check
+        run: pnpm typecheck`
+			),
+		])
+		if (steps) jobs.push({ id: 'typecheck', needs: ['dependencies'], steps })
 	}
 
 	if (hasTests) {
@@ -125,21 +171,26 @@ export function githubJobs(config: ProjectConfig): CiJob[] {
           token: \${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false`
 			: ''
-		jobs.push({
-			id: 'test',
-			needs: ['dependencies'],
-			steps: `${SETUP_STEPS}
-
-      - name: 🧪 Run tests
-        run: ${hasCoverage ? 'pnpm coverage' : 'pnpm test'}${coverageUpload}`,
-		})
+		// Fall back to `pnpm test` when the repo has no coverage script — the
+		// coverage upload goes with it, since there'd be no lcov to upload.
+		const useCoverage = hasCoverage && (!opts.scripts || 'coverage' in opts.scripts)
+		const steps = jobSteps([
+			stepFor(
+				opts,
+				useCoverage ? 'coverage' : 'test',
+				`      - name: 🧪 Run tests
+        run: ${useCoverage ? 'pnpm coverage' : 'pnpm test'}${useCoverage ? coverageUpload : ''}`
+			),
+		])
+		if (steps) jobs.push({ id: 'test', needs: ['dependencies'], steps })
 	}
 
-	if (hasBuild) {
+	if (hasBuild && (!opts.scripts || 'build' in opts.scripts)) {
 		// attw and publint validate what's about to be published — libraries only.
-		const attw = isLibrary
-			? '\n      - name: 🔍 Validate type resolution (are-the-types-wrong)\n        run: pnpm attw\n'
-			: ''
+		const attw =
+			isLibrary && (!opts.scripts || 'attw' in opts.scripts)
+				? '\n      - name: 🔍 Validate type resolution (are-the-types-wrong)\n        run: pnpm attw\n'
+				: ''
 		const publint = config.publint
 			? '\n      - name: 🔍 Validate package with publint\n        run: pnpm exec publint --strict\n'
 			: ''

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -16,12 +16,22 @@ import { generateESLintConfig, generatePrettierConfig } from '../../cli/generato
 import {
 	alignNodeVersion,
 	ensureEnginesNode,
+	ensurePackageManager,
 	generateKnipConfig,
 	generateNvmrc,
 	generateSizeLimitConfig,
 	generateVscodeExtensions,
 } from '../../cli/generators/misc.js'
-import { composeVerifyScriptFromPkg } from '../../cli/generators/package-json.js'
+import { scriptsOf } from './ci.js'
+import { composeVerifyScriptFromPkg, ensureScripts } from '../../cli/generators/package-json.js'
+
+/** Kept in step with the biome branch of getScripts() in package-json.ts. */
+const BIOME_SCRIPTS: Record<string, string> = {
+	lint: 'biome lint .',
+	format: 'biome format .',
+	check: 'biome check .',
+	'check:fix': 'biome check --fix .',
+}
 import {
 	WORKSPACE_FILE,
 	dependsOnEsbuild,
@@ -137,13 +147,18 @@ const GH_WORKFLOW_FIXERS: Fixer[] = GH_WORKFLOWS.map((name) => ({
 export const FIXERS: Fixer[] = [
 	{
 		target: 'biome',
-		description: 'Scaffold biome.json extending the @rtorcato/repo-tooling preset',
+		description:
+			'Scaffold biome.json extending the @rtorcato/repo-tooling preset, plus the scripts that run it',
 		appliesTo: ['Biome'],
-		outputs: ['biome.json'],
+		outputs: ['biome.json', 'package.json (scripts)'],
 		canFixDrift: true,
 		async run({ targetDir }) {
 			const result = await copyPreset('biome', targetDir)
-			return { filesWritten: [result.target] }
+			const filesWritten = [result.target]
+			// A config with no way to run it left `pnpm check` undefined, which the
+			// generated CI called and `fix verify` needed to compose a chain (#364).
+			if (await ensureScripts(targetDir, BIOME_SCRIPTS)) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{
@@ -336,7 +351,7 @@ export const FIXERS: Fixer[] = [
 		target: 'github-actions',
 		description: 'Scaffold .github/workflows/ci.yml (+ codecov.yml when tests run)',
 		appliesTo: ['GitHub Actions', 'Coverage upload', 'npm OIDC publish'],
-		outputs: [CI_WORKFLOW, 'codecov.yml'],
+		outputs: [CI_WORKFLOW, 'codecov.yml', 'package.json (packageManager field)'],
 		canFixDrift: true,
 		async run({ targetDir, pkg, result }) {
 			// Only a `GitHub Actions` finding means the user was shown that the
@@ -345,7 +360,14 @@ export const FIXERS: Fixer[] = [
 			// customized ci.yml down with it (#349).
 			const filesWritten = await generateGitHubActions(inferProjectConfig(pkg), targetDir, {
 				overwrite: result.check === 'GitHub Actions',
+				// Only reference scripts this repo actually has (#364).
+				scripts: scriptsOf(pkg),
 			})
+			// `pnpm/action-setup` is emitted without a `version:` input, so without
+			// this every job dies at setup with "No pnpm version is specified".
+			if ((await ensurePackageManager(targetDir)) === 'added') {
+				filesWritten.push('package.json')
+			}
 			if (!filesWritten.includes(CI_WORKFLOW)) {
 				console.error(
 					chalk.yellow(

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -7,6 +7,7 @@ import {
 	runDoctor,
 	summarize,
 } from '../../../src/cli/commands/doctor.js'
+import { checkBuildApprovals } from '../../../src/languages/js/checks.js'
 import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -1202,5 +1203,53 @@ describe('doctor README badges check', () => {
 		expect(checks.has('package.json')).toBe(false)
 		expect(checks.has('TypeScript')).toBe(false)
 		expect(checks.has('Node')).toBe(false)
+	})
+})
+
+// #364: pnpm 11 turned undecided build scripts into a hard error, so
+// `pnpm install --frozen-lockfile` exits non-zero with ERR_PNPM_IGNORED_BUILDS.
+// Locally the same message reads as advisory, which is why it goes unnoticed
+// until the pipeline is red.
+describe('checkBuildApprovals', () => {
+	async function seedDep(dir: string, name: string, scripts: Record<string, string>) {
+		await fs.outputJson(join(dir, 'node_modules', name, 'package.json'), { name, scripts })
+	}
+
+	it('flags a dependency with an install script and no recorded decision', async () => {
+		const dir = newTmpDir()
+		const pkg = { name: 'demo', devDependencies: { 'better-sqlite3': '^12.0.0' } }
+		await seedDep(dir, 'better-sqlite3', { install: 'prebuild-install || node-gyp rebuild' })
+
+		const result = await checkBuildApprovals(dir, pkg)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('better-sqlite3')
+		expect(result.hint).toContain('allowBuilds')
+	})
+
+	it('accepts a decision either way — declining a build is still deciding', async () => {
+		const dir = newTmpDir()
+		const pkg = { name: 'demo', devDependencies: { esbuild: '^0.25.0', '@prisma/client': '^5.0.0' } }
+		await seedDep(dir, 'esbuild', { postinstall: 'node install.js' })
+		await seedDep(dir, '@prisma/client', { postinstall: 'prisma generate' })
+		await fs.writeFile(
+			join(dir, 'pnpm-workspace.yaml'),
+			'allowBuilds:\n  esbuild: true\n  "@prisma/client": false\n'
+		)
+
+		expect((await checkBuildApprovals(dir, pkg)).status).toBe('ok')
+	})
+
+	it('says nothing about dependencies that ship no build script', async () => {
+		const dir = newTmpDir()
+		const pkg = { name: 'demo', devDependencies: { chalk: '^5.0.0' } }
+		await seedDep(dir, 'chalk', { test: 'vitest' })
+
+		expect((await checkBuildApprovals(dir, pkg)).status).toBe('ok')
+	})
+
+	it('stays quiet when nothing is installed to inspect', async () => {
+		const result = await checkBuildApprovals(newTmpDir(), { name: 'demo', devDependencies: { x: '1' } })
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('no installed dependencies')
 	})
 })

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1182,3 +1182,42 @@ describe('fix --diff', () => {
 		}
 	})
 })
+
+// #364: `fix biome` scaffolded a config with no way to run it, so the generated
+// CI's `pnpm check` step and `fix verify`'s lint half both had nothing to call.
+describe('fix biome scripts', () => {
+	it('adds the scripts that run Biome, without touching existing ones', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { scripts: { check: 'my own check' } })
+		await fixCommand('biome', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.check).toBe('my own check')
+		expect(pkg.scripts.lint).toBe('biome lint .')
+		expect(pkg.scripts['check:fix']).toBe('biome check --fix .')
+	})
+})
+
+// #364: pnpm/action-setup has no `version:` input, so the workflow needs
+// packageManager or every job dies at setup.
+describe('fix github-actions packageManager', () => {
+	it('pins packageManager alongside the workflow', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('github-actions', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+$/)
+	})
+
+	it('only references scripts the repo actually has', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { scripts: { typecheck: 'tsc --noEmit' } })
+		await fixCommand('github-actions', { directory: dir, yes: true })
+
+		const workflow = await fs.readFile(join(dir, '.github/workflows/ci.yml'), 'utf-8')
+		expect(workflow).toContain('run: pnpm typecheck')
+		expect(workflow).not.toContain('run: pnpm knip')
+		expect(workflow).not.toContain('run: pnpm coverage')
+	})
+})

--- a/tests/cli/generators/github-actions.test.ts
+++ b/tests/cli/generators/github-actions.test.ts
@@ -234,3 +234,68 @@ describe('generateGitHubActions', () => {
 		expect(content).toContain('pnpm lint')
 	})
 })
+
+// #364: the generated workflow called `pnpm check`, `pnpm knip` and
+// `pnpm coverage` on repos where no fix target had ever created those scripts,
+// so every run died with ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL.
+describe('generateGitHubActions script gating', () => {
+	const config = baseConfig({
+		testing: { framework: 'vitest' },
+		bundler: 'tsup',
+	})
+
+	it('omits steps whose scripts the repo does not define', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(config, dir, {
+			scripts: { typecheck: 'tsc --noEmit', test: 'vitest run' },
+		})
+		const workflow = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+
+		expect(workflow).toContain('run: pnpm typecheck')
+		// No check/knip script → the whole lint job goes, rather than a job with
+		// no steps.
+		expect(workflow).not.toContain('run: pnpm check')
+		expect(workflow).not.toContain('run: pnpm knip')
+		expect(workflow).not.toMatch(/^ {2}lint:$/m)
+		// No coverage script → run the tests that do exist, and drop the upload
+		// since there'd be no lcov to send.
+		expect(workflow).toContain('run: pnpm test')
+		expect(workflow).not.toContain('codecov-action')
+		// No build script → no build job.
+		expect(workflow).not.toContain('run: pnpm build')
+	})
+
+	it('keeps every step when the scripts are there', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(config, dir, {
+			scripts: {
+				typecheck: 'tsc --noEmit',
+				check: 'biome check .',
+				knip: 'knip',
+				coverage: 'vitest run --coverage',
+				build: 'tsup',
+				attw: 'attw --pack',
+			},
+		})
+		const workflow = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+
+		expect(workflow).toContain('run: pnpm check')
+		expect(workflow).toContain('run: pnpm knip')
+		expect(workflow).toContain('run: pnpm coverage')
+		expect(workflow).toContain('codecov-action')
+		expect(workflow).toContain('run: pnpm build')
+		expect(workflow).toContain('run: pnpm attw')
+	})
+
+	it('assumes the full setup shape when no scripts are supplied', async () => {
+		const dir = newTmpDir()
+		await generateGitHubActions(config, dir)
+		const workflow = await fs.readFile(join(dir, WORKFLOW_PATH), 'utf-8')
+
+		// setup writes these scripts as part of the same scaffold, so gating on a
+		// package.json that doesn't exist yet would strip a working pipeline.
+		expect(workflow).toContain('run: pnpm check')
+		expect(workflow).toContain('run: pnpm knip')
+		expect(workflow).toContain('run: pnpm coverage')
+	})
+})

--- a/tests/cli/generators/misc.test.ts
+++ b/tests/cli/generators/misc.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import {
 	ensureEnginesNode,
+	ensurePackageManager,
 	generateEditorConfig,
 	generateKnipConfig,
 	generateMiscBaseline,
@@ -280,5 +281,30 @@ describe('generateMiscBaseline', () => {
 		expect(await fs.pathExists(join(dir, 'knip.json'))).toBe(true)
 		const pkg = await fs.readJson(join(dir, 'package.json'))
 		expect(pkg.engines?.node).toBe('>=22')
+	})
+})
+
+// #364: `pnpm/action-setup` is emitted with no `version:` input, so without
+// `packageManager` every generated job died at setup with "No pnpm version is
+// specified" before a single check ran.
+describe('ensurePackageManager', () => {
+	it('pins packageManager when absent', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', version: '0.0.0' })
+
+		expect(await ensurePackageManager(dir, '11.20.0')).toBe('added')
+		expect((await fs.readJson(join(dir, 'package.json'))).packageManager).toBe('pnpm@11.20.0')
+	})
+
+	it('leaves an existing pin alone', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', packageManager: 'yarn@4.9.1' })
+
+		expect(await ensurePackageManager(dir, '11.20.0')).toBe('already-set')
+		expect((await fs.readJson(join(dir, 'package.json'))).packageManager).toBe('yarn@4.9.1')
+	})
+
+	it('reports no-package-json rather than creating one', async () => {
+		expect(await ensurePackageManager(newTmpDir(), '11.20.0')).toBe('no-package-json')
 	})
 })

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import {
 	composeVerifyScript,
+	composeVerifyScriptFromPkg,
 	generatePackageJson,
 } from '../../../src/cli/generators/package-json.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -301,5 +302,25 @@ describe('composeVerifyScript', () => {
 			})
 		)
 		expect(result).toBeNull()
+	})
+})
+
+// #364: `fix verify` skipped on a repo with both typecheck and test scripts,
+// because the test half only counted when a runner it recognised was in deps.
+describe('composeVerifyScriptFromPkg test fallback', () => {
+	it('counts a test script from a runner it does not recognise', () => {
+		const verify = composeVerifyScriptFromPkg({
+			scripts: { typecheck: 'tsc --noEmit', test: 'node --test' },
+			devDependencies: { typescript: '^5.9.3' },
+		})
+		expect(verify).toBe('pnpm typecheck && pnpm test')
+	})
+
+	it('still prefers the recognised runner when one is installed', () => {
+		const verify = composeVerifyScriptFromPkg({
+			scripts: { typecheck: 'tsc --noEmit', test: 'vitest' },
+			devDependencies: { typescript: '^5.9.3', vitest: '^4.0.0' },
+		})
+		expect(verify).toBe('pnpm typecheck && pnpm exec vitest run')
 	})
 })


### PR DESCRIPTION
Closes #364.

`fix github-actions` emitted a `ci.yml` that failed three times in a row on a repo scaffolded by this same tool. All three fixed here.

## 1. `pnpm/action-setup` had no version to resolve

The workflow uses `pnpm/action-setup@v6` with no `version:` input — correct *only* if something declares the version. Nothing in the `fix` path did, so every job died at setup:

```
Error: No pnpm version is specified.
```

`fix github-actions` now pins `packageManager`, **detected from the pnpm actually running** rather than hardcoded. A baked-in constant would pin strangers' repos to whatever was current when this file was last touched; the old `PNPM_VERSION = '11.1.3'` in `package-json.ts` had already drifted. `PNPM_FALLBACK_VERSION` covers a machine with no pnpm on PATH.

## 2. The workflow called scripts no target creates

`pnpm check`, `pnpm knip`, `pnpm coverage` — none guaranteed to exist. Steps are now emitted only for scripts the `package.json` actually has, and a job left with no steps is dropped rather than rendered empty (the `release` job's `needs` already derives from the jobs emitted, so it follows).

Doctor renders its comparison workflow through the **same** gate (`scriptsOf(pkg)`), so a repo can't drift against a preset the fixer would never write.

`setup` is unaffected — it passes no `scripts`, because it writes them itself in the same scaffold.

### The two gaps that fed this

- **`fix biome` scaffolded a config with no way to run it**, so `pnpm check` never existed. It now adds `lint` / `format` / `check` / `check:fix`, leaving any the repo already defines alone.
- **`fix verify` skipped on repos that had both halves.** `composeVerifyScriptFromPkg` only counted tests when it recognised the runner in deps, so a `node --test` repo got *"not enough tools enabled to compose a verify chain"*. It now falls back to the `test` script.

## 3. Undecided pnpm build approvals

New doctor check `pnpm build approvals`. pnpm 11 treats undecided build scripts as an **error**, so `pnpm install --frozen-lockfile` exits non-zero with `ERR_PNPM_IGNORED_BUILDS` — guaranteed CI failure, while the same message reads as advisory locally.

A decision either way counts (`name: true` *or* `false`); the legacy `onlyBuiltDependencies` / `ignoredBuiltDependencies` lists are read too. **No fixer** — approving a package to run arbitrary install scripts is a supply-chain decision the tool shouldn't make for you, so it reports and hints.

Only direct dependencies are inspected. Reaching transitive ones means walking `node_modules/.pnpm`; the packages that trip this in practice (`better-sqlite3`, `@prisma/client`, `esbuild`) are ones the repo asked for by name. A transitive offender is a false negative, never a false positive.

## Note on conflicts

Touches the `biome` fixer body, as does #366. Whichever merges second needs a trivial rebase.

## Verification

- `misc.test.ts` — `ensurePackageManager` adds / preserves / reports no-package-json.
- `github-actions.test.ts` — steps omitted when scripts are missing, kept when present, and the full setup shape when no scripts are supplied.
- `doctor.test.ts` — build approvals flagged, decisions either way accepted, quiet with nothing installed.
- `fix.test.ts` — `fix biome` adds scripts without clobbering; `fix github-actions` pins `packageManager` and references only existing scripts.
- `package-json.test.ts` — verify chain falls back to the `test` script, still prefers a recognised runner.
- Full suite: 790 passed. `pnpm run check` and typecheck clean.