### PR TITLE
feat(ai): scaffold .claude/settings.json worktree symlinks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "worktree": {
+    "symlinkDirectories": [
+      "node_modules"
+    ]
+  }
+}

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -20,6 +20,7 @@ All of it derives from **one source of truth** — the shipped Claude skill
 | `.github/copilot-instructions.md` | GitHub Copilot | Merge-safe delimited block |
 | `.claude/skills/repo-tooling.md` | Claude Code skill | Copied verbatim |
 | `.mcp.json.example` | Model Context Protocol | Commented template (see below) |
+| `.claude/settings.json` | Claude Code worktrees | Merge-safe key upsert (see below), JS repos only |
 | `README.md` | Your repo's own skills | Merge-safe block, only if this repo ships `skills/<name>/SKILL.md` |
 
 Every file is either a merge-safe **delimited block** (`<!-- js-tooling:start -->`
@@ -69,6 +70,30 @@ auto-writes this same install section into your `README.md` — one
 `npx skills add` command per skill, with the GitHub URL derived from
 `package.json`'s `repository`. It's a merge-safe delimited block, so your own
 README content is never touched, and repos without a `skills/` dir get nothing.
+
+## Worktrees: symlink `node_modules` instead of reinstalling it
+
+A Claude Code worktree starts empty, so an agent working one pays a full
+`pnpm install` before it can typecheck, lint or test — every time. `fix ai`
+upserts this into `.claude/settings.json` so Claude symlinks the directory from
+the main checkout instead:
+
+```json
+{
+  "worktree": {
+    "symlinkDirectories": ["node_modules"]
+  }
+}
+```
+
+Only the `worktree.symlinkDirectories` key is touched — your `hooks`,
+`permissions` and anything else in that file survive, and entries you added
+yourself are kept. A file that doesn't parse is left alone rather than
+clobbered; `doctor` reports it as drift for you to repair by hand.
+
+Skipped for Swift, Python and Perl repos — no `node_modules` to symlink, so the
+key would be noise. `doctor` reports `Claude worktree settings`, and it honours
+the same `aiSetup` opt-out in `.repo-tooling.json` as the rest of this feature.
 
 ## CLAUDE.md is a pointer, not a copy
 

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -195,7 +195,7 @@ export const BASE_FIXERS: Fixer[] = [
 		target: 'ai',
 		description:
 			'Install all AI agent files at once (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill, MCP example)',
-		appliesTo: ['AI setup'],
+		appliesTo: ['AI setup', 'Claude worktree settings'],
 		outputs: [
 			'AGENTS.md',
 			'CLAUDE.md',
@@ -203,6 +203,8 @@ export const BASE_FIXERS: Fixer[] = [
 			'.github/copilot-instructions.md',
 			'.claude/skills/repo-tooling.md',
 			'.mcp.json.example',
+			// Only written for a repo with a package.json — nothing to symlink otherwise.
+			'.claude/settings.json',
 			// Only written when the repo ships its own skills/<name>/SKILL.md.
 			'README.md',
 		],

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -39,6 +39,7 @@ import type { CheckResult, CheckStatus } from '../../base/types.js'
 import {
 	allDeps,
 	checkAreTheTypesWrong,
+	checkClaudeWorktreeSettings,
 	checkConfigSchemaVersions,
 	checkDocsSite,
 	checkEnginesNode,
@@ -391,6 +392,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 	results.push(await checkPnpmWorkspace(targetDir, pkg))
 	results.push(await checkBuildApprovals(targetDir, pkg))
+	results.push(await checkClaudeWorktreeSettings(targetDir))
 	// Turborepo is monorepo-only — only surface the check when a workspace exists.
 	if (await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))) {
 		results.push(await checkTurborepo(targetDir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -46,6 +46,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'README badges': 'badges',
 	TypeDoc: 'typedoc',
 	'AI setup': 'ai',
+	'Claude worktree settings': 'ai',
 }
 
 /**
@@ -164,6 +165,9 @@ export function declinedInLock(lock: Lockfile | null, checkName: string): boolea
 		case 'README badges':
 			return c.badges === false
 		case 'AI setup':
+		// The same recorded choice: the worktree settings are part of what
+		// `fix ai` writes, so a repo that declined AI setup declined them too.
+		case 'Claude worktree settings':
 			return c.aiSetup === false
 		case 'Turborepo':
 			return c.turborepo === false

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -306,7 +306,8 @@ export function computeFileList(config: ProjectConfig): string[] {
 			'.cursor/rules/repo-tooling.mdc',
 			'.github/copilot-instructions.md',
 			'.claude/skills/repo-tooling.md',
-			'.mcp.json.example'
+			'.mcp.json.example',
+			'.claude/settings.json'
 		)
 	}
 	if (config.turborepo) files.push('turbo.json')

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -32,6 +32,64 @@ export function hasStaleAgentBlock(content: string): boolean {
 
 export type AgentTarget = 'cursor' | 'copilot' | 'agents-md'
 
+export const CLAUDE_SETTINGS_FILE = path.join('.claude', 'settings.json')
+/**
+ * Directories Claude Code symlinks from the main checkout into a fresh
+ * worktree instead of leaving the agent to reinstall them (#396). An agent
+ * working a per-issue worktree can typecheck immediately rather than paying a
+ * full `pnpm install` first, on every issue.
+ */
+export const WORKTREE_SYMLINK_DIRS = ['node_modules'] as const
+
+function asObject(value: unknown): Record<string, unknown> | null {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null
+}
+
+/** Parsed `.claude/settings.json`, or null when absent, malformed, or not an object. */
+export async function readClaudeSettings(
+	targetDir: string
+): Promise<Record<string, unknown> | null> {
+	try {
+		return asObject(await fs.readJson(path.join(targetDir, CLAUDE_SETTINGS_FILE)))
+	} catch {
+		return null
+	}
+}
+
+/** The `worktree.symlinkDirectories` entries already recorded, ignoring junk. */
+export function worktreeSymlinkDirs(settings: Record<string, unknown> | null): string[] {
+	const dirs = asObject(settings?.worktree)?.symlinkDirectories
+	return Array.isArray(dirs) ? dirs.filter((d): d is string => typeof d === 'string') : []
+}
+
+/**
+ * Upsert `worktree.symlinkDirectories` into `.claude/settings.json`. Repos
+ * already keep `hooks` and `permissions` in that file, so only the one key is
+ * merged and everything else survives — the same contract the AGENTS.md and
+ * copilot-instructions blocks give.
+ *
+ * Returns the written path, or null when there is nothing to write: a repo with
+ * no package.json has no node_modules to symlink (Swift, Python, Perl), and a
+ * file that doesn't parse is left for a human rather than clobbered.
+ */
+export async function installClaudeSettings(targetDir: string): Promise<string | null> {
+	if (!(await fs.pathExists(path.join(targetDir, 'package.json')))) return null
+	const file = path.join(targetDir, CLAUDE_SETTINGS_FILE)
+	const exists = await fs.pathExists(file)
+	const settings = exists ? await readClaudeSettings(targetDir) : {}
+	if (!settings) return null
+	const existing = worktreeSymlinkDirs(settings)
+	const symlinkDirectories = [
+		...existing,
+		...WORKTREE_SYMLINK_DIRS.filter((d) => !existing.includes(d)),
+	]
+	const worktree = { ...asObject(settings.worktree), symlinkDirectories }
+	await fs.outputJson(file, { ...settings, worktree }, { spaces: 2 })
+	return CLAUDE_SETTINGS_FILE
+}
+
 interface Skill {
 	description: string
 	body: string
@@ -102,6 +160,9 @@ export async function installAiSetup(targetDir: string): Promise<string[]> {
 	written.push(await installAgentRules(targetDir, 'copilot'))
 	written.push((await copyPreset('claude-skill', targetDir)).target)
 	written.push((await copyPreset('mcp-example', targetDir)).target)
+	// Only for repos that have node_modules to symlink — see installClaudeSettings.
+	const claudeSettings = await installClaudeSettings(targetDir)
+	if (claudeSettings) written.push(claudeSettings)
 	// If this repo ships its own skills (skills/<name>/SKILL.md), document their
 	// one-command `npx skills add` install in README.md. No-op for repos without.
 	const skillsDoc = await installSkillsInstallDocs(targetDir)

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -3,6 +3,11 @@ import fs from 'fs-extra'
 import type { BadgeAudience, FileCheck, GitHooksProfile } from '../../base/checks.js'
 import { hookHasUncommented } from '../../base/checks.js'
 import {
+	CLAUDE_SETTINGS_FILE,
+	readClaudeSettings,
+	worktreeSymlinkDirs,
+} from '../../cli/generators/agent-rules.js'
+import {
 	WORKSPACE_FILE,
 	dependsOnEsbuild,
 	familyGlob,
@@ -1043,6 +1048,45 @@ export async function checkTreeshakeSetup(dir: string, pkg: Pkg | null): Promise
 		status: 'optional-missing',
 		detail: `package exports ${subpaths.length} subpaths with sideEffects: false but no apps/treeshake-check/`,
 		hint: 'Run `npx @rtorcato/repo-tooling fix treeshake-check` to scaffold an esbuild metafile assertion',
+	}
+}
+
+/**
+ * A Claude Code worktree starts with no node_modules, so every agent working
+ * one pays a full install before it can typecheck, lint or test — unless
+ * `.claude/settings.json` tells Claude to symlink the directory from the main
+ * checkout (#396). JS-only: the other language modules have nothing to symlink.
+ */
+export async function checkClaudeWorktreeSettings(dir: string): Promise<CheckResult> {
+	const check = 'Claude worktree settings'
+	const hint = `Run \`npx ${PACKAGE} fix ai\` to merge worktree.symlinkDirectories into ${CLAUDE_SETTINGS_FILE}`
+	if (!(await fs.pathExists(path.join(dir, CLAUDE_SETTINGS_FILE)))) {
+		return {
+			check,
+			status: 'optional-missing',
+			detail: `no ${CLAUDE_SETTINGS_FILE} — agent worktrees reinstall node_modules from scratch`,
+			hint,
+		}
+	}
+	const settings = await readClaudeSettings(dir)
+	if (!settings) {
+		return {
+			check,
+			status: 'drift',
+			detail: `${CLAUDE_SETTINGS_FILE} is not a readable JSON object`,
+			// `fix ai` deliberately skips an unparseable file rather than clobbering
+			// hand-written hooks/permissions, so this one is on the human.
+			hint: `Repair the JSON in ${CLAUDE_SETTINGS_FILE} by hand — \`fix ai\` refuses to overwrite it`,
+		}
+	}
+	if (worktreeSymlinkDirs(settings).includes('node_modules')) {
+		return { check, status: 'ok', detail: 'worktree.symlinkDirectories carries node_modules' }
+	}
+	return {
+		check,
+		status: 'optional-missing',
+		detail: `${CLAUDE_SETTINGS_FILE} has no worktree.symlinkDirectories entry for node_modules`,
+		hint,
 	}
 }
 

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -497,6 +497,39 @@ describe('doctor extended checks', () => {
 		expect(results.find((r) => r.check === 'AI setup')?.status).toBe('ok')
 	})
 
+	const worktreeCheck = async (dir: string) =>
+		(await runDoctor(dir)).find((r) => r.check === 'Claude worktree settings')
+
+	it('Claude worktree settings: optional-missing with no .claude/settings.json (#396)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		expect((await worktreeCheck(dir))?.status).toBe('optional-missing')
+	})
+
+	it('Claude worktree settings: optional-missing when the file lacks the entry', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputJson(join(dir, '.claude', 'settings.json'), { hooks: {} })
+		expect((await worktreeCheck(dir))?.status).toBe('optional-missing')
+	})
+
+	it('Claude worktree settings: ok once node_modules is symlinked', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputJson(join(dir, '.claude', 'settings.json'), {
+			worktree: { symlinkDirectories: ['node_modules'] },
+		})
+		expect((await worktreeCheck(dir))?.status).toBe('ok')
+	})
+
+	it('Claude worktree settings: drift when settings.json is unparseable', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.claude', 'settings.json'), '{ not json')
+		expect((await worktreeCheck(dir))?.status).toBe('drift')
+	})
+
+
 	it('detects lint-staged in package.json', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
@@ -1007,6 +1040,15 @@ describe('doctor + lockfile', () => {
 		})
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'lockfile')?.status).toBe('drift')
+	})
+
+	it('demotes Claude worktree settings to ok when the lock records aiSetup: false', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await writeLock(dir, { aiSetup: false })
+		const result = (await runDoctor(dir)).find((r) => r.check === 'Claude worktree settings')
+		expect(result?.status).toBe('ok')
+		expect(result?.detail).toMatch(/intentionally declined/)
 	})
 
 	it('demotes Vitest to ok when the lock records testing.framework=jest', async () => {

--- a/tests/cli/generators/agent-rules.test.ts
+++ b/tests/cli/generators/agent-rules.test.ts
@@ -1,7 +1,11 @@
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
-import { installAiSetup, installClaudeMd } from '../../../src/cli/generators/agent-rules.js'
+import {
+	installAiSetup,
+	installClaudeMd,
+	installClaudeSettings,
+} from '../../../src/cli/generators/agent-rules.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -23,6 +27,12 @@ describe('installAiSetup', () => {
 		for (const rel of AI_FILES) {
 			expect(await fs.pathExists(join(dir, rel))).toBe(true)
 		}
+	})
+
+	it('adds .claude/settings.json for a repo that has node_modules to symlink', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		expect(await installAiSetup(dir)).toEqual([...AI_FILES, join('.claude', 'settings.json')])
 	})
 
 	it('makes CLAUDE.md a pointer to AGENTS.md, not a duplicate', async () => {
@@ -53,6 +63,51 @@ describe('installAiSetup', () => {
 		expect(agents).toContain('Keep these.')
 		// exactly one delimited block, not duplicated by the second run
 		expect(agents.match(/<!-- js-tooling:start -->/g)).toHaveLength(1)
+	})
+})
+
+describe('installClaudeSettings', () => {
+	const settingsPath = (dir: string) => join(dir, '.claude', 'settings.json')
+
+	it('scaffolds .claude/settings.json with the worktree symlink entry', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		expect(await installClaudeSettings(dir)).toBe(join('.claude', 'settings.json'))
+		expect(await fs.readJson(settingsPath(dir))).toEqual({
+			worktree: { symlinkDirectories: ['node_modules'] },
+		})
+	})
+
+	it('upserts — existing keys survive and re-running does not duplicate entries', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.outputJson(settingsPath(dir), {
+			hooks: { Stop: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+			worktree: { symlinkDirectories: ['.venv'], copyFiles: ['.env'] },
+		})
+		await installClaudeSettings(dir)
+		await installClaudeSettings(dir)
+		expect(await fs.readJson(settingsPath(dir))).toEqual({
+			hooks: { Stop: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+			worktree: { symlinkDirectories: ['.venv', 'node_modules'], copyFiles: ['.env'] },
+		})
+	})
+
+	it('skips a repo with no package.json — nothing to symlink (swift-library)', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version:5.9\n')
+		expect(await installClaudeSettings(dir)).toBeNull()
+		expect(await fs.pathExists(settingsPath(dir))).toBe(false)
+		// …and the umbrella leaves it out too.
+		expect(await installAiSetup(dir)).not.toContain(join('.claude', 'settings.json'))
+	})
+
+	it('refuses to clobber a settings.json that does not parse', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.outputFile(settingsPath(dir), '{ not json')
+		expect(await installClaudeSettings(dir)).toBeNull()
+		expect(await fs.readFile(settingsPath(dir), 'utf8')).toBe('{ not json')
 	})
 })
 


### PR DESCRIPTION
Closes #396

A Claude Code worktree starts with no `node_modules`, so every agent working one pays a full `pnpm install` before it can typecheck, lint or test. `fix ai` now upserts the `worktree.symlinkDirectories` entry into `.claude/settings.json` so Claude symlinks the directory from the main checkout instead:

```json
{
  "worktree": {
    "symlinkDirectories": ["node_modules"]
  }
}
```

## What changed

- `installClaudeSettings` in `src/cli/generators/agent-rules.ts`, called from the `installAiSetup` umbrella — so `fix ai`, `setup` and the preset file list all get it.
- **Upsert, not overwrite.** Only `worktree.symlinkDirectories` is merged; existing `hooks` / `permissions` blocks survive, and entries already listed are kept (union, no duplicates). Re-running is idempotent.
- **Skipped when there's no `package.json`** — swift-library, Python and Perl repos have no `node_modules` to symlink, so the key would be noise. One predicate covers all three rather than a per-preset flag.
- **Never clobbers a broken file.** A `settings.json` that doesn't parse is left alone and `doctor` reports it as drift for a human to repair.
- New JS-only doctor check `Claude worktree settings` (`ok` / `optional-missing` / `drift`), mapped to the `ai` fix target and demotable to "intentionally declined" through the existing `aiSetup` flag in `.repo-tooling.json` — no new lockfile field.
- Dogfooded: this repo's own `.claude/settings.json` is the generator's output.
- Docs: a new section in `apps/docs/docs/guides/ai-setup.md`.

## The second half of the referenced report

The lint-staged preset here already passes `--no-errors-on-unmatched` to both biome invocations (`src/cli/generators/git.ts`), so the aborted-commit bug from rtorcato/js-common#171 doesn't reproduce from this scaffolder. No change needed.

## Verification

`pnpm verify` (biome check, typecheck, 846 tests, build) passes. New tests cover the upsert-preserves-other-keys case, the no-`package.json` skip, the unparseable-file refusal, and all four doctor statuses including the lockfile demotion.