### PR TITLE
fix(js): add the scripts that run eslint and prettier

### DIFF
--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -37,6 +37,17 @@ const BIOME_SCRIPTS: Record<string, string> = {
 	check: 'biome check .',
 	'check:fix': 'biome check --fix .',
 }
+
+/** Kept in step with the eslint branch of getScripts() in package-json.ts. */
+const ESLINT_SCRIPTS: Record<string, string> = {
+	lint: 'eslint .',
+	'lint:fix': 'eslint . --fix',
+}
+
+/** Kept in step with the eslint branch of getScripts() in package-json.ts. */
+const PRETTIER_SCRIPTS: Record<string, string> = {
+	format: 'prettier --write .',
+}
 import {
 	WORKSPACE_FILE,
 	dependsOnEsbuild,
@@ -180,24 +191,31 @@ export const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'eslint',
-		description: 'Scaffold eslint.config.mjs importing the @rtorcato/repo-tooling preset',
+		description:
+			'Scaffold eslint.config.mjs importing the @rtorcato/repo-tooling preset, plus the scripts that run it',
 		appliesTo: ['ESLint'],
-		outputs: ['eslint.config.mjs'],
+		outputs: ['eslint.config.mjs', 'package.json (scripts)'],
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			await generateESLintConfig(inferProjectConfig(pkg), targetDir)
-			return { filesWritten: ['eslint.config.mjs'] }
+			const filesWritten = ['eslint.config.mjs']
+			// Without `lint` the generated CI drops its lint step and `fix verify`
+			// composes a chain with no linting in it at all (#371).
+			if (await ensureScripts(targetDir, ESLINT_SCRIPTS)) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{
 		target: 'prettier',
-		description: 'Scaffold prettier.config.mjs re-exporting the preset',
+		description: 'Scaffold prettier.config.mjs re-exporting the preset, plus the `format` script',
 		appliesTo: ['Prettier'],
-		outputs: ['prettier.config.mjs'],
+		outputs: ['prettier.config.mjs', 'package.json (scripts)'],
 		canFixDrift: true,
 		async run({ targetDir }) {
 			await generatePrettierConfig(targetDir)
-			return { filesWritten: ['prettier.config.mjs'] }
+			const filesWritten = ['prettier.config.mjs']
+			if (await ensureScripts(targetDir, PRETTIER_SCRIPTS)) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1236,6 +1236,42 @@ describe('fix biome scripts', () => {
 	})
 })
 
+// #371: `fix eslint` / `fix prettier` had the same gap #364 closed for biome —
+// a config with no script to run it, so CI dropped its lint step silently.
+describe('fix eslint/prettier scripts', () => {
+	it('adds the scripts that run ESLint, without touching existing ones', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { scripts: { lint: 'my own lint' } })
+		await fixCommand('eslint', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.lint).toBe('my own lint')
+		expect(pkg.scripts['lint:fix']).toBe('eslint . --fix')
+	})
+
+	it('adds the `format` script alongside the Prettier config', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('prettier', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.format).toBe('prettier --write .')
+	})
+
+	it('lets `fix verify` compose a chain that includes linting', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, {
+			scripts: { typecheck: 'tsc --noEmit' },
+			devDependencies: { eslint: '^9.0.0', typescript: '^5.9.3', vitest: '^3.0.0' },
+		})
+		await fixCommand('eslint', { directory: dir, yes: true })
+		await fixCommand('verify', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.verify).toContain('pnpm lint')
+	})
+})
+
 // #364: pnpm/action-setup has no `version:` input, so the workflow needs
 // packageManager or every job dies at setup.
 describe('fix github-actions packageManager', () => {


### PR DESCRIPTION
`fix eslint` and `fix prettier` wrote a config and nothing else, so a repo got a linter it could not invoke. Since #364 the generated CI only emits a step when the script exists, so the lint step vanished instead of failing, and `fix verify` composed a chain with no linting in it.

Both fixers now call `ensureScripts`, which only fills in names that are missing, so a repo's own commands survive. The commands match the eslint branch of `getScripts()` in `src/cli/generators/package-json.ts`.

Left `riskLevel` alone. The issue suggested `safe-merge`, but these fixers still overwrite the config file itself, so that prompt wording ("existing fields preserved") would be wrong and would default a drift overwrite to Yes. `fix biome` does not set it either.

Tests: three cases in `tests/cli/commands/fix.test.ts` — eslint scripts added without clobbering, prettier `format` added, and a repo with eslint + typecheck + vitest composing a verify chain that includes `pnpm lint`.

Closes #371