### PR TITLE
feat(github): make squash the only merge method in the standard

### DIFF
--- a/apps/docs/docs/guides/ai-issue-loop.md
+++ b/apps/docs/docs/guides/ai-issue-loop.md
@@ -107,8 +107,10 @@ implication, a deliberate omission, a follow-up that must be filed.
 npx @rtorcato/repo-tooling fix github-settings --yes
 ```
 
-`GITHUB_STANDARD` already encodes exactly what the loop needs: squash merge,
-auto-merge, delete-branch-on-merge, and `required_pull_request_reviews: null`
+`GITHUB_STANDARD` already encodes exactly what the loop needs: squash as the
+*only* merge method (Pass 2 finds the `(#N)` squash subject on `main` to confirm
+work landed — a merge commit makes it look like nothing merged, and the worktree
+leaks), auto-merge, delete-branch-on-merge, and `required_pull_request_reviews: null`
 with a comment explaining that required review deadlocks auto-merge. You also
 need **at least one required status check** — that is the gate doing the real
 work.
@@ -116,7 +118,7 @@ work.
 Verify:
 
 ```bash
-gh api repos/$OWNER_REPO --jq '{allow_squash_merge, allow_auto_merge, delete_branch_on_merge}'
+gh api repos/$OWNER_REPO --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge, allow_auto_merge, delete_branch_on_merge}'
 gh api repos/$OWNER_REPO/branches/main/protection \
   --jq '{contexts: .required_status_checks.contexts, reviews: .required_pull_request_reviews}'
 ```

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -46,7 +46,7 @@ using `dependabot/fetch-metadata` + `gh pr merge --auto --squash`, gated to
 > and classic branch protection are unavailable on **private repos on the free
 > tier** — GitHub returns 403 for branch protection and silently ignores
 > `allow_auto_merge`. On such repos `repo-tooling fix github-settings` applies what
-> it can (squash-merge, delete-branch-on-merge, workflow permissions) but leaves
+> it can (squash-only merging, delete-branch-on-merge, workflow permissions) but leaves
 > auto-merge and protection off, so `doctor` keeps reporting them as drift. Make
 > the repo public or upgrade the plan to converge fully.
 

--- a/apps/docs/docs/guides/git-flow.md
+++ b/apps/docs/docs/guides/git-flow.md
@@ -52,6 +52,19 @@ and deletion are blocked.
 | Allow force pushes | ❌ |
 | Allow deletions | ❌ |
 
+### Merge method: squash, and only squash
+
+`fix github-settings` turns `allow_merge_commit` and `allow_rebase_merge` **off**
+as well as turning squash on, so the merge button offers one option. Leaving the
+other two enabled means the rule lives only in this document, and one mis-click
+puts every intermediate branch commit on `main`:
+
+- **semantic-release reads them all.** Squash yields one commit per PR whose
+  subject is the reviewed PR title. A merge commit lands subjects nobody
+  reviewed — a stray `fix:` inside a docs-only PR cuts a release.
+- **Agent worktrees leak.** `ai-issue-loop` confirms work landed by finding the
+  `(#N)` squash subject on `main`; without it, cleanup silently finds nothing.
+
 ### Required status checks
 
 The required contexts are exactly the jobs that run on **`pull_request → main`**:

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -805,10 +805,14 @@ times against one trivial issue and watch the labels advance.
 ## Repo prerequisites
 
 ```bash
-gh api repos/$OWNER_REPO --jq '{allow_squash_merge, allow_auto_merge, delete_branch_on_merge}'
+gh api repos/$OWNER_REPO --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge, allow_auto_merge, delete_branch_on_merge}'
 gh api repos/$OWNER_REPO/branches/main/protection --jq '{contexts: .required_status_checks.contexts, reviews: .required_pull_request_reviews}'
 ```
 
-Need: squash + auto-merge + delete-on-merge all true, at least one required
-status check, and `required_pull_request_reviews: null`. See the
-`github-pr-workflow` skill for the one-time bootstrap.
+Need: auto-merge + delete-on-merge + squash all true, **`allow_merge_commit` and
+`allow_rebase_merge` both false**, at least one required status check, and
+`required_pull_request_reviews: null`. Squash has to be the *only* method, not
+merely an available one: Pass 2 confirms a PR landed by finding its `(#N)` squash
+subject on `main`, and a merge commit leaves nothing to find — the worktree then
+survives every tick and its `ai-wip` slot leaks. See the `github-pr-workflow`
+skill for the one-time bootstrap.

--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -124,6 +124,9 @@ interface RepoInfo {
 	autoMerge: boolean
 	squashMerge: boolean
 	deleteOnMerge: boolean
+	/** Squash must be the *only* method — see checkMergeSettings (#410). */
+	mergeCommit: boolean
+	rebaseMerge: boolean
 	// The merge-setting booleans are only returned when the token has admin:read.
 	// A read/write token (e.g. CI's default GITHUB_TOKEN) omits them entirely, so
 	// we track visibility to skip the check rather than read `undefined` as "off".
@@ -155,9 +158,15 @@ async function probeRepo(exec: GhExec): Promise<{ info: RepoInfo } | { skip: str
 			autoMerge: d.allow_auto_merge === true,
 			squashMerge: d.allow_squash_merge === true,
 			deleteOnMerge: d.delete_branch_on_merge === true,
-			mergeVisible: ['allow_auto_merge', 'allow_squash_merge', 'delete_branch_on_merge'].every(
-				(k) => typeof d[k] === 'boolean'
-			),
+			mergeCommit: d.allow_merge_commit === true,
+			rebaseMerge: d.allow_rebase_merge === true,
+			mergeVisible: [
+				'allow_auto_merge',
+				'allow_squash_merge',
+				'delete_branch_on_merge',
+				'allow_merge_commit',
+				'allow_rebase_merge',
+			].every((k) => typeof d[k] === 'boolean'),
 		},
 	}
 }
@@ -240,6 +249,16 @@ async function checkBranchProtection(
 	return { check, status: 'ok', detail: `${branch} protected per standard` }
 }
 
+/**
+ * Squash is required *and exclusive* (#410). Leaving merge-commit or rebase
+ * enabled only makes them available on the merge button, and one mis-click puts
+ * every intermediate branch commit on the default branch: semantic-release then
+ * reads subjects nobody reviewed (a stray `fix:` inside a docs PR cuts a
+ * release), and `ai-issue-loop`'s Pass 2 stops finding the `(#N)` squash subject
+ * it uses to confirm work landed, so worktrees leak. Observed on `js-common`
+ * #204, whose CONTRIBUTING already said squash-only — the rule existed, nothing
+ * enforced it.
+ */
 function checkMergeSettings(info: RepoInfo): CheckResult {
 	const check = 'Merge settings'
 	// The token can't see the merge-setting fields (no admin:read) — skip rather
@@ -249,14 +268,16 @@ function checkMergeSettings(info: RepoInfo): CheckResult {
 	if (!info.autoMerge) deltas.push('auto-merge disabled')
 	if (!info.squashMerge) deltas.push('squash-merge disabled')
 	if (!info.deleteOnMerge) deltas.push('delete-branch-on-merge disabled')
+	if (info.mergeCommit) deltas.push('merge commits allowed (squash only)')
+	if (info.rebaseMerge) deltas.push('rebase merging allowed (squash only)')
 	if (deltas.length)
 		return {
 			check,
 			status: 'drift',
 			detail: deltas.join('; '),
-			hint: 'Enable auto-merge, squash-merge, and delete-branch-on-merge in repo settings',
+			hint: 'Enable auto-merge and delete-branch-on-merge, and make squash the only merge method',
 		}
-	return { check, status: 'ok', detail: 'auto-merge, squash-merge, delete-on-merge all on' }
+	return { check, status: 'ok', detail: 'squash-only, auto-merge and delete-on-merge on' }
 }
 
 async function checkWorkflowPermissions(exec: GhExec, nwo: string): Promise<CheckResult> {
@@ -437,7 +458,7 @@ export function buildGhApplyCommands(state: GhApplyState): GhCommand[] {
 	const commands: GhCommand[] = []
 	if (state.merge)
 		commands.push({
-			label: 'merge settings (auto-merge, squash, delete-on-merge)',
+			label: 'merge settings (squash-only, auto-merge, delete-on-merge)',
 			args: [
 				'api',
 				'-X',
@@ -449,6 +470,10 @@ export function buildGhApplyCommands(state: GhApplyState): GhCommand[] {
 				'allow_squash_merge=true',
 				'-F',
 				'delete_branch_on_merge=true',
+				'-F',
+				'allow_merge_commit=false',
+				'-F',
+				'allow_rebase_merge=false',
 			],
 		})
 	if (state.protection)

--- a/tests/base/github-settings.test.ts
+++ b/tests/base/github-settings.test.ts
@@ -35,6 +35,9 @@ const COMPLIANT_REPO = JSON.stringify({
 	allow_auto_merge: true,
 	allow_squash_merge: true,
 	delete_branch_on_merge: true,
+	// Squash-only: the other two methods are off, not merely unused (#410).
+	allow_merge_commit: false,
+	allow_rebase_merge: false,
 })
 const COMPLIANT_PROTECTION = JSON.stringify({
 	required_status_checks: { strict: false, contexts: ['lint', 'typecheck', 'build', 'test'] },
@@ -226,11 +229,34 @@ describe('checkGitHubSettings — drift', () => {
 				allow_auto_merge: false,
 				allow_squash_merge: true,
 				delete_branch_on_merge: true,
+				allow_merge_commit: false,
+				allow_rebase_merge: false,
 			})
 		)
 		const ms = byName(await checkGitHubSettings(gitRepo(), fakeGh({ repo })), 'Merge settings')
 		expect(ms?.status).toBe('drift')
 		expect(ms?.detail).toContain('auto-merge disabled')
+	})
+
+	it('drifts when merge commits or rebase merging are still allowed (#410)', async () => {
+		// Everything the old standard asked for is on — squash just isn't exclusive,
+		// so the merge button still offers all three and one mis-click puts every
+		// branch commit on main.
+		const repo = ok(
+			JSON.stringify({
+				full_name: 'owner/repo',
+				default_branch: 'main',
+				allow_auto_merge: true,
+				allow_squash_merge: true,
+				delete_branch_on_merge: true,
+				allow_merge_commit: true,
+				allow_rebase_merge: true,
+			})
+		)
+		const ms = byName(await checkGitHubSettings(gitRepo(), fakeGh({ repo })), 'Merge settings')
+		expect(ms?.status).toBe('drift')
+		expect(ms?.detail).toContain('merge commits allowed')
+		expect(ms?.detail).toContain('rebase merging allowed')
 	})
 
 	it('skips (not drifts) when the token cannot see merge fields (no admin:read)', async () => {
@@ -275,6 +301,10 @@ describe('buildGhApplyCommands', () => {
 				'allow_squash_merge=true',
 				'-F',
 				'delete_branch_on_merge=true',
+				'-F',
+				'allow_merge_commit=false',
+				'-F',
+				'allow_rebase_merge=false',
 			],
 			['api', '-X', 'PUT', 'repos/owner/repo/branches/main/protection', '--input', '-'],
 			[
@@ -344,6 +374,8 @@ describe('applyGithubSettings', () => {
 				allow_auto_merge: false,
 				allow_squash_merge: false,
 				delete_branch_on_merge: false,
+				allow_merge_commit: true,
+				allow_rebase_merge: true,
 			})
 		)
 		const { exec, calls } = recordingGh({
@@ -358,7 +390,7 @@ describe('applyGithubSettings', () => {
 		})
 		const labels = await applyGithubSettings(gitRepo(), exec)
 		expect(labels).toEqual([
-			'merge settings (auto-merge, squash, delete-on-merge)',
+			'merge settings (squash-only, auto-merge, delete-on-merge)',
 			'branch protection on main',
 			'workflow permissions (read-only)',
 		])


### PR DESCRIPTION
🤖 *AI-authored PR. Written by Claude Code under the owner's account; not a human-written description.*

Closes #410.

## What changed

`GITHUB_STANDARD` asserted `allow_squash_merge` but never that squash was the
*only* method, so `allow_merge_commit` and `allow_rebase_merge` stayed on and the
merge button kept offering all three.

- `Merge settings` now drifts on either extra method: `merge commits allowed (squash only)` / `rebase merging allowed (squash only)`.
- The fixer's PATCH adds `allow_merge_commit=false` and `allow_rebase_merge=false`.
- `probeRepo` reads all five merge booleans and `mergeVisible` covers them, so a
  token without `admin:read` still *skips* rather than misreading absent fields
  as "off" — the same false-positive guard the check already had.

## Why it's worth a check rather than a line in CONTRIBUTING

`js-common` #204 landed as a merge commit and put three unreviewed subjects on
`main`. The rule already existed in prose; nothing enforced it. Two things
depend on one-commit-per-PR and both fail *quietly*:

1. **semantic-release reads every subject on `main`.** #204's three were all
   `docs(skills):` so no release fired — but one was fixing a security problem,
   and an agent typing `fix:` there would have cut a patch release for a
   docs-only PR. Under squash the reviewed PR title governs and that can't happen.
2. **`ai-issue-loop` Pass 2** confirms a PR landed by finding its `(#N)` squash
   subject on `main`. A merge commit leaves nothing to find, so the worktree
   survives every tick and its `ai-wip` slot leaks while the loop reports idle.

## Docs

`git-flow.md` gains a "squash, and only squash" section with those two reasons;
`ai-issue-loop.md` and the shipped `SKILL.md` state the prerequisite as
squash-*only* and their verify snippets now print `allow_merge_commit` /
`allow_rebase_merge`; `dependabot-strategy.md` wording follows.

## Verification

- `pnpm verify` — 915 tests, biome + typecheck + build clean.
- New test: a repo with everything the old standard wanted, plus both extra
  methods on, now drifts. Existing fixtures gained the two fields, and the
  no-`admin:read` skip test is unchanged and still passes.
- Read-only check against the live fleet — `repo-tooling`, `shared-docs`,
  `js-common`, `cf-common`, `api-common` are all already `merge=false rebase=false`.

### Before merging

This codifies current fleet state, so no repo should move when `fix
github-settings` next runs. A repo that *deliberately* allows merge commits
would now be reported as drift and silently corrected — same asymmetry
`required_pull_request_reviews: null` already has, and the reason both are
documented in the source.
