### PR TITLE
fix(doctor): accept an inlined biome preset, not just an extends pointer

### DIFF
--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -40,9 +40,18 @@ export interface FileCheck {
 	candidates: string[]
 	/** Phrased to read after the filename: `.swiftlint.yml ${expected}`. */
 	expected: string
-	matcher: RegExp
+	/**
+	 * A regex over the raw text, or — where presence of a marker isn't enough to
+	 * conclude the config is still ours — a predicate that parses it (#378).
+	 */
+	matcher: RegExp | ((contents: string) => boolean)
 	optional?: boolean
 	hint?: string
+}
+
+/** Applies a `FileCheck` matcher of either form to a file's contents. */
+export function matches(matcher: FileCheck['matcher'], contents: string): boolean {
+	return typeof matcher === 'function' ? matcher(contents) : matcher.test(contents)
 }
 
 export async function checkFile(dir: string, spec: FileCheck): Promise<CheckResult> {
@@ -51,7 +60,7 @@ export async function checkFile(dir: string, spec: FileCheck): Promise<CheckResu
 		if (!(await fs.pathExists(filepath))) continue
 
 		const contents = await fs.readFile(filepath, 'utf-8')
-		if (spec.matcher.test(contents)) {
+		if (matches(spec.matcher, contents)) {
 			return {
 				check: spec.check,
 				status: 'ok',

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -58,17 +58,58 @@ export function evaluateNodeVersion(version: string): CheckResult {
 }
 
 /**
+ * JSONC → object, or null when it genuinely won't parse. `biome.jsonc` is a
+ * declared candidate and the format allows comments and trailing commas, so
+ * bare `JSON.parse` would reject configs Biome itself accepts.
+ *
+ * The first alternative consumes whole string literals, so a `//` or `/*`
+ * inside one (a `$schema` URL, most obviously) is never mistaken for a comment.
+ */
+function parseJsonc(text: string): Record<string, any> | null {
+	const withoutComments = text.replace(
+		/("(?:\\.|[^"\\])*")|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+		(_, str: string | undefined) => str ?? ''
+	)
+	try {
+		return JSON.parse(withoutComments.replace(/,(\s*[}\]])/g, '$1')) as Record<string, any>
+	} catch {
+		return null
+	}
+}
+
+const BIOME_PRESET_REF = /@rtorcato\/(?:js|repo)-tooling\/biome/
+
+/**
  * Both shapes of a `biome.json` this package produces (#378): the thin
  * `extends` pointer `fix biome` writes, and the whole preset inlined, which is
  * what `copy biome` drops — it carries no `extends` at all, so matching only
  * the first left every `copy biome` repo permanently drifted with no way out.
  *
- * The inline form is recognised by the biomejs `$schema` plus a `preset` key,
- * via lookaheads so key order doesn't matter. A config that is merely valid
- * JSON (`{"linter":{"enabled":false}}`) has neither and still reports drift.
+ * Read structurally, not as text. Accepting the inline form on the presence of
+ * a `$schema` URL and a `preset` key alone would pass a config that keeps both
+ * markers and turns the linter off — the very drift this check exists to catch
+ * — and the markers could even sit in a `biome.jsonc` comment. So the config is
+ * parsed, `linter.enabled: false` disqualifies either shape, and anything
+ * unparseable counts as drift rather than being waved through.
  */
-const BIOME_CONFIG =
-	/@rtorcato\/(?:js|repo)-tooling\/biome|^(?=[\s\S]*biomejs\.dev\/schemas\/)(?=[\s\S]*"preset"\s*:)/
+function matchesBiomeConfig(contents: string): boolean {
+	const config = parseJsonc(contents)
+	if (!config) return false
+
+	const linter = config.linter as { enabled?: unknown; rules?: Record<string, unknown> } | undefined
+	if (linter?.enabled === false) return false
+
+	if (BIOME_PRESET_REF.test(JSON.stringify(config.extends ?? ''))) return true
+
+	// The inlined preset: biome's own `$schema` plus the `linter.rules.preset`
+	// key the shipped `tooling/biome/biome.json` sets.
+	const schema = config.$schema
+	return (
+		typeof schema === 'string' &&
+		schema.includes('biomejs.dev/schemas/') &&
+		linter?.rules?.preset !== undefined
+	)
+}
 
 export const FILE_CHECKS: FileCheck[] = [
 	{
@@ -81,8 +122,8 @@ export const FILE_CHECKS: FileCheck[] = [
 	{
 		check: 'Biome',
 		candidates: ['biome.json', 'biome.jsonc'],
-		expected: `extends "${PACKAGE}/biome" or inlines the preset`,
-		matcher: BIOME_CONFIG,
+		expected: `extends "${PACKAGE}/biome" or inlines the preset, with the linter on`,
+		matcher: matchesBiomeConfig,
 		optional: true,
 		hint: 'Run `npx @rtorcato/repo-tooling fix biome` to scaffold',
 	},

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -57,6 +57,19 @@ export function evaluateNodeVersion(version: string): CheckResult {
 	}
 }
 
+/**
+ * Both shapes of a `biome.json` this package produces (#378): the thin
+ * `extends` pointer `fix biome` writes, and the whole preset inlined, which is
+ * what `copy biome` drops — it carries no `extends` at all, so matching only
+ * the first left every `copy biome` repo permanently drifted with no way out.
+ *
+ * The inline form is recognised by the biomejs `$schema` plus a `preset` key,
+ * via lookaheads so key order doesn't matter. A config that is merely valid
+ * JSON (`{"linter":{"enabled":false}}`) has neither and still reports drift.
+ */
+const BIOME_CONFIG =
+	/@rtorcato\/(?:js|repo)-tooling\/biome|^(?=[\s\S]*biomejs\.dev\/schemas\/)(?=[\s\S]*"preset"\s*:)/
+
 export const FILE_CHECKS: FileCheck[] = [
 	{
 		check: 'TypeScript',
@@ -68,11 +81,9 @@ export const FILE_CHECKS: FileCheck[] = [
 	{
 		check: 'Biome',
 		candidates: ['biome.json', 'biome.jsonc'],
-		expected: `extends "${PACKAGE}/biome"`,
-		matcher: /@rtorcato\/(?:js|repo)-tooling\/biome/,
+		expected: `extends "${PACKAGE}/biome" or inlines the preset`,
+		matcher: BIOME_CONFIG,
 		optional: true,
-		// `fix biome`, not `copy biome`: copy drops the whole preset inline, which
-		// carries no `extends` for the matcher above to find (#365).
 		hint: 'Run `npx @rtorcato/repo-tooling fix biome` to scaffold',
 	},
 	{

--- a/src/languages/python/checks.ts
+++ b/src/languages/python/checks.ts
@@ -18,7 +18,7 @@
  */
 import path from 'node:path'
 import fs from 'fs-extra'
-import { type FileCheck, type GitHooksProfile, checkFile } from '../../base/checks.js'
+import { type FileCheck, type GitHooksProfile, checkFile, matches } from '../../base/checks.js'
 import type { CheckResult } from '../../base/types.js'
 import { PYTHON_GITIGNORE_SENTINELS } from './gitignore.js'
 import { PYTHON_HOOKS_DIR } from './git-hooks.js'
@@ -88,7 +88,7 @@ async function checkPythonTool(dir: string, spec: PythonToolCheck): Promise<Chec
 	for (const candidate of spec.shared) {
 		const filepath = path.join(dir, candidate)
 		if (!(await fs.pathExists(filepath))) continue
-		if (spec.dedicated.matcher.test(await fs.readFile(filepath, 'utf-8'))) {
+		if (matches(spec.dedicated.matcher, await fs.readFile(filepath, 'utf-8'))) {
 			return {
 				check: spec.dedicated.check,
 				status: 'ok',

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../src/cli/commands/doctor.js'
 import { checkBuildApprovals, pnpmStoreDirToName } from '../../../src/languages/js/checks.js'
 import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
+import { copyPreset } from '../../../src/cli/utils/copy-preset.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -125,6 +126,27 @@ describe('doctor', () => {
 		const eslint = results.find((r) => r.check === 'ESLint')
 		expect(biome?.status).toBe('ok')
 		expect(eslint?.status).toBe('ok')
+	})
+
+	// #378: `copy biome` writes the preset inline, with no `extends` to match,
+	// so the repo was reported as drifted forever — re-running `copy` wrote the
+	// same file again.
+	it('reports ok for the biome.json `copy biome` writes', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await copyPreset('biome', dir)
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Biome')?.status).toBe('ok')
+	})
+
+	it('still reports drift for a biome.json that is neither a pointer nor the preset', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'biome.json'), { linter: { enabled: false } })
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Biome')?.status).toBe('drift')
 	})
 
 	it('summarize tallies statuses correctly', async () => {

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -115,7 +115,12 @@ describe('doctor', () => {
 	it('detects biome.jsonc and eslint configs that import our presets', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await fs.writeFile(join(dir, 'biome.jsonc'), '{ "extends": ["@rtorcato/repo-tooling/biome"] }\n')
+		// The comment is the point: biome.jsonc is a candidate, so the matcher has
+		// to tolerate what the format allows rather than assume strict JSON.
+		await fs.writeFile(
+			join(dir, 'biome.jsonc'),
+			'// shared preset\n{ "extends": ["@rtorcato/repo-tooling/biome"] }\n'
+		)
 		await fs.writeFile(
 			join(dir, 'eslint.config.mjs'),
 			"export { default } from '@rtorcato/repo-tooling/eslint/base'\n"
@@ -144,6 +149,30 @@ describe('doctor', () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await fs.writeJson(join(dir, 'biome.json'), { linter: { enabled: false } })
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Biome')?.status).toBe('drift')
+	})
+
+	// Keeping the preset's markers while switching the linter off is exactly the
+	// drift this check exists to catch, so the shape has to be parsed rather than
+	// scanned for `$schema` / `preset` as text.
+	it('reports drift for a preset-shaped biome.json with the linter disabled', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'biome.json'), {
+			$schema: 'https://biomejs.dev/schemas/2.5.0/schema.json',
+			linter: { enabled: false, rules: { preset: 'recommended' } },
+		})
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'Biome')?.status).toBe('drift')
+	})
+
+	it('reports drift for a biome.json that is too corrupt to parse', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(join(dir, 'biome.json'), '{ "extends": ["@rtorcato/repo-tooling/biome"')
 
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Biome')?.status).toBe('drift')


### PR DESCRIPTION
## Approach

Took the **preferred** option from the issue: the `Biome` doctor check now
accepts an inlined preset as well as an `extends` pointer. `copy biome` is
untouched — it still copies the real preset file, like every other entry in
`PRESETS`. The alternative (making `copy biome` emit a thin pointer) was not
implemented; only one path changed.

## What changed

`src/languages/js/checks.ts` — the `Biome` check's matcher is now
`BIOME_CONFIG`, which matches either:

- `@rtorcato/(js|repo)-tooling/biome` — the pointer `fix biome` writes; or
- the biomejs `$schema` **and** a `"preset":` key — the shape `copy biome`
  drops inline.

The second alternative uses two lookaheads rather than a sequence, so a
reformatted or key-reordered config still matches. `expected` now reads
`extends "@rtorcato/repo-tooling/biome" or inlines the preset`, and the stale
comment explaining why the hint says `fix biome` instead of `copy biome` is
gone — both are valid now.

## The check can still fail

Three cases, all covered by tests in `tests/cli/commands/doctor.test.ts`:

| `biome.json` | status |
|---|---|
| verbatim `copy biome` output (via `copyPreset('biome', dir)`) | `ok` (new test) |
| thin `extends` pointer | `ok` (existing test, still passing) |
| `{"linter":{"enabled":false}}` | `drift` (new test) |

The first test copies the real shipped preset rather than a fixture, so it
keeps tracking `tooling/biome/biome.json` if that file changes.

## Verification

`pnpm run check`, `tsc --noEmit --project src/cli/tsconfig.json`, and
`vitest run` (799 passed, 18 skipped) all pass.

## Noted, not fixed

`copy tsconfig` writes `tooling/typescript/tsconfig.base.json`, which likewise
carries no `@rtorcato/.../typescript/` string, so the `TypeScript` check has
the same shape of problem. Left alone — out of scope for this issue.

Closes #378
