### PR TITLE
chore(git): map placeholder author identity via .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+# Re-attributes commits made under a placeholder git identity (see #327).
+#
+# `richardtorcato@example.com` came from a tracked ~/.gitconfig that kept
+# resetting the identity on checkout. example.com is IANA-reserved, so the
+# address can never be verified and GitHub can never re-link those commits.
+# Rewriting 79 commits would orphan 116 tags, so this maps them instead:
+# git log/shortlog/blame now report one author. GitHub's contribution graph
+# does not honour .mailmap and stays unchanged.
+Richard Torcato <rtorcato@me.com> <richardtorcato@example.com>


### PR DESCRIPTION
## What

Adds a `.mailmap` that re-attributes the 79 commits authored under the
placeholder `richardtorcato@example.com` to `rtorcato@me.com`.

## Why this and not a history rewrite

#327 recommends against rewriting for most repos, and this one is a clear
case: 116 tags plus a semantic-release history would all be orphaned by a
force-push. A `.mailmap` is git-native, is one file, and touches no SHAs.

Verified locally:

| | before | after |
|---|---|---|
| `git shortlog -sne` | 209 + 79 as two authors | 288 as one |
| raw `git log --format=%ae` | 79 placeholder | 79 placeholder (unchanged) |

The `GitLab CI <ci@example.com>` bot identity is deliberately left alone —
it is a real bot, not a mis-attribution.

## Limitation

GitHub's contribution graph does not honour `.mailmap`, so those commits stay
unlinked there. That is unfixable without a rewrite, since `example.com` is
IANA-reserved and can never be verified. The `.mailmap` comment says so.

## Scope note

This closes out the repo-tooling side of #327. The per-project detection
follow-up already landed as #328 (`src/base/git-identity.ts`, wired into
`doctor`). The remaining follow-up — `git config --global` writes landing in
the tracked file — lives in the dotfiles repo, so #327 stays open.

Refs #327
