### PR TITLE
fix(cli): route fix tsconfig through generateTSConfig

### DIFF
--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -63,7 +63,9 @@ export const FILE_CHECKS: FileCheck[] = [
 		candidates: ['tsconfig.json'],
 		expected: `extends "${PACKAGE}/typescript/*"`,
 		matcher: /@rtorcato\/(?:js|repo)-tooling\/typescript\//,
-		hint: 'Set `"extends": "@rtorcato/repo-tooling/typescript/base"` in tsconfig.json',
+		// `fix tsconfig`, not `copy tsconfig`: copy drops the whole preset inline,
+		// which carries no `extends` for the matcher above to find (#381).
+		hint: 'Run `npx @rtorcato/repo-tooling fix tsconfig` to scaffold',
 	},
 	{
 		check: 'Biome',

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -77,6 +77,7 @@ import {
 import { generatePostcss } from '../../cli/generators/postcss.js'
 import { generateCypressConfig, generateVitestConfig } from '../../cli/generators/testing.js'
 import { generateTreeshakeCheck, inferSubpathsFromExports } from '../../cli/generators/treeshake.js'
+import { generateTSConfig } from '../../cli/generators/tsconfig.js'
 import { generateTailwind } from '../../cli/generators/tailwind.js'
 import { generateTurborepo } from '../../cli/generators/turborepo.js'
 import { generateNx } from '../../cli/generators/nx.js'
@@ -104,7 +105,13 @@ export function inferProjectConfig(pkg: Pkg): ProjectConfig {
 	return {
 		projectName: (pkg?.name as string) ?? 'project',
 		projectType,
-		typescript: { enabled: true, config: projectType === 'nextjs-app' ? 'next' : 'base' },
+		typescript: {
+			enabled: true,
+			// Same mapping the react-app/nextjs-app setup presets use — a react-app on
+			// the base preset has no DOM libs, so `document`/`window` don't typecheck.
+			config:
+				projectType === 'nextjs-app' ? 'next' : projectType === 'react-app' ? 'react' : 'base',
+		},
 		linting: {
 			tool: 'biome',
 			eslintConfig: projectType === 'nextjs-app' ? 'nextjs' : 'base',
@@ -205,9 +212,17 @@ export const FIXERS: Fixer[] = [
 		appliesTo: ['TypeScript'],
 		outputs: ['tsconfig.json', 'package.json (scripts)'],
 		canFixDrift: true,
-		async run({ targetDir }) {
-			const result = await copyPreset('tsconfig', targetDir)
-			const filesWritten = [result.target]
+		async run({ targetDir, pkg }) {
+			// Shares generateTSConfig with the setup path — copyPreset used to inline
+			// the whole base preset, which carries no `extends` for doctor's matcher
+			// and threw away the project-type settings setup emits (#381).
+			const config = inferProjectConfig(pkg)
+			// Bun leaves no package.json trace, so inferProjectConfig can't see it; a
+			// bunfig.toml is the signal, and without it this would strip `types: ['bun']`
+			// off a Bun repo by dropping it back onto the base preset.
+			if (await fs.pathExists(path.join(targetDir, 'bunfig.toml'))) config.bun = true
+			await generateTSConfig(config, targetDir)
+			const filesWritten = ['tsconfig.json']
 			// Without `typecheck` the generated CI drops its typecheck job entirely
 			// (#377). Shared with non-JS paths, so this is a no-op when there's no
 			// package.json to add it to.

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
 import { fixCommand, getFixers, listFixers } from '../../../src/cli/commands/fix.js'
 import {
 	DEPENDABOT_AUTOMERGE_WORKFLOW,
@@ -137,6 +138,64 @@ describe('fix bun', () => {
 		await seedPackageJson(dir)
 		await fixCommand('bun', { directory: dir, yes: true })
 		expect(await fs.pathExists(join(dir, 'bunfig.toml'))).toBe(true)
+		expect((await fs.readJson(join(dir, 'tsconfig.json'))).extends).toBe(
+			'@rtorcato/repo-tooling/typescript/bun'
+		)
+	})
+})
+
+// #381: `fix tsconfig` used to copy the base preset inline — no `extends` for
+// doctor's TypeScript matcher, and none of the project-type settings setup emits.
+describe('fix tsconfig', () => {
+	it('writes an extends pointer doctor reads as ok', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		expect((await fs.readJson(join(dir, 'tsconfig.json'))).extends).toBe(
+			'@rtorcato/repo-tooling/typescript/base'
+		)
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'TypeScript')?.status).toBe('ok')
+	})
+
+	it('keeps the library outDir/rootDir', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		const tsconfig = await fs.readJson(join(dir, 'tsconfig.json'))
+		expect(tsconfig.compilerOptions.outDir).toBe('./dist')
+		expect(tsconfig.compilerOptions.rootDir).toBe('./src')
+	})
+
+	it('carries the Next wiring on a Next.js app', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { dependencies: { next: '^15.0.0' } })
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		const tsconfig = await fs.readJson(join(dir, 'tsconfig.json'))
+		expect(tsconfig.extends).toBe('@rtorcato/repo-tooling/typescript/next')
+		expect(tsconfig.include).toContain('next-env.d.ts')
+		expect(tsconfig.exclude).toContain('.next')
+	})
+
+	it('uses the react preset on a React app, for the DOM libs', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { dependencies: { 'react-dom': '^19.0.0' } })
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
+		expect((await fs.readJson(join(dir, 'tsconfig.json'))).extends).toBe(
+			'@rtorcato/repo-tooling/typescript/react'
+		)
+	})
+
+	it('keeps a Bun repo on the Bun-typed preset', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(join(dir, 'bunfig.toml'), '[install]\n')
+		await fixCommand('tsconfig', { directory: dir, yes: true })
+
 		expect((await fs.readJson(join(dir, 'tsconfig.json'))).extends).toBe(
 			'@rtorcato/repo-tooling/typescript/bun'
 		)


### PR DESCRIPTION
`fix tsconfig` copied `tooling/typescript/tsconfig.base.json` inline. That file carries no `@rtorcato/repo-tooling/typescript/` string, which is exactly what doctor's `TypeScript` matcher looks for — so the fix could never clear the check it was offered for, and it discarded every project-type setting `setup` emits.

The target now builds a `ProjectConfig` with `inferProjectConfig(pkg)` and hands it to `generateTSConfig`, the same routing PR #366 used for `fix biome`. `copy tsconfig` is untouched (#378).

## Two gaps in `inferProjectConfig`, both closed here

- **`typescript.config`** — it mapped `nextjs-app` to `next` and everything else to `base`, so a React app landed on the base preset, whose `lib` is ES2022. `document`/`window` would not typecheck. It now maps `react-app` to `react`, matching the react-app setup preset. `generateTSConfig` is the only consumer of that field.
- **`bun`** — it does not derive it, and cannot: Bun leaves no package.json trace. The fixer reads a `bunfig.toml` in the target dir as the signal, so `fix tsconfig` on a Bun repo keeps the Bun-typed preset instead of stripping `types: ['bun']` off it.

`web-app` never comes out of `inferProjectConfig` (nothing in a package.json distinguishes it from a library), so the `web-app`-on-`base` DOM-lib branch stays unreachable from the fix path. It is reachable from `setup`, where the user picks the type.

The doctor hint for `TypeScript` now points at `fix tsconfig` rather than telling the user to hand-edit `extends`, mirroring what #366 did to the Biome hint.

## Verification

Five tests in `tests/cli/commands/fix.test.ts`, covering the issue's list: the emitted `extends` pointer plus `runDoctor` reporting `TypeScript: ok` straight after; library `outDir`/`rootDir`; Next includes and `.next` exclusion on a repo with `next` in dependencies; the react preset on a repo with `react-dom`; the bun preset when a `bunfig.toml` is present.

`pnpm run check`, `pnpm run typecheck`, and `vitest run` (806 passed, 18 skipped) are green.

Closes #381