### PR TITLE
fix(doctor): accept an inlined TypeScript preset

### DIFF
--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -111,14 +111,60 @@ function matchesBiomeConfig(contents: string): boolean {
 	)
 }
 
+const TS_PRESET_REF = /@rtorcato\/(?:js|repo)-tooling\/typescript\//
+
+/**
+ * Options `tooling/typescript/tsconfig.base.json` sets that a tsconfig written
+ * by hand is unlikely to carry all of. `strict` alone is far too common to
+ * conclude anything from.
+ */
+const TS_PRESET_STRICTNESS = [
+	'strict',
+	'noUncheckedIndexedAccess',
+	'noImplicitOverride',
+	'noPropertyAccessFromIndexSignature',
+] as const
+
+/**
+ * The same two shapes as `matchesBiomeConfig`, for the same reason (#385): the
+ * `extends` pointer `fix tsconfig` writes, and the whole preset inlined, which
+ * is what `copy tsconfig` drops — `tooling/typescript/tsconfig.base.json` *is*
+ * the preset, so it names it nowhere, and every `copy tsconfig` repo was
+ * reported as drifted with no way out. This check isn't optional, so that read
+ * as a real problem rather than an optional one.
+ *
+ * Structural rather than textual, and for the same reason: `strict: false` is
+ * drift whichever shape the config takes, a marker sitting in a comment proves
+ * nothing, and unparseable counts as drift rather than being waved through.
+ */
+function matchesTsConfig(contents: string): boolean {
+	const config = parseJsonc(contents)
+	if (!config) return false
+
+	const compilerOptions = (config.compilerOptions ?? {}) as Record<string, unknown>
+	// Naming the preset and then switching strictness off is precisely the drift
+	// this check exists to catch, so it disqualifies either shape.
+	if (compilerOptions.strict === false) return false
+
+	if (TS_PRESET_REF.test(JSON.stringify(config.extends ?? ''))) return true
+
+	// The inlined preset: a `${configDir}`-anchored rootDir — how a preset meant
+	// to be extended resolves against the consuming repo — plus the strict block
+	// the shipped preset sets.
+	const rootDir = compilerOptions.rootDir
+	return (
+		typeof rootDir === 'string' &&
+		rootDir.includes('${configDir}') &&
+		TS_PRESET_STRICTNESS.every((key) => compilerOptions[key] === true)
+	)
+}
+
 export const FILE_CHECKS: FileCheck[] = [
 	{
 		check: 'TypeScript',
 		candidates: ['tsconfig.json'],
-		expected: `extends "${PACKAGE}/typescript/*"`,
-		matcher: /@rtorcato\/(?:js|repo)-tooling\/typescript\//,
-		// `fix tsconfig`, not `copy tsconfig`: copy drops the whole preset inline,
-		// which carries no `extends` for the matcher above to find (#381).
+		expected: `extends "${PACKAGE}/typescript/*" or inlines the preset, with strict on`,
+		matcher: matchesTsConfig,
 		hint: 'Run `npx @rtorcato/repo-tooling fix tsconfig` to scaffold',
 	},
 	{

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -126,6 +126,25 @@ const TS_PRESET_STRICTNESS = [
 ] as const
 
 /**
+ * `strict` and every flag it implies. TypeScript lets any one of these be
+ * switched off individually while `strict: true` is still literally present —
+ * the explicit override wins — so a config can keep every marker this check
+ * looks for and still ship with type safety off. Any of them explicitly
+ * `false` is drift.
+ */
+const TS_STRICT_FLAGS = [
+	'strict',
+	'noImplicitAny',
+	'strictNullChecks',
+	'strictFunctionTypes',
+	'strictBindCallApply',
+	'strictPropertyInitialization',
+	'noImplicitThis',
+	'useUnknownInCatchVariables',
+	'alwaysStrict',
+] as const
+
+/**
  * The same two shapes as `matchesBiomeConfig`, for the same reason (#385): the
  * `extends` pointer `fix tsconfig` writes, and the whole preset inlined, which
  * is what `copy tsconfig` drops — `tooling/typescript/tsconfig.base.json` *is*
@@ -143,8 +162,9 @@ function matchesTsConfig(contents: string): boolean {
 
 	const compilerOptions = (config.compilerOptions ?? {}) as Record<string, unknown>
 	// Naming the preset and then switching strictness off is precisely the drift
-	// this check exists to catch, so it disqualifies either shape.
-	if (compilerOptions.strict === false) return false
+	// this check exists to catch, so it disqualifies either shape — `strict`
+	// itself or any single flag it implies.
+	if (TS_STRICT_FLAGS.some((key) => compilerOptions[key] === false)) return false
 
 	if (TS_PRESET_REF.test(JSON.stringify(config.extends ?? ''))) return true
 

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -112,6 +112,72 @@ describe('doctor', () => {
 		expect(ts?.hint).toMatch(/tsconfig/)
 	})
 
+	// #385: `copy tsconfig` writes the preset inline — the preset names itself
+	// nowhere, so the old text matcher could never match what copy produced and
+	// the repo stayed drifted however many times it re-ran.
+	it('reports ok for the tsconfig.json `copy tsconfig` writes', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await copyPreset('tsconfig', dir)
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'TypeScript')?.status).toBe('ok')
+	})
+
+	it('still reports drift for a tsconfig that is neither a pointer nor the preset', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'tsconfig.json'), { compilerOptions: { strict: false } })
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'TypeScript')?.status).toBe('drift')
+	})
+
+	// Keeping the preset's shape while turning strictness off is exactly the
+	// drift this check exists to catch — the bypass the #379 security review
+	// caught on the Biome side, one preset over.
+	it('reports drift for a preset-shaped tsconfig with strict disabled', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		// The real preset, one option flipped: every other marker still present.
+		await copyPreset('tsconfig', dir)
+		const tsconfigPath = join(dir, 'tsconfig.json')
+		const inlined = await fs.readFile(tsconfigPath, 'utf-8')
+		const disabled = inlined.replace('"strict": true', '"strict": false')
+		expect(disabled).not.toBe(inlined)
+		await fs.writeFile(tsconfigPath, disabled)
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'TypeScript')?.status).toBe('drift')
+	})
+
+	it('reports drift when the preset it extends has strict switched back off', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, 'tsconfig.json'), {
+			extends: '@rtorcato/repo-tooling/typescript/base',
+			compilerOptions: { strict: false },
+		})
+
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'TypeScript')?.status).toBe('drift')
+	})
+
+	it('accepts a commented tsconfig.json and does not crash on a corrupt one', async () => {
+		const commented = newTmpDir()
+		await seedPackageJson(commented)
+		await fs.writeFile(
+			join(commented, 'tsconfig.json'),
+			'// shared preset\n{ "extends": "@rtorcato/repo-tooling/typescript/base" /* base */ }\n'
+		)
+		const corrupt = newTmpDir()
+		await seedPackageJson(corrupt)
+		await fs.writeFile(join(corrupt, 'tsconfig.json'), '{ "extends": "…/typescript/base"')
+
+		expect((await runDoctor(commented)).find((r) => r.check === 'TypeScript')?.status).toBe('ok')
+		expect((await runDoctor(corrupt)).find((r) => r.check === 'TypeScript')?.status).toBe('drift')
+	})
+
 	it('detects biome.jsonc and eslint configs that import our presets', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -163,6 +163,31 @@ describe('doctor', () => {
 		expect(results.find((r) => r.check === 'TypeScript')?.status).toBe('drift')
 	})
 
+	// `strict: true` can stay literally present while any one flag it implies is
+	// overridden to false — the override wins, so both shapes above would keep
+	// every marker and still ship with type safety off.
+	it('reports drift when a strict-implied flag is switched off on either shape', async () => {
+		const pointer = newTmpDir()
+		await seedPackageJson(pointer)
+		await fs.writeJson(join(pointer, 'tsconfig.json'), {
+			extends: '@rtorcato/repo-tooling/typescript/base',
+			compilerOptions: { noImplicitAny: false },
+		})
+
+		const inlined = newTmpDir()
+		await seedPackageJson(inlined)
+		await copyPreset('tsconfig', inlined)
+		const tsconfigPath = join(inlined, 'tsconfig.json')
+		const preset = await fs.readFile(tsconfigPath, 'utf-8')
+		// `strict` itself stays true, as do all four TS_PRESET_STRICTNESS keys.
+		const weakened = preset.replace('"strict": true', '"strict": true, "strictNullChecks": false')
+		expect(weakened).not.toBe(preset)
+		await fs.writeFile(tsconfigPath, weakened)
+
+		expect((await runDoctor(pointer)).find((r) => r.check === 'TypeScript')?.status).toBe('drift')
+		expect((await runDoctor(inlined)).find((r) => r.check === 'TypeScript')?.status).toBe('drift')
+	})
+
 	it('accepts a commented tsconfig.json and does not crash on a corrupt one', async () => {
 		const commented = newTmpDir()
 		await seedPackageJson(commented)


### PR DESCRIPTION
`copy tsconfig` writes `tooling/typescript/tsconfig.base.json` verbatim. That file *is* the preset, so it carries no `@rtorcato/repo-tooling/typescript/` string for the old text matcher to find, and every repo that ran `copy tsconfig` was reported as drifted with no way out — the check is not optional, so it read as a real problem rather than an optional one.

The config is now parsed the way #379 taught the Biome check to parse (JSONC-aware, string-safe, via the shared `parseJsonc`), and either shape is accepted: an `extends` pointing at the preset, or the preset inlined (a `${configDir}`-anchored `rootDir` plus the preset's strict block).

Structural rather than textual, so the check stays capable of failing:

- `extends: "@rtorcato/repo-tooling/typescript/base"` → ok
- the real `copyPreset('tsconfig')` output → ok
- `{"compilerOptions":{"strict":false}}` → drift
- the copied preset with only `strict` flipped to false → drift (the bypass the #379 security review caught, one preset over)
- `extends` the preset but `strict: false` → drift
- commented JSONC → ok; unparseable → drift, no crash

`fix tsconfig` is untouched: #383 already routes it through `generateTSConfig`, which emits an `extends`.

Closes #385