### PR TITLE
fix(doctor): flag transitive pnpm build approvals

### DIFF
--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -1008,9 +1008,18 @@ async function undecidedTransitiveBuilds(
 		// A package present at two versions has two store dirs; report it once.
 		if (!name || seen.has(name) || skip(name)) continue
 		seen.add(name)
+		// Store directory names come from registry metadata, and only the *first*
+		// `+` is decoded — the rest of the entry passes through literally, so a
+		// hostile name (`..+..@1.0.0` → `../..`) would climb out of the package
+		// directory and have `fs.readJson` read an unrelated file, whose `name`
+		// then lands in the report. Confirm the resolved path stays under this
+		// entry's `node_modules` before reading it.
+		const root = path.resolve(store, entry, 'node_modules')
+		const target = path.join(root, name, 'package.json')
+		if (!target.startsWith(root + path.sep)) continue
 		let depPkg: { name?: string; scripts?: Record<string, string> }
 		try {
-			depPkg = await fs.readJson(path.join(store, entry, 'node_modules', name, 'package.json'))
+			depPkg = await fs.readJson(target)
 		} catch {
 			continue
 		}

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -974,17 +974,65 @@ export function decidedBuilds(yaml: string): Set<string> {
 }
 
 /**
- * Direct dependencies whose install would run a build script (#364).
+ * Package name encoded in a `node_modules/.pnpm` directory name (#373).
+ *
+ * Entries read `<name>@<version>` with `/` written as `+`, and the version may
+ * carry a peer suffix that contains further `@`s
+ * (`@babel+core@7.0.0_supports-color@8.0.0`), so the separator is the *first*
+ * `@` after index 0 — never the last.
+ */
+export function pnpmStoreDirToName(entry: string): string | null {
+	const at = entry.indexOf('@', 1)
+	if (at < 1) return null
+	return entry.slice(0, at).replace('+', '/')
+}
+
+/**
+ * Transitive packages that ship a build script and have no decision (#373).
+ *
+ * One `package.json` read per unique name — never a recursive walk — and the
+ * whole pass is skipped when `.pnpm` is absent (npm/yarn repos, or nothing
+ * installed). `skip` drops the names the direct pass already owns.
+ */
+async function undecidedTransitiveBuilds(
+	modulesDir: string,
+	skip: (name: string) => boolean
+): Promise<string[]> {
+	const store = path.join(modulesDir, '.pnpm')
+	if (!(await fs.pathExists(store))) return []
+
+	const seen = new Set<string>()
+	const undecided = new Set<string>()
+	for (const entry of await fs.readdir(store)) {
+		const name = pnpmStoreDirToName(entry)
+		// A package present at two versions has two store dirs; report it once.
+		if (!name || seen.has(name) || skip(name)) continue
+		seen.add(name)
+		let depPkg: { name?: string; scripts?: Record<string, string> }
+		try {
+			depPkg = await fs.readJson(path.join(store, entry, 'node_modules', name, 'package.json'))
+		} catch {
+			continue
+		}
+		const scripts = depPkg.scripts ?? {}
+		// `name` from the manifest is exact; the decoded dir name is the fallback.
+		if (BUILD_LIFECYCLE_SCRIPTS.some((s) => scripts[s])) undecided.add(depPkg.name ?? name)
+	}
+	return [...undecided].filter((n) => !skip(n)).sort()
+}
+
+/**
+ * Dependencies whose install would run a build script (#364, #373).
  *
  * pnpm 11 turned undecided build scripts into a hard error, so
  * `pnpm install --frozen-lockfile` exits non-zero with ERR_PNPM_IGNORED_BUILDS
  * — a guaranteed CI failure. Locally the same message reads as advisory, which
  * is exactly why it gets missed until the pipeline goes red.
  *
- * Only direct dependencies are inspected: reaching transitive ones means
- * walking node_modules/.pnpm, and the packages that trip this in practice
- * (better-sqlite3, @prisma/client, esbuild) are ones the repo asked for by
- * name. A transitive offender is a false negative, never a false positive.
+ * Direct and transitive offenders are graded apart. A direct one is `drift`:
+ * the repo asked for the package by name and can answer for it. A transitive
+ * one is `optional-missing` — still worth recording, but common enough that
+ * grading it as drift would drown the report in noise.
  */
 export async function checkBuildApprovals(dir: string, pkg: Pkg | null): Promise<CheckResult> {
 	const check = 'pnpm build approvals'
@@ -1016,13 +1064,29 @@ export async function checkBuildApprovals(dir: string, pkg: Pkg | null): Promise
 		if (BUILD_LIFECYCLE_SCRIPTS.some((s) => scripts[s])) undecided.push(name)
 	}
 
-	if (undecided.length === 0) {
+	const transitive = await undecidedTransitiveBuilds(
+		modulesDir,
+		(name) => decided.has(name) || name in deps
+	)
+
+	if (undecided.length === 0 && transitive.length === 0) {
 		return { check, status: 'ok', detail: 'every dependency with a build script has a decision' }
 	}
+
+	const parts: string[] = []
+	if (undecided.length)
+		parts.push(
+			`${undecided.length} dependenc${undecided.length === 1 ? 'y' : 'ies'} with undecided build scripts: ${undecided.join(', ')}`
+		)
+	if (transitive.length)
+		parts.push(
+			`${transitive.length} transitive dependenc${transitive.length === 1 ? 'y' : 'ies'} with undecided build scripts: ${transitive.join(', ')}`
+		)
+
 	return {
 		check,
-		status: 'drift',
-		detail: `${undecided.length} dependenc${undecided.length === 1 ? 'y' : 'ies'} with undecided build scripts: ${undecided.join(', ')}`,
+		status: undecided.length ? 'drift' : 'optional-missing',
+		detail: parts.join('; '),
 		hint: `Record a decision per package under \`allowBuilds:\` in ${WORKSPACE_FILE} (\`name: true\` to run it, \`false\` to skip). pnpm 11 fails \`pnpm install --frozen-lockfile\` outright while any is undecided, so CI cannot pass until each is answered.`,
 	}
 }

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1325,6 +1325,26 @@ describe('checkBuildApprovals', () => {
 			expect(result.detail).toContain('esbuild')
 		})
 
+		// Only the first `+` is decoded, so a hostile entry name can leave `..`
+		// segments in the decoded package name and point the read outside the
+		// package directory.
+		it('refuses a store entry whose decoded name escapes its package directory', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { vite: '^7.0.0' } }
+			await seedDep(dir, 'vite', { test: 'vitest' })
+			// `..+..@1.0.0` decodes to `../..`, so the unguarded read climbs out of
+			// the entry's `node_modules` and resolves to this file in the store root.
+			await fs.ensureDir(join(dir, 'node_modules', '.pnpm', '..+..@1.0.0'))
+			await fs.outputJson(join(dir, 'node_modules', '.pnpm', 'package.json'), {
+				name: 'pwned',
+				scripts: { postinstall: 'node steal.js' },
+			})
+
+			const result = await checkBuildApprovals(dir, pkg)
+			expect(result.status).toBe('ok')
+			expect(result.detail ?? '').not.toContain('pwned')
+		})
+
 		it('does not double-report a direct dependency that also sits in the store', async () => {
 			const dir = newTmpDir()
 			const pkg = { name: 'demo', devDependencies: { esbuild: '^0.25.0' } }

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -7,7 +7,7 @@ import {
 	runDoctor,
 	summarize,
 } from '../../../src/cli/commands/doctor.js'
-import { checkBuildApprovals } from '../../../src/languages/js/checks.js'
+import { checkBuildApprovals, pnpmStoreDirToName } from '../../../src/languages/js/checks.js'
 import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -1251,5 +1251,99 @@ describe('checkBuildApprovals', () => {
 		const result = await checkBuildApprovals(newTmpDir(), { name: 'demo', devDependencies: { x: '1' } })
 		expect(result.status).toBe('ok')
 		expect(result.detail).toContain('no installed dependencies')
+	})
+
+	// #373: pnpm names transitive packages in ERR_PNPM_IGNORED_BUILDS too, so a
+	// direct-only scan reports clean while CI goes red.
+	describe('transitive dependencies', () => {
+		async function seedStoreDep(
+			dir: string,
+			storeEntry: string,
+			name: string,
+			scripts: Record<string, string>
+		) {
+			await fs.outputJson(
+				join(dir, 'node_modules', '.pnpm', storeEntry, 'node_modules', name, 'package.json'),
+				{ name, scripts }
+			)
+		}
+
+		it('flags a transitive package with an install script and no decision', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { vite: '^7.0.0' } }
+			await seedDep(dir, 'vite', { test: 'vitest' })
+			await seedStoreDep(dir, 'esbuild@0.25.0', 'esbuild', { postinstall: 'node install.js' })
+
+			const result = await checkBuildApprovals(dir, pkg)
+			expect(result.status).toBe('optional-missing')
+			expect(result.detail).toContain('esbuild')
+			expect(result.detail).toContain('transitive')
+		})
+
+		it('decodes a scoped store directory back to its package name', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { vite: '^7.0.0' } }
+			await seedDep(dir, 'vite', { test: 'vitest' })
+			await seedStoreDep(dir, '@prisma+client@5.22.0', '@prisma/client', {
+				postinstall: 'prisma generate',
+			})
+
+			expect((await checkBuildApprovals(dir, pkg)).detail).toContain('@prisma/client')
+		})
+
+		it('says nothing about a transitive package already under allowBuilds', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { vite: '^7.0.0' } }
+			await seedDep(dir, 'vite', { test: 'vitest' })
+			await seedStoreDep(dir, 'esbuild@0.25.0', 'esbuild', { postinstall: 'node install.js' })
+			await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), 'allowBuilds:\n  esbuild: true\n')
+
+			expect((await checkBuildApprovals(dir, pkg)).status).toBe('ok')
+		})
+
+		it('reports a package present at two versions once', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { vite: '^7.0.0' } }
+			await seedDep(dir, 'vite', { test: 'vitest' })
+			await seedStoreDep(dir, 'esbuild@0.24.0', 'esbuild', { postinstall: 'node install.js' })
+			await seedStoreDep(dir, 'esbuild@0.25.0', 'esbuild', { postinstall: 'node install.js' })
+
+			const detail = (await checkBuildApprovals(dir, pkg)).detail ?? ''
+			expect(detail.match(/esbuild/g)).toHaveLength(1)
+			expect(detail).toContain('1 transitive dependency')
+		})
+
+		it('grades a direct offender as drift even when transitive ones exist', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { 'better-sqlite3': '^12.0.0' } }
+			await seedDep(dir, 'better-sqlite3', { install: 'node-gyp rebuild' })
+			await seedStoreDep(dir, 'esbuild@0.25.0', 'esbuild', { postinstall: 'node install.js' })
+
+			const result = await checkBuildApprovals(dir, pkg)
+			expect(result.status).toBe('drift')
+			expect(result.detail).toContain('better-sqlite3')
+			expect(result.detail).toContain('esbuild')
+		})
+
+		it('does not double-report a direct dependency that also sits in the store', async () => {
+			const dir = newTmpDir()
+			const pkg = { name: 'demo', devDependencies: { esbuild: '^0.25.0' } }
+			await seedDep(dir, 'esbuild', { postinstall: 'node install.js' })
+			await seedStoreDep(dir, 'esbuild@0.25.0', 'esbuild', { postinstall: 'node install.js' })
+
+			const detail = (await checkBuildApprovals(dir, pkg)).detail ?? ''
+			expect(detail.match(/esbuild/g)).toHaveLength(1)
+			expect(detail).not.toContain('transitive')
+		})
+	})
+})
+
+describe('pnpmStoreDirToName', () => {
+	it('decodes plain, scoped, and peer-suffixed store directories', () => {
+		expect(pnpmStoreDirToName('esbuild@0.25.0')).toBe('esbuild')
+		expect(pnpmStoreDirToName('@prisma+client@5.22.0')).toBe('@prisma/client')
+		// The peer suffix carries its own `@` — the first one still wins.
+		expect(pnpmStoreDirToName('@babel+core@7.0.0_supports-color@8.0.0')).toBe('@babel/core')
+		expect(pnpmStoreDirToName('node_modules')).toBeNull()
 	})
 })


### PR DESCRIPTION
The `pnpm build approvals` check only inspected direct dependencies, so a repo pulling a native module in transitively reported clean while `pnpm install --frozen-lockfile` failed CI with `ERR_PNPM_IGNORED_BUILDS`.

Adds a second pass over `node_modules/.pnpm/*/node_modules/<name>/package.json`:

- One `package.json` read per unique package name — never a recursive walk into the store trees.
- The whole pass is skipped when `.pnpm` is absent (npm/yarn repos, or nothing installed).
- A package present at two versions is reported once.
- The existing early return when `node_modules` is absent is unchanged.

Store directory names are decoded back to package names (`@prisma+client@5.22.0` → `@prisma/client`), splitting on the *first* `@` after index 0 so peer-suffixed entries like `@babel+core@7.0.0_supports-color@8.0.0` decode correctly. The name is then taken from the manifest itself, with the decoded name as fallback.

Direct and transitive offenders are graded apart: direct stays `drift` (the repo asked for the package by name), transitive is `optional-missing`, since transitive build scripts are common enough that grading them as drift would drown the report.

## Verification

Six new `checkBuildApprovals` cases plus a `pnpmStoreDirToName` unit test. `pnpm run check`, `tsc --noEmit --project src/cli/tsconfig.json` and `vitest run` (787 passed, 18 skipped) all pass.

Closes #373