### PR TITLE
feat(doctor): audit milestone hygiene, close completed milestones

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -193,6 +193,7 @@ Implementation note: the preview is computed by shadow-running the fixer in a te
 | `renovate` | `renovate.json` (alternative to Dependabot) |
 | `codeql` | `.github/workflows/codeql.yml` (security scanning) |
 | `github-settings` | branch protection + auto-merge + workflow permissions + a code-scanning branch ruleset (when CodeQL is on) via `gh api` (mutates the remote repo) |
+| `milestones` | closes 100%-complete open milestones via `gh api` (mutates the remote repo). Never deletes or creates one — see [milestone hygiene](./git-flow.md#milestones) |
 | `codeowners` | `.github/CODEOWNERS` with commented examples |
 | `community-health` | `CONTRIBUTING.md`, `SECURITY.md`, PR + issue templates |
 | `lockfile` | records current tool choices in the repo-tooling lockfile |

--- a/apps/docs/docs/guides/git-flow.md
+++ b/apps/docs/docs/guides/git-flow.md
@@ -83,6 +83,30 @@ under an admin's PAT / GitHub App token and leave "include administrators" off,
 so that identity bypasses.) This bypass is for the release bot only — humans
 always go through a PR.
 
+## Milestones
+
+A milestone is a **release gate, not a chore bucket**. Milestone an issue only if
+leaving it undone would block declaring that stage complete; refactors, CI,
+dependency bumps and docs typos get no milestone. Otherwise the percentage
+inverts — a `v1.0` milestone reads 80% because it is full of chores while the
+three items that actually define v1.0 stay open.
+
+Corollary: `ai-ready` and milestone-worthy are near-mutually-exclusive.
+`ai-ready` means mechanical and bounded; milestone-worthy means it shapes the
+public API, which is precisely what should not run unattended.
+
+`doctor` audits this as the `Milestones` check:
+
+| Finding | Why it matters |
+| --- | --- |
+| 100% complete but still open | "Open" stops meaning "in flight", so the milestone list carries no signal |
+| No issues at all | GitHub renders the bar as `closed / total`, so an empty milestone is a permanent 0% |
+| Titled `backlog` / `post-N` / `someday` | No completion criterion means it can never close — that is a label |
+
+`fix milestones` closes only the first case. It never deletes a milestone and
+never creates one, because both destroy or invent planning intent. A repo with
+no milestones at all is skipped — that is a legitimate choice.
+
 ## Single source of truth
 
 - This standard, `CONTRIBUTING.md` (branch prefixes, the ≤67-char PR-title

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -26,6 +26,7 @@ import { detectLanguage } from '../cli/utils/detect-language.js'
 import type { Lockfile } from '../cli/utils/lockfile.js'
 import { resolveLanguageModule } from '../languages/registry.js'
 import { applyGithubSettings } from './github-settings.js'
+import { closeCompletedMilestones } from './milestones.js'
 import type { CheckResult } from './types.js'
 
 /** A parsed package.json, or null when the repo has none (any non-JS repo). */
@@ -159,6 +160,20 @@ export const BASE_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			return { filesWritten: await applyGithubSettings(targetDir) }
+		},
+	},
+	{
+		target: 'milestones',
+		description:
+			'Close 100%-complete open milestones on GitHub via gh api (mutates the remote repo, not files). Never deletes or creates one',
+		appliesTo: ['Milestones'],
+		outputs: ['GitHub milestones (remote, via gh api)'],
+		// safe-add for the same reason github-settings is: it exempts this fixer
+		// from the `--diff` shadow-run, which executes run() for a mere preview.
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await closeCompletedMilestones(targetDir) }
 		},
 	},
 	{

--- a/src/base/milestones.ts
+++ b/src/base/milestones.ts
@@ -1,0 +1,159 @@
+import path from 'node:path'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import { type GhExec, realGhExec } from './github-settings.js'
+import type { CheckResult } from './types.js'
+
+/**
+ * Milestone hygiene (#397). `doctor` already audits GitHub-side state, and an
+ * open milestone at 100% is the same class of drift: "open" stops meaning "in
+ * flight", so the milestone list carries no signal.
+ *
+ * Read-only, on the same `gh` seam as github-settings.ts. No repo probe is
+ * needed — `gh` expands `{owner}/{repo}` from the remote itself.
+ */
+
+const CHECK = 'Milestones'
+
+interface Milestone {
+	number: number
+	title: string
+	state: string
+	open_issues: number
+	closed_issues: number
+}
+
+/**
+ * A milestone with no completion criterion can never close, so it is
+ * structurally a label. Warned about, never fixed — the call is the
+ * maintainer's.
+ */
+const CATCH_ALL_TITLE = /backlog|post-\d|someday/i
+
+const skip = (reason: string): CheckResult => ({
+	check: CHECK,
+	status: 'ok',
+	detail: `skipped — ${reason}`,
+})
+
+const titles = (ms: Milestone[]) => ms.map((m) => `"${m.title}"`).join(', ')
+
+async function readMilestones(gh: GhExec): Promise<Milestone[] | null> {
+	// `-f`/`-F` on a GET land in the query string, so the path keeps gh's
+	// {owner}/{repo} placeholders intact.
+	const r = await gh([
+		'api',
+		'repos/{owner}/{repo}/milestones',
+		'-f',
+		'state=all',
+		'-F',
+		'per_page=100',
+	])
+	if (!r.ok) return null
+	try {
+		const parsed = JSON.parse(r.stdout)
+		return Array.isArray(parsed) ? parsed : null
+	} catch {
+		return null
+	}
+}
+
+function classify(milestones: Milestone[]) {
+	const open = milestones.filter((m) => m.state === 'open')
+	return {
+		// The number guard is the injection boundary: it is interpolated into the
+		// PATCH path by the fixer below.
+		complete: open.filter(
+			(m) => m.open_issues === 0 && m.closed_issues > 0 && Number.isInteger(m.number)
+		),
+		// GitHub renders the bar as closed/total, so an empty milestone is a
+		// permanent 0% that can never move.
+		empty: open.filter((m) => m.open_issues === 0 && m.closed_issues === 0),
+		catchAll: open.filter((m) => CATCH_ALL_TITLE.test(m.title)),
+	}
+}
+
+/**
+ * The catch-all warning rides in `detail` rather than being its own finding:
+ * `fix` deliberately can't resolve it (converting a milestone to a label is a
+ * planning decision), and a permanently-unfixable drift row would nag forever.
+ */
+const catchAllNote = (catchAll: Milestone[]) =>
+	catchAll.length === 0
+		? ''
+		: ` — note: ${titles(catchAll)} has no completion criterion so it can never close; that is a label, not a milestone`
+
+export async function checkMilestones(dir: string, exec?: GhExec): Promise<CheckResult> {
+	// Cheap gate first: no .git → never spawn (keeps tmp-dir doctor runs offline).
+	if (!(await fs.pathExists(path.join(dir, '.git')))) return skip('not a git repository')
+	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin, dir))
+	const milestones = await readMilestones(gh)
+	if (!milestones) return skip('could not read milestones')
+	// Using no milestones at all is a legitimate choice, not drift.
+	if (milestones.length === 0) return skip('repo uses no milestones')
+
+	const { complete, empty, catchAll } = classify(milestones)
+	const deltas: string[] = []
+	if (complete.length) deltas.push(`100% complete but still open: ${titles(complete)}`)
+	if (empty.length) deltas.push(`no issues, so a permanent 0%: ${titles(empty)}`)
+	const note = catchAllNote(catchAll)
+
+	if (deltas.length)
+		return {
+			check: CHECK,
+			status: 'drift',
+			detail: deltas.join('; ') + note,
+			hint: 'Run `npx @rtorcato/repo-tooling fix milestones` to close the 100%-complete ones. Empty milestones are left alone — file their issues or delete them by hand',
+		}
+	return {
+		check: CHECK,
+		status: 'ok',
+		detail: `${milestones.length} milestone(s); none complete-but-open or empty${note}`,
+	}
+}
+
+/**
+ * Closes every open milestone that is 100% complete. Deliberately the only
+ * mutation: deleting an empty milestone or creating a missing one would destroy
+ * or invent planning intent. Idempotent — a clean repo is a no-op.
+ *
+ * Advisories go to `console.error`; stdout carries the `--json` payload (#357).
+ */
+export async function closeCompletedMilestones(dir: string, exec?: GhExec): Promise<string[]> {
+	if (!(await fs.pathExists(path.join(dir, '.git')))) {
+		console.error(chalk.gray('   skipped — not a git repository'))
+		return []
+	}
+	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin, dir))
+	const milestones = await readMilestones(gh)
+	if (!milestones) {
+		console.error(chalk.gray('   skipped — could not read milestones'))
+		return []
+	}
+
+	const { complete, empty } = classify(milestones)
+	const closed: string[] = []
+	for (const m of complete) {
+		const r = await gh([
+			'api',
+			'-X',
+			'PATCH',
+			`repos/{owner}/{repo}/milestones/${m.number}`,
+			'-f',
+			'state=closed',
+		])
+		if (r.ok) closed.push(`closed milestone "${m.title}"`)
+		else
+			console.error(
+				chalk.yellow(`   could not close "${m.title}": ${r.stderr.trim() || 'gh error'}`)
+			)
+	}
+	if (empty.length)
+		console.error(
+			chalk.gray(
+				`   left ${empty.length} empty milestone(s) alone — file their issues or delete them by hand`
+			)
+		)
+	if (closed.length === 0) console.error(chalk.gray('   no 100%-complete open milestones to close'))
+	return closed
+}

--- a/src/base/milestones.ts
+++ b/src/base/milestones.ts
@@ -39,10 +39,14 @@ const skip = (reason: string): CheckResult => ({
 const titles = (ms: Milestone[]) => ms.map((m) => `"${m.title}"`).join(', ')
 
 async function readMilestones(gh: GhExec): Promise<Milestone[] | null> {
-	// `-f`/`-F` on a GET land in the query string, so the path keeps gh's
+	// `-X GET` is load-bearing: `-f`/`-F` without an explicit method make `gh`
+	// switch to POST, which would hit the *create* milestone endpoint. With it,
+	// the fields land in the query string and the path keeps gh's
 	// {owner}/{repo} placeholders intact.
 	const r = await gh([
 		'api',
+		'-X',
+		'GET',
 		'repos/{owner}/{repo}/milestones',
 		'-f',
 		'state=all',

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -13,6 +13,7 @@ import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../languages/swift/checks.js
 import { readSwiftPackage, renderSwiftWorkflow } from '../../languages/swift/ci.js'
 import { type DetectedLanguage, detectLanguage } from '../utils/detect-language.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
+import { checkMilestones } from '../../base/milestones.js'
 import { checkGitIdentity } from '../../base/git-identity.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
@@ -242,6 +243,8 @@ async function runBaseChecks(
 	// GitHub repo-settings drift (branch protection, merge settings, workflow
 	// permissions). Read-only; self-skips as `ok` outside a live GitHub repo.
 	results.push(...(await checkGitHubSettings(dir)))
+	// Milestone hygiene (#397) — same seam, same self-skip.
+	results.push(await checkMilestones(dir))
 	results.push(await checkGitLabCI(dir))
 	results.push(await checkCodeowners(dir))
 	results.push(await checkCommunityHealth(dir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -31,6 +31,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'Merge settings': 'github-settings',
 	'Workflow permissions': 'github-settings',
 	'Code-scanning gate': 'github-settings',
+	Milestones: 'milestones',
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
 	Turborepo: 'turborepo',

--- a/tests/base/milestones.test.ts
+++ b/tests/base/milestones.test.ts
@@ -1,0 +1,123 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GhExec, GhResult } from '../../src/base/github-settings.js'
+import { checkMilestones, closeCompletedMilestones } from '../../src/base/milestones.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+function gitRepo(): string {
+	const dir = newTmpDir()
+	fs.ensureDirSync(join(dir, '.git'))
+	return dir
+}
+
+const ok = (stdout: string): GhResult => ({ ok: true, stdout, stderr: '', code: 0 })
+
+const milestone = (over: Partial<Record<string, unknown>> = {}) => ({
+	number: 1,
+	title: 'v1.0 — Stable API',
+	state: 'open',
+	open_issues: 2,
+	closed_issues: 3,
+	...over,
+})
+
+/** Serves the milestone list; PATCHes succeed unless `patch` says otherwise. */
+function fakeGh(milestones: unknown[], patch?: GhResult): GhExec {
+	return vi.fn(async (args: string[]) =>
+		args.includes('-X') ? (patch ?? ok('{}')) : ok(JSON.stringify(milestones))
+	)
+}
+
+describe('checkMilestones', () => {
+	it('never spawns gh outside a git repo', async () => {
+		const exec = fakeGh([])
+		expect((await checkMilestones(newTmpDir(), exec)).detail).toContain('not a git repository')
+		expect(exec).not.toHaveBeenCalled()
+	})
+
+	it('skips a repo that uses no milestones — that is a choice, not drift', async () => {
+		const r = await checkMilestones(gitRepo(), fakeGh([]))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('no milestones')
+	})
+
+	it('is ok when every open milestone still has work in it', async () => {
+		expect((await checkMilestones(gitRepo(), fakeGh([milestone()]))).status).toBe('ok')
+	})
+
+	it('flags a 100%-complete milestone left open', async () => {
+		const exec = fakeGh([milestone({ open_issues: 0, closed_issues: 6 })])
+		const r = await checkMilestones(gitRepo(), exec)
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('100% complete but still open')
+	})
+
+	it('flags an empty milestone as a permanent 0%', async () => {
+		const r = await checkMilestones(
+			gitRepo(),
+			fakeGh([milestone({ open_issues: 0, closed_issues: 0 })])
+		)
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('permanent 0%')
+	})
+
+	it('ignores closed milestones entirely', async () => {
+		const closed = milestone({ state: 'closed', open_issues: 0, closed_issues: 6 })
+		expect((await checkMilestones(gitRepo(), fakeGh([closed]))).status).toBe('ok')
+	})
+
+	it('warns about a catch-all title without making it a fixable drift', async () => {
+		const r = await checkMilestones(gitRepo(), fakeGh([milestone({ title: 'Backlog' })]))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('can never close')
+	})
+
+	it('matches post-N and someday titles too', async () => {
+		const r = await checkMilestones(gitRepo(), fakeGh([milestone({ title: 'Post-1 cleanup' })]))
+		expect(r.detail).toContain('can never close')
+	})
+
+	it('self-skips when the milestone read fails', async () => {
+		const exec: GhExec = async () => ({ ok: false, stdout: '', stderr: 'gh error', code: 1 })
+		const r = await checkMilestones(gitRepo(), exec)
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('could not read milestones')
+	})
+})
+
+describe('closeCompletedMilestones', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('closes only the 100%-complete ones', async () => {
+		const exec = fakeGh([
+			milestone({ number: 1, title: 'Done', open_issues: 0, closed_issues: 6 }),
+			milestone({ number: 2, title: 'In flight' }),
+		])
+		expect(await closeCompletedMilestones(gitRepo(), exec)).toEqual(['closed milestone "Done"'])
+		expect(exec).toHaveBeenCalledWith([
+			'api',
+			'-X',
+			'PATCH',
+			'repos/{owner}/{repo}/milestones/1',
+			'-f',
+			'state=closed',
+		])
+	})
+
+	it('never deletes an empty milestone', async () => {
+		const exec = fakeGh([milestone({ open_issues: 0, closed_issues: 0 })])
+		expect(await closeCompletedMilestones(gitRepo(), exec)).toEqual([])
+		expect(vi.mocked(exec).mock.calls.every((c) => !c[0].includes('DELETE'))).toBe(true)
+	})
+
+	it('is a no-op outside a git repo', async () => {
+		const exec = fakeGh([])
+		expect(await closeCompletedMilestones(newTmpDir(), exec)).toEqual([])
+		expect(exec).not.toHaveBeenCalled()
+	})
+})

--- a/tests/base/milestones.test.ts
+++ b/tests/base/milestones.test.ts
@@ -24,11 +24,26 @@ const milestone = (over: Partial<Record<string, unknown>> = {}) => ({
 	...over,
 })
 
+/**
+ * Mirrors `gh api`'s flag-to-method inference: `-f`/`-F` without an explicit
+ * `-X` switches the request to POST. So only a real `GET` serves the list — a
+ * read that forgets `-X GET` reads as "create milestone" and fails here, the
+ * way it does against GitHub.
+ */
+function ghMethod(args: string[]): string {
+	const i = args.indexOf('-X')
+	if (i !== -1) return args[i + 1] ?? ''
+	return args.includes('-f') || args.includes('-F') ? 'POST' : 'GET'
+}
+
 /** Serves the milestone list; PATCHes succeed unless `patch` says otherwise. */
 function fakeGh(milestones: unknown[], patch?: GhResult): GhExec {
-	return vi.fn(async (args: string[]) =>
-		args.includes('-X') ? (patch ?? ok('{}')) : ok(JSON.stringify(milestones))
-	)
+	return vi.fn(async (args: string[]) => {
+		const method = ghMethod(args)
+		if (method === 'GET') return ok(JSON.stringify(milestones))
+		if (method === 'PATCH') return patch ?? ok('{}')
+		return { ok: false, stdout: '', stderr: `unexpected ${method}`, code: 422 }
+	})
 }
 
 describe('checkMilestones', () => {
@@ -46,6 +61,21 @@ describe('checkMilestones', () => {
 
 	it('is ok when every open milestone still has work in it', async () => {
 		expect((await checkMilestones(gitRepo(), fakeGh([milestone()]))).status).toBe('ok')
+	})
+
+	it('lists milestones with an explicit GET, not gh’s inferred POST', async () => {
+		const exec = fakeGh([milestone()])
+		await checkMilestones(gitRepo(), exec)
+		expect(exec).toHaveBeenCalledWith([
+			'api',
+			'-X',
+			'GET',
+			'repos/{owner}/{repo}/milestones',
+			'-f',
+			'state=all',
+			'-F',
+			'per_page=100',
+		])
 	})
 
 	it('flags a 100%-complete milestone left open', async () => {


### PR DESCRIPTION
Adds a `Milestones` check. An open milestone at 100% (open_issues 0,
closed_issues > 0) and an empty one both report drift — GitHub renders
the bar as closed/total, so an empty milestone is a permanent 0%.

A catch-all title (backlog / post-N / someday) rides in the detail
rather than as its own finding: converting one to a label is a
planning decision `fix` must not make, and a permanently-unfixable
drift row would nag forever. A repo with no milestones is skipped;
that is a legitimate choice.

`fix milestones` closes only the unambiguous 100%-complete case. It
never deletes or creates a milestone: both destroy or invent
planning intent.

Closes #397