### PR TITLE
feat(github): flag the code-scanning gate colliding with the git plugin

### DIFF
--- a/apps/docs/docs/reference/semantic-release.md
+++ b/apps/docs/docs/reference/semantic-release.md
@@ -55,6 +55,12 @@ That script reads the Releases API, so it cannot freeze the way a file does. Its
 docs workflow needs a `release: types: [published]` trigger — with no release
 commit landing on `main`, a `push` trigger never fires after a release.
 
+`doctor` and `fix github-settings` detect the broken combination for you: if
+code-scanning is enforced on the default branch while your `release.config.mjs`
+still resolves `@semantic-release/git`, the code-scanning gate reports drift and
+names `GH013`. It reads the resolved `plugins` array, so re-exporting the preset
+or filtering the plugin out both read correctly.
+
 :::warning Adding a bypass actor is not the fix
 Exempting the release bot from the ruleset would also make the push succeed. It
 exempts the one commit nobody reviews.

--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import chalk from 'chalk'
 import fs from 'fs-extra'
 import type { CheckResult } from './types.js'
@@ -386,10 +387,56 @@ async function hasCodeScanningRuleset(
 	return 'no'
 }
 
+/** Release config filenames semantic-release picks up that we can import. */
+const RELEASE_CONFIG_FILES = ['release.config.mjs', 'release.config.js'] as const
+
+/** How to stop the GH013 collision, wherever it is reported. */
+const GIT_PLUGIN_REMEDY =
+	'Drop `@semantic-release/git` and `@semantic-release/changelog` from the release config (rtorcato/repo-tooling#417) — the shipped `semantic-release/github` preset already has, so a bare re-export of it is enough. Do NOT add a bypass actor to the ruleset: it exempts the one commit nobody reviews'
+
+/**
+ * Does the repo's release config still resolve `@semantic-release/git`?
+ *
+ * That plugin pushes the release commit straight to the default branch, which a
+ * `code_scanning` ruleset rejects with GH013 — a commit created seconds earlier
+ * can never carry CodeQL results (#417). The two are individually correct and
+ * jointly unwinnable, and the failure is silent, because a merge that produces
+ * no release goes green either way.
+ *
+ * The config is imported rather than grepped, because every cheaper signal is
+ * wrong on a config we ship or recommend: a bare re-export names no plugin at
+ * all; a pinned older repo-tooling re-exports a preset that *does* have it; the
+ * current preset mentions it in a comment explaining its absence; and the
+ * documented way to drop it lists the name in a filter. Only the resolved
+ * `plugins` array distinguishes those. Importing config is what semantic-release
+ * itself does with this file.
+ *
+ * `false` on anything unreadable — a false negative is a missed warning, a false
+ * positive is a wrong one.
+ */
+export async function releaseUsesGitPlugin(dir: string): Promise<boolean> {
+	for (const name of RELEASE_CONFIG_FILES) {
+		const file = path.join(dir, name)
+		if (!(await fs.pathExists(file))) continue
+		try {
+			const mod = await import(pathToFileURL(file).href)
+			const plugins: unknown = mod.default?.plugins
+			if (!Array.isArray(plugins)) return false
+			return plugins.some((p) => (Array.isArray(p) ? p[0] : p) === '@semantic-release/git')
+		} catch {
+			return false
+		}
+	}
+	return false
+}
+
 /**
  * The #269 gap: CodeQL results are advisory by default — a High alert still
  * merges unless a branch ruleset requires the code-scanning check. Only
  * meaningful where CodeQL is actually on, so it no-ops otherwise.
+ *
+ * It also reports the #419 collision: a gate that is correctly in place is still
+ * drift when the release config pushes to the branch it guards.
  */
 async function checkCodeScanningRuleset(
 	gh: GhExec,
@@ -403,14 +450,25 @@ async function checkCodeScanningRuleset(
 	}
 	const found = await hasCodeScanningRuleset(gh, nwo, branch)
 	if (found === 'skip') return skip(check, 'could not read rulesets')
+	const gitPlugin = await releaseUsesGitPlugin(dir)
 	if (found === 'yes') {
+		if (gitPlugin) {
+			return {
+				check,
+				status: 'drift',
+				detail: `active ruleset requires code-scanning on ${branch}, but the release config still uses \`@semantic-release/git\` — its push to ${branch} will be rejected with GH013, and the release fails silently`,
+				hint: GIT_PLUGIN_REMEDY,
+			}
+		}
 		return { check, status: 'ok', detail: `active ruleset requires code-scanning on ${branch}` }
 	}
 	return {
 		check,
 		status: 'drift',
 		detail: `CodeQL is on but no active ruleset requires code-scanning on ${branch} (High alerts stay advisory)`,
-		hint: 'Run `npx @rtorcato/repo-tooling fix github-settings` to add a code_scanning branch ruleset that blocks merge on High+ CodeQL alerts',
+		hint: gitPlugin
+			? `Run \`npx @rtorcato/repo-tooling fix github-settings\` to add a code_scanning branch ruleset that blocks merge on High+ CodeQL alerts. That ruleset will reject this repo's release commit with GH013 while the config uses \`@semantic-release/git\`. ${GIT_PLUGIN_REMEDY}`
+			: 'Run `npx @rtorcato/repo-tooling fix github-settings` to add a code_scanning branch ruleset that blocks merge on High+ CodeQL alerts',
 	}
 }
 
@@ -555,9 +613,13 @@ export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<s
 	}
 
 	// Code-scanning ruleset (#269): POST only when CodeQL is on and no active gate
-	// covers the default branch — the check re-read keeps this idempotent.
-	const cs = await checkCodeScanningRuleset(gh, info.nwo, info.branch, dir)
-	if (cs.status === 'drift') {
+	// covers the default branch. Asked directly rather than via the check's
+	// status, because that status is also `drift` when the gate is already
+	// installed and merely collides with the release config (#419) — keying the
+	// POST off it would file a duplicate ruleset.
+	const codeql = await codeqlEnabled(gh, info.nwo, dir)
+	const ruleset = codeql ? await hasCodeScanningRuleset(gh, info.nwo, info.branch) : 'skip'
+	if (ruleset === 'no') {
 		const label = `code-scanning ruleset on ${info.branch}`
 		const r = await gh(
 			['api', '-X', 'POST', `repos/${info.nwo}/rulesets`, '--input', '-'],
@@ -566,6 +628,19 @@ export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<s
 		if (r.ok) applied.push(label)
 		else
 			console.error(chalk.yellow(`   could not apply ${label}: ${r.stderr.trim() || 'gh error'}`))
+	}
+
+	// #419: the gate is right and the release config is wrong, so say so instead
+	// of quietly installing the half that breaks the next release. Warned on
+	// `yes` too — that repo is already broken, it just hasn't released yet.
+	if (ruleset !== 'skip' && (await releaseUsesGitPlugin(dir))) {
+		console.error(
+			chalk.yellow(
+				`   warning: code-scanning is enforced on ${info.branch}, but the release config still uses \`@semantic-release/git\`.\n` +
+					`   Its push to ${info.branch} will be rejected with GH013 and the release will fail silently.\n` +
+					`   ${GIT_PLUGIN_REMEDY}.`
+			)
+		)
 	}
 
 	if (applied.length === 0) console.error(chalk.gray('   already configured — nothing to apply'))

--- a/tests/base/github-settings.test.ts
+++ b/tests/base/github-settings.test.ts
@@ -7,6 +7,7 @@ import {
 	checkGitHubSettings,
 	type GhExec,
 	type GhResult,
+	releaseUsesGitPlugin,
 } from '../../src/base/github-settings.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
@@ -51,9 +52,42 @@ const COMPLIANT_WORKFLOW = JSON.stringify({
 	can_approve_pull_request_reviews: false,
 })
 
+/** A repo carrying a release.config.mjs, for the #419 collision checks. */
+function repoWithRelease(source: string): string {
+	const dir = gitRepo()
+	fs.writeFileSync(join(dir, 'release.config.mjs'), source)
+	return dir
+}
+
+const WITH_GIT_PLUGIN = `export default {
+	plugins: ['@semantic-release/npm', ['@semantic-release/git', { assets: ['package.json'] }]],
+}
+`
+
+/** The remedy's own shape: the plugin name appears, filtered out of the array. */
+const FILTERS_GIT_PLUGIN = `const DROPPED = new Set(['@semantic-release/git', '@semantic-release/changelog'])
+const preset = { plugins: ['@semantic-release/npm', '@semantic-release/git'] }
+export default {
+	...preset,
+	plugins: preset.plugins.filter((p) => !DROPPED.has(Array.isArray(p) ? p[0] : p)),
+}
+`
+
 /** default-setup reads `not-configured` unless overridden → CodeQL gate no-ops. */
 const CODEQL_OFF = JSON.stringify({ state: 'not-configured' })
 const CODEQL_ON = JSON.stringify({ state: 'configured' })
+
+/** CodeQL on, with an active code_scanning ruleset covering the default branch. */
+const ACTIVE_GATE = {
+	defaultSetup: ok(CODEQL_ON),
+	rulesets: ok(JSON.stringify([{ id: 7, target: 'branch', enforcement: 'active' }])),
+	rulesetDetail: ok(
+		JSON.stringify({
+			rules: [{ type: 'code_scanning' }],
+			conditions: { ref_name: { include: ['~DEFAULT_BRANCH'] } },
+		})
+	),
+}
 
 interface GhOverrides {
 	repo?: GhResult
@@ -131,16 +165,7 @@ describe('checkGitHubSettings — code-scanning gate (#269)', () => {
 	})
 
 	it('is ok when an active ruleset enforces code-scanning on the default branch', async () => {
-		const exec = fakeGh({
-			defaultSetup: ok(CODEQL_ON),
-			rulesets: ok(JSON.stringify([{ id: 7, target: 'branch', enforcement: 'active' }])),
-			rulesetDetail: ok(
-				JSON.stringify({
-					rules: [{ type: 'code_scanning' }],
-					conditions: { ref_name: { include: ['~DEFAULT_BRANCH'] } },
-				})
-			),
-		})
+		const exec = fakeGh(ACTIVE_GATE)
 		const g = gate(await checkGitHubSettings(gitRepo(), exec))
 		expect(g?.status).toBe('ok')
 		expect(g?.detail).toContain('requires code-scanning on main')
@@ -166,6 +191,43 @@ describe('checkGitHubSettings — code-scanning gate (#269)', () => {
 		const g = gate(await checkGitHubSettings(gitRepo(), exec))
 		expect(g?.status).toBe('ok')
 		expect(g?.detail).toContain('skipped')
+	})
+
+	it('drifts when the gate is in place but the release config still pushes to it (#419)', async () => {
+		const dir = repoWithRelease(WITH_GIT_PLUGIN)
+		const g = gate(await checkGitHubSettings(dir, fakeGh(ACTIVE_GATE)))
+		expect(g?.status).toBe('drift')
+		expect(g?.detail).toContain('GH013')
+		expect(g?.hint).toContain('@semantic-release/changelog')
+	})
+
+	it('names the collision in the hint when the gate is still missing (#419)', async () => {
+		const dir = repoWithRelease(WITH_GIT_PLUGIN)
+		const exec = fakeGh({ defaultSetup: ok(CODEQL_ON), rulesets: ok('[]') })
+		const g = gate(await checkGitHubSettings(dir, exec))
+		expect(g?.status).toBe('drift')
+		expect(g?.detail).toContain('High alerts stay advisory')
+		expect(g?.hint).toContain('GH013')
+	})
+})
+
+describe('releaseUsesGitPlugin (#419)', () => {
+	it('is true when the resolved plugins include the git plugin', async () => {
+		expect(await releaseUsesGitPlugin(repoWithRelease(WITH_GIT_PLUGIN))).toBe(true)
+	})
+
+	it('is false when a config lists the plugin only to filter it out', async () => {
+		// The documented way to drop it names the plugin in a Set, so any
+		// text-level grep reports this backwards. Only the resolved array is right.
+		expect(await releaseUsesGitPlugin(repoWithRelease(FILTERS_GIT_PLUGIN))).toBe(false)
+	})
+
+	it('is false when there is no release config at all', async () => {
+		expect(await releaseUsesGitPlugin(gitRepo())).toBe(false)
+	})
+
+	it('is false (never a wrong warning) when the config throws on import', async () => {
+		expect(await releaseUsesGitPlugin(repoWithRelease('throw new Error("boom")\n'))).toBe(false)
 	})
 })
 
@@ -426,5 +488,41 @@ describe('applyGithubSettings', () => {
 		const { exec, calls } = recordingGh()
 		await applyGithubSettings(gitRepo(), exec)
 		expect(calls.some((c) => c.args.includes('POST'))).toBe(false)
+	})
+
+	it('does not POST a duplicate when the gate exists and the config collides (#419)', async () => {
+		// That combination is drift on the check side now, so the POST must not
+		// key off the check's status.
+		const { exec, calls } = recordingGh(ACTIVE_GATE)
+		const labels = await applyGithubSettings(repoWithRelease(WITH_GIT_PLUGIN), exec)
+		expect(labels).not.toContain('code-scanning ruleset on main')
+		expect(
+			calls.some((c) => c.args.some((a) => a.endsWith('/rulesets')) && c.args.includes('POST'))
+		).toBe(false)
+	})
+
+	it('warns about the git plugin while still installing the ruleset (#419)', async () => {
+		const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			const { exec } = recordingGh({ defaultSetup: ok(CODEQL_ON), rulesets: ok('[]') })
+			const labels = await applyGithubSettings(repoWithRelease(WITH_GIT_PLUGIN), exec)
+			expect(labels).toContain('code-scanning ruleset on main')
+			const said = warn.mock.calls.flat().join('\n')
+			expect(said).toContain('GH013')
+			expect(said).toContain('@semantic-release/git')
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it('stays quiet when the release config has no git plugin (#419)', async () => {
+		const warn = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			const { exec } = recordingGh(ACTIVE_GATE)
+			await applyGithubSettings(repoWithRelease(FILTERS_GIT_PLUGIN), exec)
+			expect(warn.mock.calls.flat().join('\n')).not.toContain('GH013')
+		} finally {
+			warn.mockRestore()
+		}
 	})
 })


### PR DESCRIPTION
> Written by Claude (AI agent) on rtorcato's behalf.

Closes #419 — the detection half of #417. #418 fixed the preset; this
catches the repos that keep the broken pair anyway: anything pinning
an older `repo-tooling`, or with a hand-rolled `release.config.mjs`.

`cf-common`, `db-common` and `browser-common` are all in that state
today. None has released since the rulesets were created, so they are
untested rather than safe — `doctor` now says so before their next
release does.

## Where it reports

| gate on default branch | config uses `@semantic-release/git` | before | now |
|---|---|---|---|
| present | yes | `ok` | **`drift`**, naming GH013 |
| missing | yes | `drift` | `drift`, hint names the collision too |
| present | no | `ok` | `ok` |
| missing | no | `drift` | `drift` |

The already-installed row is the one that matters: that repo is
already broken, it just has not released yet.

`fix github-settings` prints the same warning **and still installs the
ruleset**. The gate is right; the release config is wrong. Per the
issue, "add a bypass actor" is never offered as the remedy — it
exempts the one commit nobody reviews.

## Why it imports the config

#419 sketched a grep with a preset-resolution fallback and I went the
other way, because every text-level signal is wrong on a config we
ship or recommend:

- a bare `export { default } from '…/semantic-release/github'` names
  no plugin at all;
- a repo pinning an older `repo-tooling` re-exports a preset that
  *does* have it — same text, opposite answer;
- the current preset mentions `@semantic-release/git` in the comment
  explaining its absence → false positive;
- the documented remedy (js-common's `DROPPED` set) lists the name in
  order to filter it out → false positive, on the exact config we tell
  people to write.

Only the resolved `plugins` array separates those, and importing this
file is what semantic-release itself does with it. Anything unreadable
returns `false`: a missed warning beats a wrong one. Both false-positive
shapes have a test.

## One thing to look at

`applyGithubSettings` used to POST the ruleset when the check's status
was `drift`. That status now also means "gate present, config
collides", so keying off it would file a **duplicate** ruleset. The
POST asks `hasCodeScanningRuleset(...) === 'no'` directly instead —
shorter, and it cannot drift back into wrongness. Covered by a test
asserting no POST in exactly that case.

## Verified

`pnpm run verify` green (926 tests, 9 new). Also confirms #418 in
production: the merge published **3.11.1** to npm with a GitHub
Release, no release commit on `main`, no GH013.
