### PR TITLE
fix(vitest): emit a config that imports the shipped preset

### DIFF
--- a/src/cli/generators/testing.ts
+++ b/src/cli/generators/testing.ts
@@ -24,26 +24,28 @@ export async function generateVitestConfig(config: ProjectConfig, targetDir: str
 	// and Vite 8 silently ignores the old `esbuild` key.
 	const jsxOverride =
 		config.projectType === 'nextjs-app'
-			? `  // tsconfig sets jsx: "preserve" for Next's compiler; vitest needs a
-  // transform of its own or .tsx tests won't parse.
-  oxc: { jsx: { runtime: 'automatic' } },
+			? `    // tsconfig sets jsx: "preserve" for Next's compiler; vitest needs a
+    // transform of its own or .tsx tests won't parse.
+    oxc: { jsx: { runtime: 'automatic' } },
 `
 			: ''
 
-	const vitestConfig = `import { defineConfig } from 'vitest/config'
+	// Layered on the shipped preset rather than hand-rolled: the preset owns
+	// globals, the shared excludes and the v8/lcov coverage reporters, so preset
+	// improvements reach consumers — and doctor's `Vitest` check (which looks for
+	// this import) can actually pass after `fix vitest` (#387).
+	const vitestConfig = `import base from '@rtorcato/repo-tooling/vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 
-export default defineConfig({
-${jsxOverride}  test: {
-    globals: true,
-    environment: '${config.testing.environment === 'browser' ? 'jsdom' : 'node'}',
-    setupFiles: ['./vitest.setup.ts'],
-    coverage: {
-      provider: 'v8',
-      // lcov feeds Codecov; text is the local console summary.
-      reporter: ['text', 'lcov']
+export default mergeConfig(
+  base,
+  defineConfig({
+${jsxOverride}    test: {
+      environment: '${config.testing.environment === 'browser' ? 'jsdom' : 'node'}',
+      setupFiles: ['./vitest.setup.ts']
     }
-  }
-})
+  })
+)
 `
 
 	await fs.writeFile(vitestConfigPath, vitestConfig)

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1033,6 +1033,16 @@ describe('fix + lockfile', () => {
 		expect(lock.config.linting.tool).toBe('biome')
 	})
 
+	it('fix vitest --yes regenerates the config but keeps an existing vitest.setup.ts', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(join(dir, 'vitest.setup.ts'), '// my real setup\n')
+		await fixCommand('vitest', { directory: dir, yes: true })
+		expect(await fs.readFile(join(dir, 'vitest.setup.ts'), 'utf-8')).toBe('// my real setup\n')
+		const config = await fs.readFile(join(dir, 'vitest.config.ts'), 'utf-8')
+		expect(config).toContain("from '@rtorcato/repo-tooling/vitest/config'")
+	})
+
 	it('fix vitest --yes on a jest-locked project auto-resyncs the lockfile', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
+++ b/tests/cli/generators/__snapshots__/snapshot.test.ts.snap
@@ -324,19 +324,17 @@ exports[`generator output snapshots > package.json (library) 1`] = `
 `;
 
 exports[`generator output snapshots > vitest.config.ts (node library) 1`] = `
-"import { defineConfig } from 'vitest/config'
+"import base from '@rtorcato/repo-tooling/vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: 'node',
-    setupFiles: ['./vitest.setup.ts'],
-    coverage: {
-      provider: 'v8',
-      // lcov feeds Codecov; text is the local console summary.
-      reporter: ['text', 'lcov']
+export default mergeConfig(
+  base,
+  defineConfig({
+    test: {
+      environment: 'node',
+      setupFiles: ['./vitest.setup.ts']
     }
-  }
-})
+  })
+)
 "
 `;

--- a/tests/cli/generators/testing.test.ts
+++ b/tests/cli/generators/testing.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import { generateTestingConfigs } from '../../../src/cli/generators/testing.js'
+import { FILE_CHECKS } from '../../../src/languages/js/checks.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -31,6 +32,30 @@ describe('generateTestingConfigs', () => {
 		const vitestConfig = await fs.readFile(join(dir, 'vitest.config.ts'), 'utf-8')
 		expect(vitestConfig).toContain("environment: 'node'")
 		expect(await fs.pathExists(join(dir, 'vitest.setup.ts'))).toBe(true)
+	})
+
+	it('writes a vitest config that satisfies the doctor Vitest check', async () => {
+		const dir = newTmpDir()
+		await generateTestingConfigs(baseConfig({ testing: { framework: 'vitest' } }), dir)
+
+		const vitestConfig = await fs.readFile(join(dir, 'vitest.config.ts'), 'utf-8')
+		const matcher = FILE_CHECKS.find((c) => c.check === 'Vitest')?.matcher as RegExp
+		expect(matcher).toBeDefined()
+		expect(vitestConfig).toMatch(matcher)
+		// …and the check still has teeth: an unrelated config must not match.
+		expect('export default {}\n').not.toMatch(matcher)
+	})
+
+	it('keeps the Next.js jsx transform override on top of the preset', async () => {
+		const dir = newTmpDir()
+		await generateTestingConfigs(
+			baseConfig({ projectType: 'nextjs-app', testing: { framework: 'vitest' } }),
+			dir
+		)
+
+		const vitestConfig = await fs.readFile(join(dir, 'vitest.config.ts'), 'utf-8')
+		expect(vitestConfig).toContain("oxc: { jsx: { runtime: 'automatic' } }")
+		expect(vitestConfig).toContain('mergeConfig(')
 	})
 
 	it('uses jsdom environment when browser is requested', async () => {

--- a/tests/vitest/config-exclude.test.ts
+++ b/tests/vitest/config-exclude.test.ts
@@ -12,4 +12,15 @@ describe('vitest preset exclude', () => {
 			expect(exclude).toContain(def)
 		}
 	})
+
+	it('declares no resolve.alias — generated configs import this preset now', () => {
+		// An alias built from the preset's own __dirname points inside
+		// node_modules, so it would resolve `@/…` to a directory that doesn't
+		// exist in any consumer (#387).
+		expect(config.resolve?.alias).toBeUndefined()
+	})
+
+	it('emits lcov so the CI we generate has something to upload to Codecov', () => {
+		expect(config.test?.coverage?.reporter).toContain('lcov')
+	})
 })

--- a/tooling/vitest/vitest.config.d.mts
+++ b/tooling/vitest/vitest.config.d.mts
@@ -1,4 +1,7 @@
-import type { UserConfig } from 'vitest/config'
+// vitest 4 re-exports vite's UserConfig under the name ViteUserConfig; there is
+// no `UserConfig` export on 'vitest/config'. Generated configs import this
+// preset now, so a wrong name here surfaces in every consumer's `tsc --noEmit`.
+import type { ViteUserConfig } from 'vitest/config'
 
-declare const config: UserConfig
+declare const config: ViteUserConfig
 export default config

--- a/tooling/vitest/vitest.config.mjs
+++ b/tooling/vitest/vitest.config.mjs
@@ -1,9 +1,10 @@
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { configDefaults, defineConfig } from 'vitest/config'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
+// No `resolve.alias` here on purpose: this file's `__dirname` is wherever the
+// package got installed, so a `@` → `<preset dir>/src` alias resolves to a
+// directory that exists in no consumer (nor in the published tarball). Now that
+// generated configs actually import this preset, that alias would poison them.
+// Consumers that want `@`/`~` declare them in their own config.
 export default defineConfig({
 	test: {
 		globals: true,
@@ -13,13 +14,9 @@ export default defineConfig({
 		exclude: [...configDefaults.exclude, '.claude/**'],
 		coverage: {
 			provider: 'v8',
-			reporter: ['text', 'json', 'html', 'json-summary'],
+			// lcov feeds Codecov (the CI we generate uploads it); text is the local
+			// console summary; the rest back the HTML report.
+			reporter: ['text', 'lcov', 'json', 'html', 'json-summary'],
 		},
-	},
-	resolve: {
-		alias: [
-			{ find: '@', replacement: resolve(__dirname, './src') },
-			{ find: '~', replacement: resolve(__dirname, './src') },
-		],
 	},
 })

--- a/tooling/vitest/vitest.config.react.d.mts
+++ b/tooling/vitest/vitest.config.react.d.mts
@@ -1,4 +1,4 @@
-import type { UserConfig } from 'vitest/config'
+import type { ViteUserConfig } from 'vitest/config'
 
-declare const config: UserConfig
+declare const config: ViteUserConfig
 export default config

--- a/tooling/vitest/vitest.config.react.mjs
+++ b/tooling/vitest/vitest.config.react.mjs
@@ -1,11 +1,9 @@
 import base from '@rtorcato/repo-tooling/vitest/config'
 import react from '@vitejs/plugin-react'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { defineConfig, mergeConfig } from 'vitest/config'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
+// Same reason as the base preset: an alias built from this file's `__dirname`
+// points inside node_modules, never at the consumer's `src`.
 export default mergeConfig(
 	base,
 	defineConfig({
@@ -16,12 +14,6 @@ export default mergeConfig(
 			css: true, // ← Vitest will stub every *.css / *.module.css import
 			exclude: ['OLD/**'],
 			setupFiles: ['./vitest.setup.ts'],
-		},
-		resolve: {
-			alias: [
-				{ find: '@', replacement: resolve(__dirname, './src') },
-				{ find: '~', replacement: resolve(__dirname, './src') },
-			],
 		},
 	})
 )


### PR DESCRIPTION
## Approach

Took the **preferred** route from the issue: the emitted `vitest.config.ts` now imports the shipped preset. **Not** the alternative (relaxing the check) — the check is unchanged.

The preset composes cleanly, so nothing had to be given up. `tooling/vitest/vitest.config.mjs` exports a plain `UserConfig` object, and `mergeConfig` layers over it — exactly what the already-shipped `vitest/react` preset does. `fix vitest` now writes:

```ts
import base from '@rtorcato/repo-tooling/vitest/config'
import { defineConfig, mergeConfig } from 'vitest/config'

export default mergeConfig(
  base,
  defineConfig({
    test: {
      environment: 'node',
      setupFiles: ['./vitest.setup.ts']
    }
  })
)
```

Per-project variation survives and is still emitted explicitly, on top of the preset rather than restating it:

- `environment: 'jsdom'` vs `'node'` — a scalar, so the override wins over the preset's `'node'`.
- The Next.js `oxc: { jsx: { runtime: 'automatic' } }` override, unchanged apart from indentation.

## Three preset fixes this exposed

Making consumers actually import the preset surfaced defects that were dormant while nobody did:

- **`resolve.alias` pointed inside `node_modules`.** Both presets built `@`/`~` aliases from their own `__dirname`, i.e. `<install dir>/tooling/vitest/src` — a directory that exists in no consumer and isn't in the published tarball either (not in `files`). Dead today; it would have silently broken `@/…` imports in every repo that took the new generated config. Removed from both presets.
- **The preset omitted `lcov`.** The CI we generate uploads coverage to Codecov, and the old hand-rolled config was the only thing asking for lcov. Adding it to the preset means the generated config doesn't restate the coverage block at all — which also avoids `mergeConfig` concatenating two reporter arrays into a list with a duplicate `text`.
- **`vitest.config.d.mts` imported a type that doesn't exist.** vitest 4 exports vite's `UserConfig` as `ViteUserConfig`; `import type { UserConfig } from 'vitest/config'` is an error. Invisible while no TypeScript file imported the preset — it would now land in every consumer's `tsc --noEmit`.

## The check keeps its teeth

The `Vitest` check and its matcher are untouched. Verified against a real fixture:

| state | doctor |
|---|---|
| after `fix vitest` | `ok` — `vitest.config.ts imports "@rtorcato/repo-tooling/vitest/config"` |
| `export default {}` | `drift` — `found but does not imports "…/vitest/config"` |

`tests/cli/generators/testing.test.ts` asserts both directions against the real `FILE_CHECKS` matcher rather than a copy of the regex, so the two can't drift apart.

## One correction to the issue

The issue lists "`vitest.setup.ts` is preserved across a re-run (already tested)" as a guardrail. **It wasn't tested** — the fixer does save and restore the file around `generateVitestConfig`, but nothing asserted it, so this change could have taken the restore with it unnoticed. Second commit adds that test.

## Verification

- `pnpm run check`, `tsc --noEmit --project src/cli/tsconfig.json` — clean.
- `vitest run` — 839 passed / 55 files. The repo's own `vitest.config.mjs` merges the same preset, so the alias and reporter changes are exercised by every test in the suite.
- Separately typechecked the `mergeConfig(base, defineConfig({…}))` shape under `--strict` to confirm the composition is valid TypeScript for consumers, not just valid at runtime.

Closes #387
