### PR TITLE
fix(gitlab-ci): only emit jobs whose scripts the repo has

### DIFF
--- a/src/cli/generators/gitlab-ci.ts
+++ b/src/cli/generators/gitlab-ci.ts
@@ -4,9 +4,18 @@ import { renderGitLabCI } from '../../base/ci.js'
 import { gitlabSpec } from '../../languages/js/ci.js'
 import type { ProjectConfig } from '../commands/setup.js'
 
-export async function generateGitLabCI(config: ProjectConfig, targetDir: string) {
+/**
+ * @param scripts The target's package.json scripts, so the pipeline only calls
+ * commands that exist (#386). Omit on the `setup` path, which writes the
+ * scripts itself as part of the same scaffold.
+ */
+export async function generateGitLabCI(
+	config: ProjectConfig,
+	targetDir: string,
+	{ scripts }: { scripts?: Record<string, string> } = {}
+) {
 	const yamlPath = path.join(targetDir, '.gitlab-ci.yml')
 	// ponytail: direct JS import until a second language module ships CI (#287).
-	await fs.writeFile(yamlPath, renderGitLabCI(gitlabSpec(config)))
+	await fs.writeFile(yamlPath, renderGitLabCI(gitlabSpec(config, { scripts })))
 	return '.gitlab-ci.yml'
 }

--- a/src/languages/js/ci.ts
+++ b/src/languages/js/ci.ts
@@ -106,9 +106,14 @@ export function scriptsOf(pkg: Record<string, unknown> | null): Record<string, s
 	return (pkg.scripts as Record<string, string> | undefined) ?? {}
 }
 
+/** The repo defines this script — or we have no scripts to check it against. */
+function hasScript(opts: JobOptions, script: string): boolean {
+	return !opts.scripts || script in opts.scripts
+}
+
 /** Emit a step only when the script it runs exists (or we can't know yet). */
 function stepFor(opts: JobOptions, script: string, step: string): string | null {
-	return !opts.scripts || script in opts.scripts ? step : null
+	return hasScript(opts, script) ? step : null
 }
 
 /** Join the steps that survived gating onto the shared setup preamble. */
@@ -269,18 +274,34 @@ ${attw}${publint}
 	return jobs
 }
 
-/** The `.gitlab-ci.yml` spec for a JS repo — node image, pnpm store cache, pnpm scripts. */
-export function gitlabSpec(config: ProjectConfig): GitLabSpec {
+/**
+ * The `.gitlab-ci.yml` spec for a JS repo — node image, pnpm store cache, pnpm
+ * scripts. `opts.scripts` gates each job on the script it runs exactly as
+ * `githubJobs` does (#386): `fix gitlab-ci` renders for a repo that already
+ * exists and may have none of them, and a job calling a missing script dies
+ * with ERR_PNPM_RECURSIVE_EXEC. Undefined still means "assume the setup shape".
+ *
+ * Dropping the `build` job takes its `artifacts` block with it; no other job
+ * references that artifact, so the pipeline stays coherent without it.
+ */
+export function gitlabSpec(config: ProjectConfig, opts: JobOptions = {}): GitLabSpec {
 	const hasTypeScript = config.typescript.enabled
 	const hasTests = config.testing.framework !== 'none'
 	const hasLint = config.linting.tool !== 'none'
 	const hasBuild = config.bundler !== 'none'
+	const test = gitlabTest(config)
 
 	const jobs: GitLabSpec['jobs'] = [
-		...(hasLint ? [{ id: 'lint', stage: 'test', script: [lintCommand(config)] }] : []),
-		...(hasTypeScript ? [{ id: 'typecheck', stage: 'test', script: ['pnpm typecheck'] }] : []),
-		...(hasTests ? [{ id: 'test', stage: 'test', script: [gitlabTestCommand(config)] }] : []),
-		...(hasBuild
+		...(hasLint && hasScript(opts, lintScript(config))
+			? [{ id: 'lint', stage: 'test', script: [lintCommand(config)] }]
+			: []),
+		...(hasTypeScript && hasScript(opts, 'typecheck')
+			? [{ id: 'typecheck', stage: 'test', script: ['pnpm typecheck'] }]
+			: []),
+		...(hasTests && (test.script === null || hasScript(opts, test.script))
+			? [{ id: 'test', stage: 'test', script: [test.command] }]
+			: []),
+		...(hasBuild && hasScript(opts, 'build')
 			? [
 					{
 						id: 'build',
@@ -318,9 +339,16 @@ default:
 	}
 }
 
-function gitlabTestCommand(config: ProjectConfig): string {
-	if (config.testing.framework === 'vitest') return 'pnpm exec vitest run'
+/**
+ * The GitLab test command, paired with the package.json script it needs.
+ * Vitest is invoked through `pnpm exec` — a direct binary call, so `script` is
+ * null and the job is never gated away; the other frameworks run a script that
+ * has to exist.
+ */
+function gitlabTest(config: ProjectConfig): { command: string; script: string | null } {
+	if (config.testing.framework === 'vitest')
+		return { command: 'pnpm exec vitest run', script: null }
 	if (config.testing.framework === 'playwright' || config.testing.framework === 'cypress')
-		return 'pnpm test:e2e'
-	return 'pnpm test'
+		return { command: 'pnpm test:e2e', script: 'test:e2e' }
+	return { command: 'pnpm test', script: 'test' }
 }

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -480,7 +480,10 @@ export const FIXERS: Fixer[] = [
 		outputs: ['.gitlab-ci.yml'],
 		canFixDrift: true,
 		async run({ targetDir, pkg }) {
-			const written = await generateGitLabCI(inferProjectConfig(pkg), targetDir)
+			// Only reference scripts this repo actually has (#386).
+			const written = await generateGitLabCI(inferProjectConfig(pkg), targetDir, {
+				scripts: scriptsOf(pkg),
+			})
 			return { filesWritten: [written] }
 		},
 	},

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -328,11 +328,22 @@ describe('fix targeted', () => {
 
 	it('fix gitlab-ci --yes writes .gitlab-ci.yml with expected stages', async () => {
 		const dir = newTmpDir()
-		await seedPackageJson(dir)
+		await seedPackageJson(dir, { scripts: { check: 'biome check .' } })
 		await fixCommand('gitlab-ci', { directory: dir, yes: true })
 		const yaml = await fs.readFile(join(dir, '.gitlab-ci.yml'), 'utf-8')
 		expect(yaml).toMatch(/^lint:$/m)
+		// vitest runs via `pnpm exec`, so the test job needs no script (#386).
 		expect(yaml).toMatch(/^test:$/m)
+	})
+
+	it('fix gitlab-ci only references scripts the repo actually has', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir, { scripts: { typecheck: 'tsc --noEmit' } })
+		await fixCommand('gitlab-ci', { directory: dir, yes: true })
+		const yaml = await fs.readFile(join(dir, '.gitlab-ci.yml'), 'utf-8')
+		expect(yaml).toContain('pnpm typecheck')
+		expect(yaml).not.toContain('pnpm check')
+		expect(yaml).not.toContain('pnpm build')
 	})
 
 	it('fix codeowners --yes writes .github/CODEOWNERS', async () => {

--- a/tests/cli/generators/gitlab-ci.test.ts
+++ b/tests/cli/generators/gitlab-ci.test.ts
@@ -78,3 +78,70 @@ describe('generateGitLabCI', () => {
 		expect(yaml).toContain('pnpm test:e2e')
 	})
 })
+
+describe('generateGitLabCI script gating', () => {
+	async function render(config: ProjectConfig, scripts?: Record<string, string>) {
+		const dir = newTmpDir()
+		await generateGitLabCI(config, dir, { scripts })
+		return fs.readFile(join(dir, '.gitlab-ci.yml'), 'utf-8')
+	}
+
+	it('omits jobs whose scripts the repo does not define', async () => {
+		const yaml = await render(baseConfig(), { typecheck: 'tsc --noEmit' })
+
+		expect(yaml).toMatch(/^typecheck:$/m)
+		expect(yaml).not.toMatch(/^lint:$/m)
+		expect(yaml).not.toContain('pnpm check')
+		// No build script → no build job, and the artifacts block goes with it.
+		expect(yaml).not.toMatch(/^build:$/m)
+		expect(yaml).not.toContain('pnpm build')
+		expect(yaml).not.toContain('dist/')
+	})
+
+	it('keeps the vitest job without a test script — pnpm exec needs none', async () => {
+		const yaml = await render(baseConfig(), {})
+
+		expect(yaml).toMatch(/^test:$/m)
+		expect(yaml).toContain('pnpm exec vitest run')
+	})
+
+	it('drops the e2e job when test:e2e is missing, keeps it when present', async () => {
+		const config = baseConfig({ testing: { framework: 'playwright' } })
+
+		expect(await render(config, {})).not.toMatch(/^test:$/m)
+		expect(await render(config, { 'test:e2e': 'playwright test' })).toContain('pnpm test:e2e')
+	})
+
+	it('keeps every job when the scripts are there', async () => {
+		const yaml = await render(baseConfig(), {
+			check: 'biome check .',
+			typecheck: 'tsc --noEmit',
+			build: 'tsup',
+		})
+
+		expect(yaml).toContain('pnpm check')
+		expect(yaml).toContain('pnpm typecheck')
+		expect(yaml).toContain('pnpm build')
+		expect(yaml).toContain('- dist/')
+	})
+
+	it('assumes the full setup shape when no scripts are supplied', async () => {
+		// setup writes these scripts as part of the same scaffold, so gating on a
+		// package.json that doesn't exist yet would strip a working pipeline.
+		const yaml = await render(baseConfig())
+
+		expect(yaml).toContain('pnpm check')
+		expect(yaml).toContain('pnpm typecheck')
+		expect(yaml).toContain('pnpm build')
+	})
+
+	it('still emits a valid stages: key when every job is dropped', async () => {
+		const yaml = await render(baseConfig({ testing: { framework: 'jest' } }), {})
+
+		expect(yaml).toContain('stages:\n  - test\n')
+		expect(yaml).not.toMatch(/^lint:$/m)
+		expect(yaml).not.toMatch(/^typecheck:$/m)
+		expect(yaml).not.toMatch(/^test:$/m)
+		expect(yaml).not.toMatch(/^build:$/m)
+	})
+})


### PR DESCRIPTION
fix(gitlab-ci): only emit jobs whose scripts the repo has

#364 gated GitHub Actions steps on the scripts a repo defines, but
`gitlabSpec` never got the same treatment. `inferProjectConfig`
hardcodes typescript/biome/vitest/tsup, so every generated
`.gitlab-ci.yml` called `pnpm check`, `pnpm typecheck` and `pnpm
build` regardless of the target and died with
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL on repos missing them.

Thread the existing `JobOptions.scripts` / `scriptsOf(pkg)` through
`gitlabSpec` and `generateGitLabCI`, and pass it from the `gitlab-ci`
fixer. Undefined `scripts` still means "assume the setup shape".

Two GitLab-only asymmetries:

- vitest runs as `pnpm exec vitest run`, a direct binary call that
  needs no script, while playwright/cypress run `pnpm test:e2e`,
  which does. `gitlabTest` now pairs the command with the script it
  needs, or null.
- dropping the build job takes its `artifacts.paths: dist/` block
  with it; no other job references that artifact.

`renderGitLabCI` already falls back to a single `test` stage when the
job list is empty, so a fully gated-off pipeline stays well-formed -
now covered by a test.

Closes #386
