### PR TITLE
docs(skills): state the approval-rule trap conditionally, not as this repo's

### DIFF
--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -32,13 +32,14 @@ the protected branch — it would deadlock every PR.
 
 **If you ever switch to real approvals** — a second GitHub account reviewing as
 someone else, so `--approve` works and the `ai-ok-*` labels become unnecessary —
-know that `@rtorcato/repo-tooling` will fight you. Its `GITHUB_STANDARD`
-(`src/base/github-settings.ts`) treats any `required_pull_request_reviews` as
-drift because required review deadlocks solo Dependabot auto-merge, and
-`fix github-settings` silently PUTs it back to `null`. So the next unrelated
-`doctor`/`fix` run would strip your approval rule and hand merges back to the
-labels, with nothing in the output tying it to this pipeline. Change the standard
-there first, or don't go down that path.
+first check what else writes your branch protection. Any repo-settings tool that
+treats `required_pull_request_reviews` as drift will PUT it back to `null` on its
+next run, because required review deadlocks solo Dependabot auto-merge. Your
+approval rule vanishes, merges hand themselves back to the labels, and nothing in
+that tool's output ties the change to this pipeline. `@rtorcato/repo-tooling`,
+which ships this skill, is one such tool — its repo-settings standard asserts
+`required_pull_request_reviews: null`, so change that standard before you rely on
+real approvals.
 
 The same constraint makes everything an agent posts *look* hand-written by the
 owner. So **every comment any agent leaves — review, blocked, gave-up, declined —


### PR DESCRIPTION
🤖 *AI-authored PR. Written by Claude Code under the owner's account; not a human-written description.*

Closes #412.

`skills/ai-issue-loop/SKILL.md` asserted this repo's internals as fact:

> know that `@rtorcato/repo-tooling` will fight you. Its `GITHUB_STANDARD`
> (`src/base/github-settings.ts`) treats any `required_pull_request_reviews` as drift…

That file isn't repo-local documentation — `fix claude-skills` installs it to
`~/.claude/skills/ai-issue-loop/SKILL.md`, and it's separately distributable
with `npx skills add … --skill ai-issue-loop`. A reader in either context has no
`src/base/github-settings.ts` to look at.

The warning stays — the trap is real and expensive to rediscover — but now
states the general rule first (*any* settings tool that treats
`required_pull_request_reviews` as drift will revert your approval rule) and
names this package as one instance, with the source path dropped. Naming the
package is provenance, not org-specificity: the skill ships from here and the
installed copy already carries a `repo-tooling-version` frontmatter stamp.

`apps/docs/docs/guides/ai-issue-loop.md` doesn't mirror this paragraph, and its
own `GITHUB_STANDARD` references are repo-local docs where naming internals is
correct. No change there.

## Deliberately out of scope

The `js-common` incident references elsewhere in the file (lines ~165, 196, 251,
483, 515-521) stay. They're evidence for generic rules — the `.claude` Biome
exclusion that silently linted zero files, the auto-merge/review race — not
assertions about internals, the repo is public, and removing them makes the
rules less credible to a reader deciding whether to follow them. Say so if you'd
rather they were genericised; it's a small follow-up.

## Verification

Text-only change to a shipped skill; no code path reads it. `pnpm test --run`
passes (914). Reviewed with no repo checked out — the paragraph now stands on
its own.

### Before merging

Consumers pick this up only on their next `fix claude-skills` after a release,
and the install refuses to downgrade, so an already-installed newer copy is
untouched.
