### PR TITLE
feat(doctor): report and fix a missing packageManager pin

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -48,6 +48,7 @@ import {
 	checkNodeVersionConsistency,
 	checkNodeVersionPin,
 	checkPackageJson,
+	checkPackageManager,
 	checkPublint,
 	checkSemanticRelease,
 	checkSizeLimit,
@@ -368,6 +369,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(evaluateNodeVersion(process.version))
 	results.push(checkPackageJson(pkg))
 	results.push(checkEnginesNode(pkg))
+	results.push(await checkPackageManager(targetDir, pkg))
 	results.push(await checkConfigSchemaVersions(targetDir, pkg))
 	results.push(checkGitDependencies(pkg))
 	results.push(await checkVscodeExtensions(targetDir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -4,6 +4,7 @@ import type { ProjectConfig } from './setup.js'
 export const FIX_TARGETS: Record<string, string> = {
 	'package.json': 'package-json',
 	'engines.node': 'engines',
+	packageManager: 'engines',
 	EditorConfig: 'editorconfig',
 	'VS Code extensions': 'vscode-extensions',
 	'Node version pin': 'nvmrc',

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -177,6 +177,42 @@ export function checkPackageJson(pkg: Pkg | null): CheckResult {
 	}
 }
 
+/**
+ * Whether the repo installs with pnpm. Three independent signals, any of which
+ * is enough: the workspace file, the lockfile, or a `packageManager` that
+ * already names pnpm. Shared so `packageManager` and `pnpm settings` agree on
+ * what "a pnpm repo" means.
+ */
+export async function usesPnpm(dir: string, pkg: Pkg | null): Promise<boolean> {
+	return (
+		(await fs.pathExists(path.join(dir, WORKSPACE_FILE))) ||
+		(await fs.pathExists(path.join(dir, 'pnpm-lock.yaml'))) ||
+		((pkg?.packageManager as string | undefined) ?? '').startsWith('pnpm')
+	)
+}
+
+/**
+ * `packageManager` pins the pnpm that `pnpm/action-setup` resolves (#364). The
+ * generated workflow passes no `version:` input, so a pnpm repo without this
+ * field fails CI at setup — before a single check runs (#372).
+ */
+export async function checkPackageManager(dir: string, pkg: Pkg | null): Promise<CheckResult> {
+	const check = 'packageManager'
+	if (!(await usesPnpm(dir, pkg))) {
+		return { check, status: 'ok', detail: 'not a pnpm repo' }
+	}
+	const declared = (pkg?.packageManager as string | undefined) ?? ''
+	if (declared.trim() !== '') {
+		return { check, status: 'ok', detail: `packageManager = ${declared}` }
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: 'packageManager not set in package.json',
+		hint: `Run \`npx ${PACKAGE} fix engines\` to pin the pnpm version CI resolves`,
+	}
+}
+
 export function checkEnginesNode(pkg: Pkg | null): CheckResult {
 	if (!pkg) {
 		return {
@@ -921,11 +957,7 @@ export async function checkPnpmWorkspace(dir: string, pkg: Pkg | null): Promise<
 	const hint = `Run \`npx ${PACKAGE} fix pnpm-workspace\` to merge them in`
 	const file = path.join(dir, WORKSPACE_FILE)
 	const exists = await fs.pathExists(file)
-	const usesPnpm =
-		exists ||
-		(await fs.pathExists(path.join(dir, 'pnpm-lock.yaml'))) ||
-		((pkg?.packageManager as string | undefined) ?? '').startsWith('pnpm')
-	if (!usesPnpm) {
+	if (!(await usesPnpm(dir, pkg))) {
 		return { check, status: 'ok', detail: 'not a pnpm repo' }
 	}
 

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -28,6 +28,7 @@ import {
 	generateVscodeExtensions,
 } from '../../cli/generators/misc.js'
 import { scriptsOf } from './ci.js'
+import { usesPnpm } from './checks.js'
 import { composeVerifyScriptFromPkg, ensureScripts } from '../../cli/generators/package-json.js'
 
 /** Kept in step with the biome branch of getScripts() in package-json.ts. */
@@ -507,14 +508,22 @@ export const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'engines',
-		description: 'Add engines.node to package.json',
-		appliesTo: ['engines.node'],
-		outputs: ['package.json (engines.node field)'],
+		description: 'Add engines.node and packageManager to package.json',
+		appliesTo: ['engines.node', 'packageManager'],
+		outputs: ['package.json (engines.node + packageManager fields)'],
 		riskLevel: 'safe-merge',
 		canFixDrift: true,
-		async run({ targetDir }) {
-			const result = await ensureEnginesNode(targetDir)
-			return { filesWritten: result === 'added' ? ['package.json'] : [] }
+		async run({ targetDir, pkg }) {
+			// Same concern as engines.node — declaring the toolchain the repo
+			// expects. `fix github-actions` also pins it, but only reaches repos
+			// whose ci.yml is already drifted (#372). Guarded on pnpm because the
+			// value we write is a pnpm range; an npm or yarn repo must not get one.
+			const engines = await ensureEnginesNode(targetDir)
+			const manager = (await usesPnpm(targetDir, pkg))
+				? await ensurePackageManager(targetDir)
+				: 'already-set'
+			const changed = engines === 'added' || manager === 'added'
+			return { filesWritten: changed ? ['package.json'] : [] }
 		},
 	},
 	{

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -207,6 +207,38 @@ describe('doctor extended checks', () => {
 		expect(engines?.status).toBe('ok')
 	})
 
+	it('reports drift when a pnpm repo has no packageManager', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+		const results = await runDoctor(dir)
+		const pm = results.find((r) => r.check === 'packageManager')
+		expect(pm?.status).toBe('drift')
+		expect(pm?.hint).toMatch(/fix engines/)
+	})
+
+	it('reports ok when packageManager is set', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			version: '0.0.0',
+			packageManager: 'pnpm@11.1.3',
+		})
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'packageManager')?.status).toBe('ok')
+	})
+
+	// Not applicable rather than drift: an npm or yarn repo has no pnpm version
+	// to pin, and inventing one would be noise.
+	it('reports ok when the repo does not use pnpm', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const results = await runDoctor(dir)
+		const pm = results.find((r) => r.check === 'packageManager')
+		expect(pm?.status).toBe('ok')
+		expect(pm?.detail).toBe('not a pnpm repo')
+	})
+
 	it('detects .editorconfig and .nvmrc presence', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -361,6 +361,33 @@ describe('fix targeted', () => {
 		expect(pkg.engines.node).toBe('>=24')
 	})
 
+	it('fix engines pins packageManager on a pnpm repo', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+		await fixCommand('engines', { directory: dir, yes: true })
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.packageManager).toMatch(/^pnpm@\d+\.\d+\.\d+$/)
+	})
+
+	it('fix engines leaves an existing packageManager alone', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { packageManager: 'pnpm@9.0.0' })
+		await fixCommand('engines', { directory: dir, yes: true })
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.packageManager).toBe('pnpm@9.0.0')
+	})
+
+	// The value written is a pnpm range, so a repo that installs with npm or
+	// yarn must not get one (#372).
+	it('fix engines does not pin packageManager on a non-pnpm repo', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('engines', { directory: dir, yes: true })
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.packageManager).toBeUndefined()
+	})
+
 	it('fix package-json adds @rtorcato/repo-tooling to devDependencies', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', version: '0.0.0' })


### PR DESCRIPTION
## Approach

Both halves of the issue — they compose: the check names the problem, `fix engines` is the target its hint points at.

1. **Doctor check** `packageManager` in `src/languages/js/checks.ts`. pnpm repo with no pin → `drift`; pinned → `ok`; non-pnpm repo → `ok` ("not a pnpm repo"). Mapped to the `engines` fix target.
2. **`fix engines`** now calls `ensurePackageManager` alongside `ensureEnginesNode` — same concern, and they were already neighbours in `generators/misc.ts`. Description, `appliesTo` and `outputs` widened.

Two notes:

- The call site is guarded on pnpm detection. `ensurePackageManager` writes a `pnpm@` range, and `fix engines` is a general target, so an npm or yarn repo must not get one. The guard is at the call site, not inside the generator — the `github-actions` fixer wants it unconditionally, since the workflow it emits is pnpm-based even in a fresh repo with no lockfile yet.
- The version still comes from the running pnpm, falling back to `PNPM_FALLBACK_VERSION`. Nothing hardcoded at the call site.

`checkPnpmWorkspace` had the pnpm-detection triple inline; extracted as `usesPnpm` so both checks agree on the definition.

## Verification

`pnpm run check`, `tsc --noEmit --project src/cli/tsconfig.json`, `vitest run` — 786 passed, 18 skipped.

New tests: three doctor cases (drift / ok / not applicable) in `tests/cli/commands/doctor.test.ts`, three fix cases (pins on pnpm, leaves an existing value alone, skips a non-pnpm repo) in `tests/cli/commands/fix.test.ts`.

Closes #372