### PR TITLE
fix(cli): fail closed when `fix claude-skills` has nowhere to install

### DIFF
--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -85,6 +85,24 @@ export interface Fixer {
 	run(ctx: FixerContext): Promise<{ filesWritten: string[] }>
 }
 
+/**
+ * A fixer giving up on something the user has to resolve — a wrong flag, not a
+ * crash. Thrown rather than printed-and-exited because a fixer runs underneath
+ * `--json`: only the command layer knows whether the failure should surface as
+ * an error payload on stdout or a red line on stderr. `code` joins the same
+ * vocabulary as the command's own `no-lockfile` / `unknown-target` errors.
+ */
+export class FixerAbort extends Error {
+	constructor(
+		readonly code: string,
+		message: string,
+		readonly hint?: string
+	) {
+		super(message)
+		this.name = 'FixerAbort'
+	}
+}
+
 /** The repo's language module, resolved from its marker files. */
 async function moduleFor(targetDir: string) {
 	return resolveLanguageModule(await detectLanguage(targetDir))
@@ -93,15 +111,20 @@ async function moduleFor(targetDir: string) {
 /**
  * Where to install user-global skills, asking only when nothing resolves. Under
  * `--yes` / `--json` a prompt is not available — `--json` would have its payload
- * corrupted by one — so an unresolvable destination becomes an advisory and a
- * no-op rather than a guess at a directory the user never mentioned.
+ * corrupted by one — and guessing at a directory the user never mentioned is not
+ * an option either, so the run fails: `--skills-dir` is required in that case
+ * (#411). It used to warn and no-op, which exited 0 with an empty `filesWritten`
+ * that no `--json` consumer could tell apart from "already up to date".
  */
 async function resolveInstallDir(explicit: string | undefined, assumeYes: boolean) {
 	const { dir } = await resolveSkillsDir(explicit)
 	if (dir) return dir
 	if (assumeYes) {
-		console.error(chalk.yellow('   skipped — no ~/.claude/skills found; pass --skills-dir <path>'))
-		return null
+		throw new FixerAbort(
+			'no-skills-dir',
+			'no ~/.claude/skills found, and --yes/--json cannot prompt for one',
+			'pass --skills-dir <path>'
+		)
 	}
 	const { answer } = await inquirer.prompt([
 		{

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -16,7 +16,13 @@ import type { CheckResult } from './doctor.js'
 import { runDoctor } from './doctor.js'
 import { declinedInLock, lockfilePatchForTarget } from './fix-targets.js'
 import { computeFileList } from './setup-presets.js'
-import { BASE_FIXERS, type Fixer, type FixRiskLevel, type Pkg } from '../../base/fixers.js'
+import {
+	BASE_FIXERS,
+	type Fixer,
+	FixerAbort,
+	type FixRiskLevel,
+	type Pkg,
+} from '../../base/fixers.js'
 import { FIXERS, readPackageJson } from '../../languages/js/fixers.js'
 import { PERL_FIXERS } from '../../languages/perl/fixers.js'
 import { PYTHON_FIXERS } from '../../languages/python/fixers.js'
@@ -524,9 +530,28 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			console.log(chalk.gray('   skipped\n'))
 			return
 		}
+		// ponytail: only the targeted path is guarded, because the only fixer that
+		// aborts is `claude-skills` and it is explicitOnly — the bulk loop below
+		// cannot reach it. A non-explicitOnly fixer that throws FixerAbort would
+		// surface as an unhandled rejection there; guard the loop when one exists.
 		const outcome = await applyFixer(fixer, effectiveResult, targetDir, pkg, lock, dryRun, silent, {
 			skillsDir: options.skillsDir,
 			assumeYes,
+		}).catch((err: unknown) => {
+			if (!(err instanceof FixerAbort)) throw err
+			if (json) {
+				console.log(
+					JSON.stringify(
+						{ directory: targetDir, target: fixer.target, error: err.code, hint: err.hint },
+						null,
+						2
+					)
+				)
+			} else {
+				console.error(chalk.red(`\n❌ ${fixer.target}: ${err.message}`))
+				if (err.hint) console.error(chalk.gray(`   ${err.hint}\n`))
+			}
+			process.exit(1)
 		})
 		actions.push(
 			recordFor(

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1,7 +1,9 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import inquirer from 'inquirer'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runDoctor } from '../../../src/cli/commands/doctor.js'
 import { fixCommand, getFixers, listFixers } from '../../../src/cli/commands/fix.js'
 import {
@@ -1534,5 +1536,53 @@ describe('fix github-actions packageManager', () => {
 		expect(workflow).toContain('run: pnpm typecheck')
 		expect(workflow).not.toContain('run: pnpm knip')
 		expect(workflow).not.toContain('run: pnpm coverage')
+	})
+})
+
+describe('fix claude-skills', () => {
+	// The fixer resolves ~/.claude/skills through os.homedir(), which reads $HOME
+	// on POSIX — so pointing HOME at an empty tmp dir is what "no skills dir
+	// anywhere" looks like from inside the command.
+	const realHome = process.env.HOME
+	beforeEach(() => {
+		process.env.HOME = mkdtempSync(join(tmpdir(), 'repo-tooling-home-'))
+	})
+	afterEach(async () => {
+		const home = process.env.HOME
+		if (realHome === undefined) delete process.env.HOME
+		else process.env.HOME = realHome
+		if (home) await fs.remove(home)
+	})
+
+	it('--json errors instead of reporting an empty success when nothing resolves (#411)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+			throw new Error('exit')
+		}) as never)
+		try {
+			await expect(
+				fixCommand('claude-skills', { directory: dir, json: true })
+			).rejects.toThrow('exit')
+			expect(exitSpy).toHaveBeenCalledWith(1)
+			const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+			expect(payload.error).toBe('no-skills-dir')
+			expect(payload.hint).toMatch(/--skills-dir/)
+			// The bug this covers: the old code emitted a normal actions payload
+			// with an empty filesWritten, which reads as "already up to date".
+			expect(payload.actions).toBeUndefined()
+		} finally {
+			logSpy.mockRestore()
+			exitSpy.mockRestore()
+		}
+	})
+
+	it('--yes --skills-dir installs the skill', async () => {
+		const dir = newTmpDir()
+		const skillsDir = join(process.env.HOME as string, 'skills')
+		await seedPackageJson(dir)
+		await fixCommand('claude-skills', { directory: dir, yes: true, skillsDir })
+		expect(await fs.pathExists(join(skillsDir, 'ai-issue-loop', 'SKILL.md'))).toBe(true)
 	})
 })


### PR DESCRIPTION
🤖 *AI-authored PR. Written by Claude Code under the owner's account; not a human-written description.*

Closes #411.

## The bug

`fix claude-skills --yes` / `--json` with no resolvable `~/.claude/skills` and
no `--skills-dir` exited `0` having installed nothing, and its JSON payload was
indistinguishable from "already up to date":

```json
{ "directory": "…", "target": "claude-skills", "actions": [ { "status": "applied", "filesWritten": [] } ] }
```

The explanation went to stderr, where a `--json` consumer isn't looking. Both
the flag help (`src/cli/index.ts`) and `apps/docs/docs/guides/ai-issue-loop.md`
already documented `--skills-dir` as *required* in that case, so the code was
the side that was wrong. No docs change here.

## The fix

`FixerAbort` — one small error class in `src/base/fixers.ts` carrying a `code`
and a `hint`. `resolveInstallDir` throws it instead of returning `null`; the
targeted-fixer path in `src/cli/commands/fix.ts` catches it and renders either
an error payload on stdout (`--json`) or a red line on stderr, then exits `1`.
`code` joins the same vocabulary as the existing `no-lockfile` /
`unknown-target` errors.

It throws rather than printing-and-exiting because a fixer runs underneath
`--json`: only the command layer knows which channel the failure belongs on, and
`tests/base/stdout-discipline.test.ts` forbids `src/base/**` from writing to
stdout at all.

The interactive path is unchanged — an empty prompt answer is a user declining,
not a failure.

## Scope note

The catch guards the targeted path only. `claude-skills` is `explicitOnly`, so
the bulk `fix` loop cannot reach it; a `ponytail:` comment marks that, so a
future non-`explicitOnly` thrower is an obvious gap rather than a silent
unhandled rejection.

## Verification

- `pnpm verify` — 916 tests pass, biome + typecheck + build clean.
- Two new tests in `tests/cli/commands/fix.test.ts`, the first coverage this
  command path has had: the `--json` failure asserts `error: "no-skills-dir"`
  *and* that no `actions` array is emitted (the old empty-success shape);
  the `--yes --skills-dir` case asserts the skill still installs.
- Manually, against a scratch consumer dir with `HOME` pointed at an empty tmp:

  | invocation | before | after |
  |---|---|---|
  | `--json`, no skills dir | `0` + empty `actions` | `1` + `{"error":"no-skills-dir","hint":"pass --skills-dir <path>"}` |
  | `--yes`, no skills dir | `0` + yellow advisory | `1` + `❌ claude-skills: no ~/.claude/skills found…` |
  | `--json --skills-dir …` | writes SKILL.md, `0` | unchanged |

### Before merging

Behaviour change: a scripted `fix claude-skills` that previously exited `0`
without installing now exits `1`. That is the point of the issue, but anything
running it opportunistically in a pipeline will start failing.
