### PR TITLE
chore(docs): update @rtorcato/shared-docs to ^1.4.3

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,7 +29,7 @@
 		"@docusaurus/module-type-aliases": "^3.10.2",
 		"@docusaurus/tsconfig": "^3.10.2",
 		"@docusaurus/types": "^3.10.2",
-		"@rtorcato/shared-docs": "^1.2.2",
+		"@rtorcato/shared-docs": "^1.4.3",
 		"@types/react": "^19.0.0",
 		"typescript": "~7.0.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^3.10.2
         version: 3.10.2(esbuild@0.28.1)(postcss@8.5.19)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@rtorcato/shared-docs':
-        specifier: ^1.2.2
-        version: 1.2.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.4.3
+        version: 1.4.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -3413,8 +3413,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rtorcato/shared-docs@1.2.2':
-    resolution: {integrity: sha512-gaaFboV1QIgqZgJcw8B7BuX6Ppz46Sn67ua4bM8Vbfbx4O380rYl8I5NTyb0qNczVLGaPVs+bmUJY4lEgW/RnQ==}
+  '@rtorcato/shared-docs@1.4.3':
+    resolution: {integrity: sha512-vxoYedHpSe6VovYFDp/+9zrOUVbu4lgxAd9ck2Ckc856o3NrxeOD5NAHuqYeXj4Vi7C+/h+/L6HzKwrhU+zi7Q==}
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -15003,7 +15003,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
-  '@rtorcato/shared-docs@1.2.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@rtorcato/shared-docs@1.4.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)


### PR DESCRIPTION
🤖 *AI-authored PR. Written by Claude Code under the owner's account; not a human-written description.*

`apps/docs` was pinned `@rtorcato/shared-docs@^1.2.2` with the lockfile resolving
1.2.2 — five releases behind, and the only consumer in the fleet that wasn't
already on 1.4.x (the others sit on `^1.4.2`, which resolves 1.4.3 on their next
install).

1.4.3 is shared-docs #42, which pairs the component colour fallbacks so light
mode no longer renders code blocks near-black on a site that hasn't imported
`theme-tokens.css` (shared-docs #40).

## Verification

`pnpm docs:build` — clean, static files generated. No source changes; the diff
is `apps/docs/package.json` + `pnpm-lock.yaml`.

Still on the git dep and therefore out of scope here: `cf-common`, `js-common`,
`supabase-common` pin `github:rtorcato/shared-docs` (unpinned `main`). That's
shared-docs #8.
