### PR TITLE
fix(js): add the scripts that run knip, vitest and tsc

### DIFF
--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -49,6 +49,25 @@ const ESLINT_SCRIPTS: Record<string, string> = {
 const PRETTIER_SCRIPTS: Record<string, string> = {
 	format: 'prettier --write .',
 }
+
+/** Kept in step with the knip line of getScripts() in package-json.ts. */
+const KNIP_SCRIPTS: Record<string, string> = {
+	knip: 'knip',
+}
+
+/** Kept in step with the typescript branch of getScripts() in package-json.ts. */
+const TSCONFIG_SCRIPTS: Record<string, string> = {
+	typecheck: 'tsc --noEmit',
+}
+
+// getScripts() also emits `test:ui`, but only the browser/both environments
+// install @vitest/ui, so a fixed-up repo would get a script it can't run.
+/** Kept in step with the vitest branch of getScripts() in package-json.ts. */
+const VITEST_SCRIPTS: Record<string, string> = {
+	test: 'vitest',
+	'test:watch': 'vitest --watch',
+	coverage: 'vitest run --coverage',
+}
 import {
 	WORKSPACE_FILE,
 	dependsOnEsbuild,
@@ -181,13 +200,19 @@ export const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'tsconfig',
-		description: 'Scaffold tsconfig.json extending the @rtorcato/repo-tooling preset',
+		description:
+			'Scaffold tsconfig.json extending the @rtorcato/repo-tooling preset, plus the `typecheck` script',
 		appliesTo: ['TypeScript'],
-		outputs: ['tsconfig.json'],
+		outputs: ['tsconfig.json', 'package.json (scripts)'],
 		canFixDrift: true,
 		async run({ targetDir }) {
 			const result = await copyPreset('tsconfig', targetDir)
-			return { filesWritten: [result.target] }
+			const filesWritten = [result.target]
+			// Without `typecheck` the generated CI drops its typecheck job entirely
+			// (#377). Shared with non-JS paths, so this is a no-op when there's no
+			// package.json to add it to.
+			if (await ensureScripts(targetDir, TSCONFIG_SCRIPTS)) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{
@@ -221,9 +246,10 @@ export const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'vitest',
-		description: 'Scaffold vitest.config.ts (preserves vitest.setup.ts if present)',
+		description:
+			'Scaffold vitest.config.ts (preserves vitest.setup.ts if present), plus the scripts that run it',
 		appliesTo: ['Vitest'],
-		outputs: ['vitest.config.ts'],
+		outputs: ['vitest.config.ts', 'package.json (scripts)'],
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
 			const setupPath = path.join(targetDir, 'vitest.setup.ts')
@@ -233,7 +259,11 @@ export const FIXERS: Fixer[] = [
 			if (hadSetup && savedSetup !== null) {
 				await fs.writeFile(setupPath, savedSetup)
 			}
-			return { filesWritten: ['vitest.config.ts'] }
+			const filesWritten = ['vitest.config.ts']
+			// Without `coverage`/`test` the generated CI drops the whole test job,
+			// Codecov upload included (#377).
+			if (await ensureScripts(targetDir, VITEST_SCRIPTS)) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{
@@ -546,13 +576,18 @@ export const FIXERS: Fixer[] = [
 	},
 	{
 		target: 'knip',
-		description: 'Scaffold knip.json (entry globs matched to the package.json build model)',
+		description:
+			'Scaffold knip.json (entry globs matched to the package.json build model), plus the `knip` script',
 		appliesTo: ['knip'],
-		outputs: ['knip.json'],
+		outputs: ['knip.json', 'package.json (scripts)'],
 		canFixDrift: true,
 		async run({ targetDir }) {
 			await generateKnipConfig(targetDir)
-			return { filesWritten: ['knip.json'] }
+			const filesWritten = ['knip.json']
+			// Without `knip` the generated CI drops its unused-code step, and with no
+			// check/lint script either the whole lint job disappears (#377).
+			if (await ensureScripts(targetDir, KNIP_SCRIPTS)) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1299,6 +1299,59 @@ describe('fix eslint/prettier scripts', () => {
 	})
 })
 
+// #377: the same gap on the three targets whose scripts the generated CI calls
+// — no script means the step (or the whole job) silently disappears.
+describe('fix knip/tsconfig/vitest scripts', () => {
+	it('adds the `knip` script, without touching an existing one', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('knip', { directory: dir, yes: true })
+
+		expect((await fs.readJson(join(dir, 'package.json'))).scripts.knip).toBe('knip')
+
+		await seedPackageJson(dir, { scripts: { knip: 'my own knip' } })
+		await fixCommand('knip', { directory: dir, yes: true })
+
+		expect((await fs.readJson(join(dir, 'package.json'))).scripts.knip).toBe('my own knip')
+	})
+
+	it('adds the `typecheck` script, without touching an existing one', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		expect((await fs.readJson(join(dir, 'package.json'))).scripts.typecheck).toBe('tsc --noEmit')
+
+		await seedPackageJson(dir, { scripts: { typecheck: 'my own typecheck' } })
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		expect((await fs.readJson(join(dir, 'package.json'))).scripts.typecheck).toBe(
+			'my own typecheck'
+		)
+	})
+
+	// tsconfig is shared with non-JS paths, so it has to survive a repo that has
+	// no package.json to add the script to.
+	it('still writes tsconfig.json when there is no package.json', async () => {
+		const dir = newTmpDir()
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		expect(await fs.pathExists(join(dir, 'tsconfig.json'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'package.json'))).toBe(false)
+	})
+
+	it('adds the scripts that run Vitest, without touching existing ones', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { scripts: { test: 'my own test' } })
+		await fixCommand('vitest', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.test).toBe('my own test')
+		expect(pkg.scripts['test:watch']).toBe('vitest --watch')
+		expect(pkg.scripts.coverage).toBe('vitest run --coverage')
+	})
+})
+
 // #364: pnpm/action-setup has no `version:` input, so the workflow needs
 // packageManager or every job dies at setup.
 describe('fix github-actions packageManager', () => {


### PR DESCRIPTION
`fix knip`, `fix vitest` and `fix tsconfig` wrote a config and nothing else, so a repo got a tool it could not invoke. Since #364 the generated CI only emits a step when the script exists, so the failure is silent rather than loud:

- no `knip` script → the unused-code step disappears, and with no `check`/`lint` either the whole `lint` job goes with it
- no `typecheck` script → the `typecheck` job disappears
- no `coverage`/`test` script → the `test` job disappears, Codecov upload included

A repo could end up with a green pipeline that type-checks nothing and tests nothing.

All three targets now call `ensureScripts`, which only fills in names that are missing, so a repo's own commands survive. The commands match `getScripts()` in `src/cli/generators/package-json.ts`.

Two deliberate deviations from the issue text:

- `test:ui` is left out of the vitest set. `getScripts()` emits it, but only the browser/both environments install `@vitest/ui`, so a fixed-up repo would get a script it cannot run.
- `riskLevel` is left alone, as #374 did for biome/eslint/prettier. The issue suggested `safe-merge`, but these fixers still overwrite the config file itself, so that prompt wording ("existing fields preserved") would be wrong and would default a drift overwrite to Yes.

`tsconfig` is shared with non-JS paths. `ensureScripts` returns false when there is no `package.json`, so the target still reports only the `tsconfig.json` it wrote — covered by a test.

## Verification

Four cases in `tests/cli/commands/fix.test.ts`: the `knip`, `typecheck` and vitest scripts land, an existing script of the same name is left untouched, and `fix tsconfig` still writes `tsconfig.json` in a directory with no `package.json`.

`pnpm run check`, `pnpm run typecheck` and `vitest run` (801 passed, 18 skipped) all pass locally.

Closes #377
