### PR TITLE
fix(commitlint): stop enforcing body/footer line length

### DIFF
--- a/.claude/skills/ship.md
+++ b/.claude/skills/ship.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Commit and push the current working tree after running all CI gates locally. Triggers on "ship it", "commit and push", "let's push", "/ship", or any explicit request to commit-then-push. Encodes this repo's conventions (pnpm + biome + commitlint strict-50/72 + semantic-release on main). Does NOT trigger on commit-only or push-only requests — use those flows directly.
+description: Commit and push the current working tree after running all CI gates locally. Triggers on "ship it", "commit and push", "let's push", "/ship", or any explicit request to commit-then-push. Encodes this repo's conventions (pnpm + biome + commitlint + semantic-release on main). Does NOT trigger on commit-only or push-only requests — use those flows directly.
 ---
 
 # Ship workflow
@@ -39,9 +39,8 @@ If any fail, **STOP**. Report the failure and ask the user how to proceed. Do no
 ## 4. Write a conventional commit
 
 Commitlint config (`tooling/commitlint/commitlint.mjs`) enforces:
-- **header-max-length: 50** (subject line ≤50 chars including `type:` prefix)
-- **body-max-line-length: 72**
-- **footer-max-line-length: 72**
+- **header-max-length: 100** (subject line ≤100 chars including `type:` prefix — keep PR titles ≤93 so GitHub's ` (#N)` squash suffix still fits)
+- body and footer line length: **unenforced**
 - types allowed: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
 - type must be lowercase, scope must be lowercase
 - no trailing period on subject
@@ -50,13 +49,14 @@ Format the message via HEREDOC to preserve newlines:
 
 ```bash
 git commit -m "$(cat <<'EOF'
-type: short subject (≤50 chars total)
+type: short subject (≤100 chars total)
 
-Body explaining WHY, wrapped at 72.
+Body explaining WHY. Wrap around 72 for readability in `git log`, but
+it isn't enforced.
 
 Optional footers:
 Refs: #123
-BREAKING CHANGE: 50-char-wrapped description.
+BREAKING CHANGE: description.
 EOF
 )"
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ npx @rtorcato/repo-tooling fix bun --yes --json         # Bun runtime/test confi
 
 ## Conventions in this repo
 
-- Conventional commits enforced via commitlint; header max 72 chars
+- Conventional commits enforced via commitlint; header max 100 chars, body/footer line length unenforced
 - Biome for lint + format (run via `pnpm exec biome check --config-path=tooling/biome/biome.json src scripts`)
 - Tests live alongside source in `tests/`; vitest with no separate config
 - semantic-release runs on push to `main`; `fix:` → patch, `feat:` → minor, `chore:` / `docs:` → no release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,11 @@ docs: update CLI usage examples in README
 chore: update dependencies to latest versions
 ```
 
-> **PR title length:** commitlint enforces a 72-char subject limit. GitHub's
-> squash-merge appends ` (#N)` to the title — keep PR titles ≤ 67 chars so
+> **PR title length:** commitlint enforces a 100-char subject limit. GitHub's
+> squash-merge appends ` (#N)` to the title — keep PR titles ≤ 93 chars so
 > the merged commit doesn't trip the post-merge `commitlint` gate (which
-> would then skip the `release` job).
+> would then skip the `release` job). Body and footer line length are not
+> enforced.
 
 ### Code Quality
 

--- a/apps/docs/docs/reference/commitlint.md
+++ b/apps/docs/docs/reference/commitlint.md
@@ -11,7 +11,18 @@ import config from '@rtorcato/repo-tooling/commitlint/config'
 export default config
 ```
 
-The preset enforces [Conventional Commits](https://www.conventionalcommits.org/) with stricter subject-line length limits.
+The preset enforces [Conventional Commits](https://www.conventionalcommits.org/).
+
+## Line lengths
+
+- `header-max-length`: **100** — the conventional-commits/semantic-release
+  default. Keep PR titles ≤ 93 chars so GitHub's ` (#N)` squash suffix still
+  fits on the merged commit.
+- `body-max-line-length` / `footer-max-line-length`: **off**. Machine-written
+  commits don't wrap, and a `BREAKING CHANGE:` footer is the input
+  semantic-release reads to cut a major — a length cap there is friction on the
+  highest-stakes commit in the repo. The subject-line rules that decide the
+  release type stay enforced.
 
 ## Skipped commits
 
@@ -19,7 +30,7 @@ Two kinds of commit are ignored outright:
 
 - anything containing `[skip ci]` (semantic-release's own release commits)
 - bot commits, matched on a `Signed-off-by: …[bot]` trailer — Dependabot and
-  Renovate bodies are machine-written blocks that never wrap at 72 characters
+  Renovate write the whole message, headers included
 
 ## With Husky
 

--- a/skills/npm-publish/SKILL.md
+++ b/skills/npm-publish/SKILL.md
@@ -23,7 +23,7 @@ If asked to "release" or "bump the version", the correct action is to land a
 
 ## How a release actually happens
 
-1. Work on a branch; commit with Conventional Commits (header ≤ 72 chars).
+1. Work on a branch; commit with Conventional Commits (header ≤ 100 chars).
 2. Open a PR; merge to `main` after review + green CI.
 3. semantic-release runs on `main` and decides the bump from the commits:
    - `fix:` → patch

--- a/tests/tooling/commitlint.test.ts
+++ b/tests/tooling/commitlint.test.ts
@@ -39,3 +39,17 @@ describe('commitlint ignores', () => {
 		expect(isIgnored('feat(swift): add DocC check\n\nCloses #311')).toBe(false)
 	})
 })
+
+describe('commitlint line-length rules', () => {
+	// Six sibling repos consume this preset with no override, so a stray
+	// re-tightening here silently breaks every agent-written BREAKING CHANGE
+	// footer downstream.
+	it('leaves body and footer line length unenforced', () => {
+		expect(config.rules['body-max-line-length']).toEqual([0])
+		expect(config.rules['footer-max-line-length']).toEqual([0])
+	})
+
+	it('caps the header at 100 so squash suffixes fit', () => {
+		expect(config.rules['header-max-length']).toEqual([2, 'always', 100])
+	})
+})

--- a/tooling/commitlint/commitlint.mjs
+++ b/tooling/commitlint/commitlint.mjs
@@ -2,11 +2,10 @@ export default {
 	extends: ["@commitlint/config-conventional"],
 	ignores: [
 		(commit) => commit.includes("[skip ci]"),
-		// Bot commit bodies are machine-written blocks (dependabot's
-		// `- dependency-name: …` YAML) that never wrap at 72, so every bot PR
-		// failed body-max-line-length. commitlint can't relax a single rule per
-		// commit, so skip bot commits wholesale — squash-merge uses the PR
-		// title, which is still linted on the merge commit.
+		// Bot commits are machine-written end to end, including headers long
+		// enough to trip header-max-length. Skipping them wholesale keeps bot
+		// PRs green — squash-merge uses the PR title, which is still linted on
+		// the merge commit.
 		// ponytail: matches the trailer, not a bare "[bot]", so a human commit
 		// that merely mentions a bot is still linted.
 		(commit) => /^Signed-off-by: .*\[bot\]/m.test(commit),
@@ -32,10 +31,15 @@ export default {
 		],
 		// 100 is the conventional-commits/semantic-release default. 72 was too
 		// tight: GitHub appends " (#NN)" to squash commits, overflowing the
-		// header on main and skipping the release. Body/footer stay at 72.
+		// header on main and skipping the release.
 		"header-max-length": [2, "always", 100],
-		"body-max-line-length": [2, "always", 72],
-		"footer-max-line-length": [2, "always", 72],
+		// Body/footer length is unenforced. Machine-written commits (agents,
+		// bots) don't wrap, and a `BREAKING CHANGE:` footer — the input
+		// semantic-release reads to cut a major — is the worst thing to make
+		// someone hand-rewrap. The subject rules below decide the release
+		// type and stay enforced.
+		"body-max-line-length": [0],
+		"footer-max-line-length": [0],
 		// Enforce case rules (allow common patterns)
 		"subject-case": [0], // Disable case enforcement to allow flexibility
 		"type-case": [2, "always", "lower-case"],


### PR DESCRIPTION
_(AI-authored PR body.)_

Closes #401. Takes **option 1** from the issue — drop both caps to `[0]`.

## Why option 1 and not 100

Option 2 (raise to 100) still breaks on the things machine-written bodies actually contain — URLs, markdown tables, stack traces — so it moves the wall rather than removing it. Option 3 (widen the `ignores` predicate to cover agent commits) needs a reliable agent-commit signal that doesn't exist; `[bot]` isn't one, which is the issue's own point. `[0]` is also where `js-common` landed independently, so this deletes that override instead of copying it to a seventh sibling repo.

Subject-line rules are untouched — those are what decide the release type.

## Docs sweep

The docs claimed rules the preset hasn't had for a while: four files said the header cap was **72** (it's been 100 since the squash-suffix fix), and `ship.md` said **50**. Since this PR changes two of the three numbers, all of them are now corrected in the same pass:

- `apps/docs/docs/reference/commitlint.md` — new "Line lengths" section
- `CONTRIBUTING.md`, `AGENTS.md`, `skills/npm-publish/SKILL.md`, `.claude/skills/ship.md`

## Test

`tests/tooling/commitlint.test.ts` gains two assertions pinning the rule values, so a re-tightening can't land silently on the six sibling repos that consume the preset with no override.

## Notes for the reviewer

- The bot `ignores` predicate **stays**. Its original justification (body length) is gone, but bot headers can still trip `header-max-length: 100`, and a red X on Dependabot PRs would block the auto-merge path. Its comment is reworded to match the surviving reason. Deleting it is a separate call.
- Downstream follow-up, not in this PR: `js-common` can drop its local `body-max-line-length` override (and rtorcato/js-common#188's footer override becomes unnecessary) once this ships.

Gates run locally: `pnpm check`, `pnpm typecheck`, `pnpm test --run` (896 passed), `pnpm build-cli` via pre-push.
