### PR TITLE
fix(brand): escape double quotes in generated SVG text

### DIFF
--- a/src/cli/generators/brand.ts
+++ b/src/cli/generators/brand.ts
@@ -35,8 +35,13 @@ export interface BrandMeta {
 	install: string | null
 }
 
+/** `"` matters because this output also lands in double-quoted attributes (the `aria-label` below). */
 function esc(s: string): string {
-	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
 }
 
 /**

--- a/tests/cli/generators/brand.test.ts
+++ b/tests/cli/generators/brand.test.ts
@@ -66,6 +66,16 @@ describe('generateBrand', () => {
 		expect(svg).toContain('Fast &amp; &lt;safe&gt;')
 		expect(svg).not.toContain('<safe>')
 	})
+
+	it('escapes quotes, which would otherwise break out of the aria-label attribute', async () => {
+		const dir = newTmpDir()
+		await generateBrand({ name: 'x', description: 'The "only" one' }, dir)
+		const svg = await fs.readFile(join(dir, 'brand/social-card.svg'), 'utf-8')
+		expect(svg).toContain('The &quot;only&quot; one')
+		expect(svg).not.toContain('"only"')
+		// the attribute must still be a single balanced pair, not three
+		expect(svg.match(/aria-label="[^"]*"/)?.[0]).toContain('&quot;only&quot;')
+	})
 })
 
 describe('resolveBrandMeta', () => {


### PR DESCRIPTION
> Note: this PR description was written by an AI agent (Claude).

## Problem

`esc()` in `src/cli/generators/brand.ts` escaped `&`, `<` and `>` but not `"`. Its output lands inside a double-quoted attribute on the `<svg>` root:

```ts
role="img" aria-label="${esc(meta.name)} — ${esc(meta.tagline)}"
```

`meta.tagline` is derived from the **consuming repo's** `package.json` description, so any repo whose description contains a quote gets a broken attribute context and stray attributes on the root element:

```
aria-label="x — The "only" one">
```

Malformed output rather than an exploit — but it ships to arbitrary consumer repos, from the generator whose whole pitch is trustworthy generated output.

## Fix

One `.replace(/"/g, '&quot;')` appended to the existing chain. `&` stays first, as before. All seven `esc()` call sites are element text or double-quoted attributes, so escaping `"` is correct at every one.

## Test

Extended the existing "escapes XML-significant characters" test rather than adding a file. Verified it genuinely fails without the fix — the failure output is the broken `aria-label` above.

`pnpm build` clean, 897/897 tests pass.