### PR TITLE
fix(js): give the size-limit budget a script and a CLI to run it

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -204,7 +204,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `bun` | `bunfig.toml` + a Bun-typed `tsconfig.json` for Bun runtime/test users |
 | `rollup` | `rollup.config.mjs` re-exporting the shared library preset |
 | `rolldown` | `rolldown.config.mjs` re-exporting the shared library preset |
-| `size-limit` | a size-limit budget (`.size-limit.cjs`/`.json`) |
+| `size-limit` | a size-limit budget (`.size-limit.cjs`/`.json`), plus the `size-limit` script and devDependency that run it |
 | `treeshake-check` | `apps/treeshake-check` — esbuild + metafile bundle assertion |
 | `pnpm-workspace` | merges the family-wide pnpm settings into `pnpm-workspace.yaml` (`verifyDepsBeforeRun`, `minimumReleaseAgeExclude`, esbuild's build approval) — never rewrites the file |
 | `turborepo` | `turbo.json` task pipeline (pnpm-workspace monorepos) |

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -231,6 +231,9 @@ export function computeFileList(config: ProjectConfig): string[] {
 	if (config.typescript.enabled) {
 		files.push('tsconfig.json', 'reset.d.ts')
 	}
+	// Libraries get a bundle-size budget plus the `size-limit` script that runs it
+	// (#382). The scaffold's exports are root-only, so it's always the static form.
+	if (config.projectType === 'library') files.push('.size-limit.json')
 	if (config.linting.tool === 'biome' || config.linting.tool === 'both') {
 		files.push(BIOME_CONFIG)
 	}

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -9,7 +9,12 @@ import { ensurePnpmSettings, familyGlob } from './pnpm-workspace.js'
 import { generateGitConfigs } from './git.js'
 import { generateGitHubActions } from './github-actions.js'
 import { generateLintingConfigs } from './linting.js'
-import { generateKnipConfig, generateMiscBaseline, generateVscodeExtensions } from './misc.js'
+import {
+	generateKnipConfig,
+	generateMiscBaseline,
+	generateSizeLimitConfig,
+	generateVscodeExtensions,
+} from './misc.js'
 import { generatePackageJson } from './package-json.js'
 import { generateReadme } from './readme.js'
 import { generateSecurityConfigs } from './security.js'
@@ -38,6 +43,13 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 
 	// Universal baseline: .editorconfig, .nvmrc, engines.node, knip.json
 	await generateMiscBaseline(targetDir)
+
+	// Bundle-size budget for publishable libraries. getScripts() emits the
+	// matching `size-limit` script, so the budget is runnable from the first
+	// commit rather than an inert file implying enforcement (#382).
+	if (config.projectType === 'library') {
+		await generateSizeLimitConfig(targetDir)
+	}
 
 	// Recommend the editor extensions matching the enabled tools
 	await generateVscodeExtensions(config, targetDir)

--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -155,6 +155,10 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
 	// profile fits the dual (cjs+esm) exports the library scaffold emits.
 	if (config.projectType === 'library') {
 		scripts['attw'] = 'attw --pack'
+		// The budget scaffolded alongside it (generateConfigs) is inert without a
+		// way to run it — a size budget nothing runs implies an enforcement that
+		// isn't there (#382).
+		Object.assign(scripts, SIZE_LIMIT_SCRIPTS)
 	}
 
 	// Git hooks
@@ -189,6 +193,16 @@ function getScripts(config: ProjectConfig, opts: GetScriptsOptions = {}): Record
  * refused to compose a chain, both because no target ever created that script
  * (#364).
  */
+/**
+ * The one definition of the `size-limit` script, shared by `getScripts()` (setup)
+ * and the `size-limit` fixer, so the two paths can't drift (#382 — the divergence
+ * behind #371 and #377).
+ */
+export const SIZE_LIMIT_SCRIPTS: Record<string, string> = { 'size-limit': 'size-limit' }
+
+/** Shared by the same two paths, for the same reason. */
+export const SIZE_LIMIT_VERSION = '^11.2.0'
+
 export async function ensureScripts(
 	targetDir: string,
 	scripts: Record<string, string>
@@ -367,8 +381,11 @@ function getDependencies(config: ProjectConfig): Record<string, string> {
 	}
 
 	// are-the-types-wrong — validate published type resolution for libraries.
+	// size-limit enforces the bundle-size budget scaffolded next to it; without
+	// the dependency the script dies with "command not found" (#382).
 	if (config.projectType === 'library') {
 		deps['@arethetypeswrong/cli'] = '^0.18.2'
+		deps['size-limit'] = SIZE_LIMIT_VERSION
 	}
 
 	// Commit linting (enforcement) + commitizen (assistance)

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -29,7 +29,12 @@ import {
 } from '../../cli/generators/misc.js'
 import { scriptsOf } from './ci.js'
 import { usesPnpm } from './checks.js'
-import { composeVerifyScriptFromPkg, ensureScripts } from '../../cli/generators/package-json.js'
+import {
+	SIZE_LIMIT_SCRIPTS,
+	SIZE_LIMIT_VERSION,
+	composeVerifyScriptFromPkg,
+	ensureScripts,
+} from '../../cli/generators/package-json.js'
 
 /** Kept in step with the biome branch of getScripts() in package-json.ts. */
 const BIOME_SCRIPTS: Record<string, string> = {
@@ -53,6 +58,25 @@ const PRETTIER_SCRIPTS: Record<string, string> = {
 /** Kept in step with the knip line of getScripts() in package-json.ts. */
 const KNIP_SCRIPTS: Record<string, string> = {
 	knip: 'knip',
+}
+
+/**
+ * Add `size-limit` to devDependencies unless the repo already pins it (either
+ * dependency list). Returns true when package.json was written.
+ */
+async function ensureSizeLimitDependency(targetDir: string): Promise<boolean> {
+	const pkgPath = path.join(targetDir, 'package.json')
+	if (!(await fs.pathExists(pkgPath))) return false
+
+	const pkg = (await fs.readJson(pkgPath)) as Record<string, unknown>
+	const deps = (pkg.dependencies as Record<string, string> | undefined) ?? {}
+	const devDeps = { ...((pkg.devDependencies as Record<string, string> | undefined) ?? {}) }
+	if (devDeps['size-limit'] || deps['size-limit']) return false
+
+	devDeps['size-limit'] = SIZE_LIMIT_VERSION
+	pkg.devDependencies = devDeps
+	await fs.writeJson(pkgPath, pkg, { spaces: 2 })
+	return true
 }
 
 /** Kept in step with the typescript branch of getScripts() in package-json.ts. */
@@ -593,13 +617,22 @@ export const FIXERS: Fixer[] = [
 	{
 		target: 'size-limit',
 		description:
-			'Scaffold a size-limit budget — exports-driven .size-limit.cjs for multi-subpath libraries, else a static .size-limit.json',
+			'Scaffold a size-limit budget — exports-driven .size-limit.cjs for multi-subpath libraries, else a static .size-limit.json — plus the `size-limit` script and devDependency',
 		appliesTo: ['size-limit'],
-		outputs: ['.size-limit.cjs', '.size-limit.json'],
+		outputs: ['.size-limit.cjs', '.size-limit.json', 'package.json (devDependencies + scripts)'],
+		// safe-merge: installs the CLI and only fills in a missing script.
+		riskLevel: 'safe-merge',
 		canFixDrift: true,
 		async run({ targetDir }) {
 			const written = await generateSizeLimitConfig(targetDir)
-			return { filesWritten: [written] }
+			const filesWritten = [written]
+			// A budget with nothing to run it is worse than no budget — the file's
+			// presence implies an enforcement that isn't there (#382). The script
+			// needs the CLI installed too, or it dies with "command not found".
+			const installed = await ensureSizeLimitDependency(targetDir)
+			const scripted = await ensureScripts(targetDir, SIZE_LIMIT_SCRIPTS)
+			if (installed || scripted) filesWritten.push('package.json')
+			return { filesWritten }
 		},
 	},
 	{

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -4,6 +4,10 @@ import inquirer from 'inquirer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fixCommand, getFixers, listFixers } from '../../../src/cli/commands/fix.js'
 import {
+	SIZE_LIMIT_VERSION,
+	generatePackageJson,
+} from '../../../src/cli/generators/package-json.js'
+import {
 	DEPENDABOT_AUTOMERGE_WORKFLOW,
 	DEPENDABOT_CONFIG,
 } from '../../../src/cli/generators/security.js'
@@ -1349,6 +1353,64 @@ describe('fix knip/tsconfig/vitest scripts', () => {
 		expect(pkg.scripts.test).toBe('my own test')
 		expect(pkg.scripts['test:watch']).toBe('vitest --watch')
 		expect(pkg.scripts.coverage).toBe('vitest run --coverage')
+	})
+})
+
+// #382: the budget was scaffolded with no script and no CLI to run it, so its
+// presence implied an enforcement that wasn't there.
+describe('fix size-limit', () => {
+	it('adds the `size-limit` script and devDependency alongside the budget', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fixCommand('size-limit', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(await fs.pathExists(join(dir, '.size-limit.json'))).toBe(true)
+		expect(pkg.scripts['size-limit']).toBe('size-limit')
+		expect(pkg.devDependencies['size-limit']).toBe(SIZE_LIMIT_VERSION)
+	})
+
+	it('leaves an existing script and pin alone', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, {
+			scripts: { 'size-limit': 'size-limit --why' },
+			devDependencies: { 'size-limit': '^10.0.0' },
+		})
+		await fixCommand('size-limit', { directory: dir, yes: true })
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts['size-limit']).toBe('size-limit --why')
+		expect(pkg.devDependencies['size-limit']).toBe('^10.0.0')
+	})
+
+	// The divergence between getScripts() and the fixers is the root cause behind
+	// #371 and #377 — assert the two paths emit the same command.
+	it('emits the same command as the setup path', async () => {
+		const setupDir = newTmpDir()
+		await generatePackageJson(
+			{
+				projectName: 'lib',
+				projectType: 'library',
+				typescript: { enabled: false, config: 'base' },
+				linting: { tool: 'none' },
+				formatting: { tool: 'none' },
+				testing: { framework: 'none' },
+				gitHooks: false,
+				commitLint: false,
+				semanticRelease: false,
+				bundler: 'none',
+			},
+			setupDir
+		)
+
+		const fixDir = newTmpDir()
+		await seedPackageJson(fixDir)
+		await fixCommand('size-limit', { directory: fixDir, yes: true })
+
+		const setupPkg = await fs.readJson(join(setupDir, 'package.json'))
+		const fixPkg = await fs.readJson(join(fixDir, 'package.json'))
+		expect(setupPkg.scripts['size-limit']).toBe(fixPkg.scripts['size-limit'])
+		expect(setupPkg.devDependencies['size-limit']).toBe(fixPkg.devDependencies['size-limit'])
 	})
 })
 

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -10,9 +10,30 @@ import {
 	PRESET_NAMES,
 	validateProjectConfig,
 } from '../../../src/cli/commands/setup-presets.js'
+import { generateConfigs } from '../../../src/cli/generators/index.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
+
+// #382: computeFileList is a promise about what generateConfigs writes — the
+// budget has to actually land, or the `size-limit` script has nothing to run.
+describe('generateConfigs size-limit budget', () => {
+	it('writes the budget for a library and nothing for an app', async () => {
+		const libDir = newTmpDir()
+		await generateConfigs(
+			{ ...buildPresetConfig('library', 'demo'), aiSetup: false, securityAutomation: false },
+			libDir
+		)
+		expect(await fs.pathExists(join(libDir, '.size-limit.json'))).toBe(true)
+
+		const appDir = newTmpDir()
+		await generateConfigs(
+			{ ...buildPresetConfig('react-app', 'demo'), aiSetup: false, securityAutomation: false },
+			appDir
+		)
+		expect(await fs.pathExists(join(appDir, '.size-limit.json'))).toBe(false)
+	})
+})
 
 describe('setup-presets', () => {
 	it('builds a valid config for every preset', () => {
@@ -117,6 +138,14 @@ describe('computeFileList', () => {
 		expect(files).toContain('tsup.config.ts')
 		expect(files).toContain('release.config.mjs')
 		expect(files).toContain('.github/dependabot.yml')
+	})
+
+	// #382: the `size-limit` script getScripts() emits needs a budget to run on.
+	it('lists the size-limit budget for libraries only', () => {
+		expect(computeFileList(buildPresetConfig('library', 'demo'))).toContain('.size-limit.json')
+		expect(computeFileList(buildPresetConfig('react-app', 'demo'))).not.toContain(
+			'.size-limit.json'
+		)
 	})
 
 	it('omits release.config.mjs for non-library presets', () => {

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -267,6 +267,7 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "commit": "cz",
     "knip": "knip",
     "attw": "attw --pack",
+    "size-limit": "size-limit",
     "prepare": "husky",
     "release": "semantic-release",
     "verify": "pnpm typecheck && pnpm check && pnpm exec vitest run && pnpm attw"
@@ -284,6 +285,7 @@ exports[`generator output snapshots > package.json (library) 1`] = `
     "husky": "^9.0.0",
     "lint-staged": "^16.0.0",
     "@arethetypeswrong/cli": "^0.18.2",
+    "size-limit": "^11.2.0",
     "@commitlint/cli": "^20.0.0",
     "@commitlint/config-conventional": "^20.0.0",
     "commitizen": "^4.3.1",

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import {
+	SIZE_LIMIT_VERSION,
 	composeVerifyScript,
 	composeVerifyScriptFromPkg,
 	generatePackageJson,
@@ -99,6 +100,23 @@ describe('generatePackageJson', () => {
 		const pkg = await fs.readJson(join(dir, 'package.json'))
 		expect(pkg.scripts.attw).toBeUndefined()
 		expect(pkg.devDependencies['@arethetypeswrong/cli']).toBeUndefined()
+	})
+
+	// #382: the budget the library scaffold writes needs a way to run it.
+	it('wires the size-limit script + dependency for library projects only', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(baseConfig({ projectType: 'library' }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts['size-limit']).toBe('size-limit')
+		expect(pkg.devDependencies['size-limit']).toBe(SIZE_LIMIT_VERSION)
+
+		const appDir = newTmpDir()
+		await generatePackageJson(baseConfig({ projectType: 'react-app' }), appDir)
+
+		const appPkg = await fs.readJson(join(appDir, 'package.json'))
+		expect(appPkg.scripts['size-limit']).toBeUndefined()
+		expect(appPkg.devDependencies['size-limit']).toBeUndefined()
 	})
 
 	it('adds library fields for library project type', async () => {


### PR DESCRIPTION
`fix size-limit` wrote `.size-limit.cjs`/`.size-limit.json` and stopped, and `getScripts()` never emitted a script on the `setup` path either — so no path in the tool produced a way to run the budget. A budget nothing runs is worse than no budget: the file's presence implies an enforcement that isn't there.

## What changed

- **Fixer** (`src/languages/js/fixers.ts`): after scaffolding the budget it installs `size-limit` and fills in a missing `size-limit` script via `ensureScripts` — an existing script or pin is left alone. `outputs` now mentions `package.json (devDependencies + scripts)` and `riskLevel` is `safe-merge`.
- **Setup** (`getScripts()` / `getDependencies()`): libraries get the same script and devDependency, gated exactly like `attw`.
- **Setup, cont.**: `generateConfigs` now writes the budget for libraries, and `computeFileList` lists `.size-limit.json`. Without this the script `getScripts()` emits would have nothing to run — the same half-wired state on the other side of the fence.
- The command string and the version range are defined once (`SIZE_LIMIT_SCRIPTS`, `SIZE_LIMIT_VERSION` in `src/cli/generators/package-json.ts`) and shared by both paths, so they can't drift the way #371 and #377 did.

Wiring `size-limit` into the `verify` chain is deliberately **not** done — out of scope per the issue.

## Tests

- `fix size-limit` adds the script + devDependency alongside the budget.
- An existing `size-limit` script and pin survive a re-run.
- A parity test asserting `getScripts()` and the fixer emit the same command and the same range.
- `computeFileList` and `generateConfigs` agree on the budget, for libraries only.

`pnpm run check`, `tsc --noEmit -p src/cli/tsconfig.json` and `vitest run` (825 passed) are green.

Closes #382