### PR TITLE
fix(ai): symlink nested workspace node_modules into agent worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "worktree": {
     "symlinkDirectories": [
-      "node_modules"
+      "node_modules",
+      "apps/docs/node_modules"
     ]
   }
 }

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -86,10 +86,32 @@ the main checkout instead:
 }
 ```
 
+In a workspace repo the nested `node_modules` are added too, so
+`pnpm --filter <pkg> build` works in a worktree instead of failing on a missing
+binary. The list is derived from your own workspace globs — `pnpm-workspace.yaml`
+`packages:` or `package.json` `workspaces` — and only workspaces that actually
+have a `node_modules` in the main checkout are listed:
+
+```json
+{
+  "worktree": {
+    "symlinkDirectories": ["node_modules", "apps/docs/node_modules"]
+  }
+}
+```
+
 Only the `worktree.symlinkDirectories` key is touched — your `hooks`,
 `permissions` and anything else in that file survive, and entries you added
 yourself are kept. A file that doesn't parse is left alone rather than
 clobbered; `doctor` reports it as drift for you to repair by hand.
+
+:::warning Never run `pnpm install` inside a worktree
+The worktree's `node_modules` is a symlink, so pnpm writes *through* it and
+re-points the shared root `.bin` shims at that worktree's virtual store —
+breaking every other worktree and the main checkout with a misleading
+`tsc: MODULE_NOT_FOUND`. Recover with `pnpm install --frozen-lockfile` from the
+main checkout.
+:::
 
 Skipped for Swift, Python and Perl repos — no `node_modules` to symlink, so the
 key would be noise. `doctor` reports `Claude worktree settings`, and it honours

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -50,9 +50,24 @@ function asObject(value: unknown): Record<string, unknown> | null {
 }
 
 /**
+ * True when `rel` resolves to something at or under `targetDir`. The entries
+ * this guards end up in `worktree.symlinkDirectories`, which Claude Code reads
+ * as symlink targets — an escaping path would point a worktree symlink outside
+ * the repo, so a workspace glob is never trusted to stay inside on its own.
+ */
+function isInside(targetDir: string, rel: string): boolean {
+	const outward = path.relative(path.resolve(targetDir), path.resolve(targetDir, rel))
+	return outward !== '' && !outward.startsWith('..') && !path.isAbsolute(outward)
+}
+
+/**
  * The repo's own workspace globs, from `pnpm-workspace.yaml` and/or
  * package.json `workspaces` (both array and `{ packages: [] }` forms). Both
  * are read because a pnpm repo can keep its globs in either file.
+ *
+ * Negations (`!apps/x`) are dropped, and so is anything absolute or containing
+ * a `..` segment: a `packages: - '../shared-lib'` entry reads as plausible in a
+ * monorepo but would write an out-of-repo symlink target into settings.json.
  */
 async function workspaceGlobs(targetDir: string): Promise<string[]> {
 	const yamlFile = path.join(targetDir, 'pnpm-workspace.yaml')
@@ -63,7 +78,11 @@ async function workspaceGlobs(targetDir: string): Promise<string[]> {
 		: asObject(pkg?.workspaces)?.packages
 	const declared = Array.isArray(field) ? field : []
 	return [...parseWorkspacePackages(yaml), ...declared].filter(
-		(g): g is string => typeof g === 'string' && !g.startsWith('!')
+		(g): g is string =>
+			typeof g === 'string' &&
+			!g.startsWith('!') &&
+			!path.isAbsolute(g) &&
+			!g.split(/[\\/]/).includes('..')
 	)
 }
 
@@ -86,7 +105,9 @@ export async function workspaceSymlinkDirs(targetDir: string): Promise<string[]>
 		globs.map((g) => `${g}/node_modules`),
 		{ cwd: targetDir }
 	)) {
-		found.push(match.split(path.sep).join('/'))
+		// Belt and braces: the glob result is what actually gets written, so it is
+		// re-checked for containment even though the input globs were filtered.
+		if (isInside(targetDir, match)) found.push(match.split(path.sep).join('/'))
 	}
 	return found.sort()
 }

--- a/src/cli/generators/agent-rules.ts
+++ b/src/cli/generators/agent-rules.ts
@@ -1,7 +1,9 @@
+import { glob } from 'node:fs/promises'
 import path from 'node:path'
 import fs from 'fs-extra'
 import { copyPreset, getPackageRoot } from '../utils/copy-preset.js'
 import { LEGACY_TOOL_NAME } from '../utils/lockfile.js'
+import { parseWorkspacePackages } from './misc.js'
 import { installSkillsInstallDocs } from './skills-install.js'
 
 /**
@@ -47,6 +49,48 @@ function asObject(value: unknown): Record<string, unknown> | null {
 		: null
 }
 
+/**
+ * The repo's own workspace globs, from `pnpm-workspace.yaml` and/or
+ * package.json `workspaces` (both array and `{ packages: [] }` forms). Both
+ * are read because a pnpm repo can keep its globs in either file.
+ */
+async function workspaceGlobs(targetDir: string): Promise<string[]> {
+	const yamlFile = path.join(targetDir, 'pnpm-workspace.yaml')
+	const yaml = (await fs.pathExists(yamlFile)) ? await fs.readFile(yamlFile, 'utf-8') : ''
+	const pkg = asObject(await fs.readJson(path.join(targetDir, 'package.json')).catch(() => null))
+	const field = Array.isArray(pkg?.workspaces)
+		? pkg.workspaces
+		: asObject(pkg?.workspaces)?.packages
+	const declared = Array.isArray(field) ? field : []
+	return [...parseWorkspacePackages(yaml), ...declared].filter(
+		(g): g is string => typeof g === 'string' && !g.startsWith('!')
+	)
+}
+
+/**
+ * The nested `<workspace>/node_modules` to symlink alongside the root one
+ * (#406). Without them a workspace-scoped command in a fresh worktree fails on
+ * a missing binary — `pnpm --filter <pkg> build` can't find its bin shims —
+ * which reads as a broken toolchain rather than a missing symlink.
+ *
+ * Derived from the repo's own workspace globs, never a hardcoded layout: this
+ * is a public CLI and every consumer nests its packages differently.
+ * Workspaces with no `node_modules` in the main checkout are skipped, because
+ * an entry pointing at nothing warns on every worktree creation.
+ */
+export async function workspaceSymlinkDirs(targetDir: string): Promise<string[]> {
+	const globs = await workspaceGlobs(targetDir)
+	if (globs.length === 0) return []
+	const found: string[] = []
+	for await (const match of glob(
+		globs.map((g) => `${g}/node_modules`),
+		{ cwd: targetDir }
+	)) {
+		found.push(match.split(path.sep).join('/'))
+	}
+	return found.sort()
+}
+
 /** Parsed `.claude/settings.json`, or null when absent, malformed, or not an object. */
 export async function readClaudeSettings(
 	targetDir: string
@@ -81,10 +125,8 @@ export async function installClaudeSettings(targetDir: string): Promise<string |
 	const settings = exists ? await readClaudeSettings(targetDir) : {}
 	if (!settings) return null
 	const existing = worktreeSymlinkDirs(settings)
-	const symlinkDirectories = [
-		...existing,
-		...WORKTREE_SYMLINK_DIRS.filter((d) => !existing.includes(d)),
-	]
+	const wanted = [...WORKTREE_SYMLINK_DIRS, ...(await workspaceSymlinkDirs(targetDir))]
+	const symlinkDirectories = [...existing, ...wanted.filter((d) => !existing.includes(d))]
 	const worktree = { ...asObject(settings.worktree), symlinkDirectories }
 	await fs.outputJson(file, { ...settings, worktree }, { spaces: 2 })
 	return CLAUDE_SETTINGS_FILE

--- a/src/cli/generators/misc.ts
+++ b/src/cli/generators/misc.ts
@@ -282,7 +282,7 @@ export async function ensurePackageManager(
  * YAML dependency. Matches `- 'apps/*'` / `- "apps/*"` / `- apps/*` entries
  * under the `packages:` key, stopping at the next top-level key.
  */
-function parseWorkspacePackages(yaml: string): string[] {
+export function parseWorkspacePackages(yaml: string): string[] {
 	const globs: string[] = []
 	let inPackages = false
 	for (const line of yaml.split('\n')) {

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -5,6 +5,7 @@ import { hookHasUncommented } from '../../base/checks.js'
 import {
 	CLAUDE_SETTINGS_FILE,
 	readClaudeSettings,
+	workspaceSymlinkDirs,
 	worktreeSymlinkDirs,
 } from '../../cli/generators/agent-rules.js'
 import {
@@ -1079,13 +1080,20 @@ export async function checkClaudeWorktreeSettings(dir: string): Promise<CheckRes
 			hint: `Repair the JSON in ${CLAUDE_SETTINGS_FILE} by hand — \`fix ai\` refuses to overwrite it`,
 		}
 	}
-	if (worktreeSymlinkDirs(settings).includes('node_modules')) {
-		return { check, status: 'ok', detail: 'worktree.symlinkDirectories carries node_modules' }
+	const recorded = worktreeSymlinkDirs(settings)
+	const wanted = ['node_modules', ...(await workspaceSymlinkDirs(dir))]
+	const missing = wanted.filter((d) => !recorded.includes(d))
+	if (missing.length === 0) {
+		return {
+			check,
+			status: 'ok',
+			detail: `worktree.symlinkDirectories carries ${wanted.join(', ')}`,
+		}
 	}
 	return {
 		check,
 		status: 'optional-missing',
-		detail: `${CLAUDE_SETTINGS_FILE} has no worktree.symlinkDirectories entry for node_modules`,
+		detail: `${CLAUDE_SETTINGS_FILE} has no worktree.symlinkDirectories entry for ${missing.join(', ')}`,
 		hint,
 	}
 }

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -522,6 +522,19 @@ describe('doctor extended checks', () => {
 		expect((await worktreeCheck(dir))?.status).toBe('ok')
 	})
 
+	it('Claude worktree settings: optional-missing when a workspace node_modules is absent (#406)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		await fs.ensureDir(join(dir, 'apps', 'docs', 'node_modules'))
+		await fs.outputJson(join(dir, '.claude', 'settings.json'), {
+			worktree: { symlinkDirectories: ['node_modules'] },
+		})
+		const result = await worktreeCheck(dir)
+		expect(result?.status).toBe('optional-missing')
+		expect(result?.detail).toContain('apps/docs/node_modules')
+	})
+
 	it('Claude worktree settings: drift when settings.json is unparseable', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/agent-rules.test.ts
+++ b/tests/cli/generators/agent-rules.test.ts
@@ -126,6 +126,26 @@ describe('installClaudeSettings', () => {
 		})
 	})
 
+	it('never writes a path outside the repo, however the workspace glob is spelled', async () => {
+		const root = newTmpDir()
+		const dir = join(root, 'repo')
+		// A sibling of the repo, with the node_modules a traversal glob would match.
+		await fs.ensureDir(join(root, 'shared-lib', 'node_modules'))
+		await fs.ensureDir(join(dir, 'packages', 'core', 'node_modules'))
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'demo',
+			workspaces: ['../shared-lib', 'packages/*'],
+		})
+		await fs.writeFile(
+			join(dir, 'pnpm-workspace.yaml'),
+			`packages:\n  - '${join(root, 'shared-lib')}'\n`
+		)
+		await installClaudeSettings(dir)
+		expect(await fs.readJson(settingsPath(dir))).toEqual({
+			worktree: { symlinkDirectories: ['node_modules', 'packages/core/node_modules'] },
+		})
+	})
+
 	it('refuses to clobber a settings.json that does not parse', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })

--- a/tests/cli/generators/agent-rules.test.ts
+++ b/tests/cli/generators/agent-rules.test.ts
@@ -102,6 +102,30 @@ describe('installClaudeSettings', () => {
 		expect(await installAiSetup(dir)).not.toContain(join('.claude', 'settings.json'))
 	})
 
+	it('adds nested workspace node_modules derived from pnpm-workspace.yaml', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })
+		await fs.writeFile(join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'apps/*'\n")
+		await fs.ensureDir(join(dir, 'apps', 'docs', 'node_modules'))
+		// A workspace with no node_modules of its own is skipped, not listed.
+		await fs.ensureDir(join(dir, 'apps', 'web'))
+		await installClaudeSettings(dir)
+		expect(await fs.readJson(settingsPath(dir))).toEqual({
+			worktree: { symlinkDirectories: ['node_modules', 'apps/docs/node_modules'] },
+		})
+	})
+
+	it('derives them from package.json workspaces too, without duplicating', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', workspaces: ['packages/*'] })
+		await fs.ensureDir(join(dir, 'packages', 'core', 'node_modules'))
+		await installClaudeSettings(dir)
+		await installClaudeSettings(dir)
+		expect(await fs.readJson(settingsPath(dir))).toEqual({
+			worktree: { symlinkDirectories: ['node_modules', 'packages/core/node_modules'] },
+		})
+	})
+
 	it('refuses to clobber a settings.json that does not parse', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), { name: 'demo' })


### PR DESCRIPTION
_(AI-authored PR — implementer agent via ai-issue-loop, posted under @rtorcato's account.)_

Only the root `node_modules` was symlinked into a fresh Claude Code worktree, so any workspace-scoped command failed there on a missing binary (`pnpm --filter <pkg> build` → `command not found`). That reads as a broken toolchain rather than a missing symlink, so the check it was meant to run gets skipped, not fixed.

## What changed

- `workspaceSymlinkDirs()` in `src/cli/generators/agent-rules.ts` derives `<workspace>/node_modules` from the consuming repo's **own** workspace globs — `pnpm-workspace.yaml` `packages:` (reusing the existing `parseWorkspacePackages`, now exported) and/or `package.json` `workspaces` (both array and `{ packages: [] }` forms). No layout is hardcoded.
- `installClaudeSettings` merges those alongside `node_modules`; still additive, so hand-added entries survive and re-running does not duplicate.
- `checkClaudeWorktreeSettings` reports the same derived list, so a repo carrying only the root entry is nudged instead of reading as ok.
- Docs: nested entries + a warning never to run `pnpm install` inside a worktree whose `node_modules` is a symlink (it re-points the shared root `.bin` shims and breaks every other worktree; recover with `pnpm install --frozen-lockfile` from the main checkout).
- Dogfood: this repo's own `.claude/settings.json` gains `apps/docs/node_modules`.

Workspaces with no `node_modules` in the main checkout are skipped — an entry pointing at nothing warns on every worktree creation, and skipping also keeps `doctor` from flapping on an uninstalled checkout.

## Verification

`biome check`, `tsc --noEmit`, full `vitest run` (882 passed / 18 skipped). New tests cover derivation from both glob sources, the skip, idempotency, and the doctor nudge.

Closes #406