### PR TITLE
fix(doctor): flag agent docs that name the dead js-tooling bin

### DIFF
--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fs from 'fs-extra'
+import { BLOCK_START, hasStaleAgentBlock } from '../cli/generators/agent-rules.js'
 import { BADGE_START, hasPublicOnlyBadges } from '../cli/generators/badges.js'
 import { type DetectedLanguage, detectNestedLanguages } from '../cli/utils/detect-language.js'
 import type { CheckResult } from './types.js'
@@ -378,21 +379,35 @@ export async function checkCoverageUpload(dir: string): Promise<CheckResult> {
 }
 
 export async function checkAiSetup(dir: string): Promise<CheckResult> {
-	// Consider AI setup present if AGENTS.md carries the js-tooling block or the
-	// Claude skill is installed — the two primary markers `fix ai` writes.
-	const agentsPath = path.join(dir, 'AGENTS.md')
-	const hasAgentsBlock =
-		(await fs.pathExists(agentsPath)) &&
-		(await fs.readFile(agentsPath, 'utf8')).includes('<!-- js-tooling:start -->')
+	// Consider AI setup present if one of the block-managed files carries the
+	// agent block or the Claude skill is installed — the markers `fix ai` writes.
+	let blockFile: string | null = null
+	const stale: string[] = []
+	for (const rel of ['AGENTS.md', 'CLAUDE.md', path.join('.github', 'copilot-instructions.md')]) {
+		const filepath = path.join(dir, rel)
+		if (!(await fs.pathExists(filepath))) continue
+		const content = await fs.readFile(filepath, 'utf8')
+		if (!content.includes(BLOCK_START)) continue
+		blockFile ??= rel
+		if (hasStaleAgentBlock(content)) stale.push(rel)
+	}
 	const hasSkill =
 		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'repo-tooling.md'))) ||
 		// Pre-rename name — still counts as present until `fix` migrates it.
 		(await fs.pathExists(path.join(dir, '.claude', 'skills', 'js-tooling.md')))
-	if (hasAgentsBlock || hasSkill) {
+	if (stale.length > 0) {
+		return {
+			check: 'AI setup',
+			status: 'drift',
+			detail: `${stale.join(', ')} still point agents at the dead \`js-tooling\` package/bin`,
+			hint: 'Run `npx @rtorcato/repo-tooling fix ai` to refresh the agent instructions in place',
+		}
+	}
+	if (blockFile || hasSkill) {
 		return {
 			check: 'AI setup',
 			status: 'ok',
-			detail: hasAgentsBlock ? 'AGENTS.md has the js-tooling block' : '.claude skill installed',
+			detail: blockFile ? `${blockFile} has the agent block` : '.claude skill installed',
 		}
 	}
 	return {

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import { copyPreset, getPackageRoot } from '../utils/copy-preset.js'
+import { LEGACY_TOOL_NAME } from '../utils/lockfile.js'
 import { installSkillsInstallDocs } from './skills-install.js'
 
 /**
@@ -9,8 +10,25 @@ import { installSkillsInstallDocs } from './skills-install.js'
  * location and the frontmatter differ per agent.
  */
 const SOURCE = 'tooling/claude/repo-tooling.md'
-const BLOCK_START = '<!-- js-tooling:start -->'
-const BLOCK_END = '<!-- js-tooling:end -->'
+// The markers keep the pre-rename text on purpose: changing them would orphan
+// every block already written and append a second one on the next fix.
+export const BLOCK_START = '<!-- js-tooling:start -->'
+export const BLOCK_END = '<!-- js-tooling:end -->'
+
+/**
+ * True when a managed block still names the pre-rename package or bin — a repo
+ * scaffolded before the rename tells agents to run `js-tooling fix ai`, which
+ * is not a runnable command (#393). Only the block *body* is inspected: the
+ * markers carry the legacy name by design, so matching on the whole file would
+ * report every repo as permanently stale.
+ */
+export function hasStaleAgentBlock(content: string): boolean {
+	const start = content.indexOf(BLOCK_START)
+	if (start === -1) return false
+	const bodyStart = start + BLOCK_START.length
+	const end = content.indexOf(BLOCK_END, bodyStart)
+	return content.slice(bodyStart, end === -1 ? undefined : end).includes(LEGACY_TOOL_NAME)
+}
 
 export type AgentTarget = 'cursor' | 'copilot' | 'agents-md'
 

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -5,10 +5,14 @@ import { validateProjectConfig } from '../commands/setup-presets.js'
 import type { ProjectConfig } from '../commands/setup.js'
 
 export const LOCKFILE_NAME = '.repo-tooling.json'
-// Name used before the js-tooling→repo-tooling rename (#272). Repos set up on an
-// older version still have it: readLockfile falls back to it, and writeLockfile
-// migrates to the new name (removing the old file) on the next write.
-export const LEGACY_LOCKFILE_NAME = '.js-tooling.json'
+// Package and bin name used before the js-tooling→repo-tooling rename (#272).
+// The bin no longer exists and the package is 404 on the registry, so any
+// generated file still naming it is stale (#393).
+export const LEGACY_TOOL_NAME = 'js-tooling'
+// Lockfile name from the same era. Repos set up on an older version still have
+// it: readLockfile falls back to it, and writeLockfile migrates to the new name
+// (removing the old file) on the next write.
+export const LEGACY_LOCKFILE_NAME = `.${LEGACY_TOOL_NAME}.json`
 // v2 added ProjectConfig.language (multi-language seam, #140). v1 files are
 // migrated to v2 on read, defaulting language to 'js'.
 export const LOCKFILE_VERSION = 2

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -476,6 +476,19 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('ok')
 	})
 
+	it('AI setup: drift when a managed block still names the dead js-tooling bin (#393)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.claude', 'skills', 'repo-tooling.md'), '# skill\n')
+		await fs.writeFile(
+			join(dir, 'CLAUDE.md'),
+			'<!-- js-tooling:start -->\nSee @AGENTS.md (kept in sync by `js-tooling fix ai`).\n<!-- js-tooling:end -->\n'
+		)
+		const result = (await runDoctor(dir)).find((r) => r.check === 'AI setup')
+		expect(result?.status).toBe('drift')
+		expect(result?.detail).toContain('CLAUDE.md')
+	})
+
 	it('AI setup: ok when the Claude skill is present without AGENTS.md', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -385,6 +385,25 @@ describe('fix targeted', () => {
 		expect(agents.match(/<!-- js-tooling:start -->/g)).toHaveLength(1)
 	})
 
+	it('fix ai --yes refreshes a block that still names the dead js-tooling bin (#393)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const stale =
+			'<!-- js-tooling:start -->\nSee @AGENTS.md (kept in sync by `js-tooling fix ai`).\n<!-- js-tooling:end -->\n'
+		await fs.writeFile(join(dir, 'CLAUDE.md'), stale)
+		await fs.writeFile(join(dir, 'AGENTS.md'), `# Mine\n\n${stale}`)
+
+		await fixCommand('ai', { directory: dir, yes: true })
+
+		const claude = await fs.readFile(join(dir, 'CLAUDE.md'), 'utf8')
+		expect(claude).toContain('`repo-tooling fix ai`')
+		expect(claude).not.toContain('`js-tooling fix ai`')
+		const agents = await fs.readFile(join(dir, 'AGENTS.md'), 'utf8')
+		expect(agents).toContain('# Mine') // surrounding content preserved
+		expect(agents).toContain('# repo-tooling')
+		expect(agents).not.toContain('js-tooling fix ai')
+	})
+
 	it('fix node-version --yes rewrites hardcoded workflow versions to node-version-file', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir, { engines: { node: '>=22' } })


### PR DESCRIPTION
## What

`fix ai` short-circuited on "the files exist" rather than "their contents are current", so any repo scaffolded before the `js-tooling` → `repo-tooling` rename kept agent instructions pointing at a dead package and bin — `js-tooling fix ai` is not runnable and `@rtorcato/js-tooling` is 404 on the registry. Self-concealing: `doctor` said ok and `fix ai` said "already configured".

`checkAiSetup` now inspects the managed block in `AGENTS.md`, `CLAUDE.md` and `.github/copilot-instructions.md` and returns `drift` when the block body still names the legacy package/bin. The existing `ai` fixer is already `canFixDrift: true` + `safe-merge`, so `fix ai --yes` refreshes the blocks in place without touching surrounding content.

## The marker subtlety

`agent-rules.ts` deliberately keeps emitting `<!-- js-tooling:start -->` / `<!-- js-tooling:end -->` — changing the marker text would orphan every block already written and append a second one on the next fix. So detection matches the **block body only** (`hasStaleAgentBlock` slices between the markers). Flagging any occurrence of `js-tooling` in the file would flag the markers the tool itself writes and leave every repo permanently dirty.

The `ok` detail also no longer reads "AGENTS.md has the js-tooling block" — as the issue notes, that phrasing is what made the stale state look intentional.

## Changes

- `src/cli/utils/lockfile.ts` — `LEGACY_TOOL_NAME = 'js-tooling'`, with `LEGACY_LOCKFILE_NAME` derived from it
- `src/cli/generators/agent-rules.ts` — export the markers plus `hasStaleAgentBlock()`
- `src/base/checks.ts` — `checkAiSetup` scans the three block-managed files, reports drift, and drops the misleading ok detail

## Tests

- `doctor.test.ts` — a `CLAUDE.md` whose block names the legacy bin reports `drift` (the legacy-content case, not just the missing-file case)
- `fix.test.ts` — `fix ai --yes` rewrites stale `CLAUDE.md` + `AGENTS.md` blocks in place, preserving the user's own content

`pnpm run verify` passes: biome, typecheck, 836 tests, build.

Closes #393