### PR TITLE
fix(docs): repair the docs tsconfig for TypeScript 7

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -3,19 +3,22 @@
 // and can also run the package.json "typecheck" script manually.
 {
   "compilerOptions": {
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0",
+    // TypeScript 7 removed `baseUrl`. `paths` without it resolves relative to
+    // this file, which is what `@site/*` needs anyway — it never resolved
+    // before, because this config sets no `paths` at all.
+    "paths": { "@site/*": ["./*"] },
     "strict": true,
     "target": "ES2020",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "exclude": [".docusaurus", "build"]
+  "include": ["src/", "docusaurus.config.ts", "sidebars.ts"],
+  "exclude": [".docusaurus", "build", "node_modules"]
 }


### PR DESCRIPTION
`pnpm exec tsc -p apps/docs/tsconfig.json` currently **fails outright** on TS 7.0.2 — not a warning, two removed options:

```
apps/docs/tsconfig.json(6,5):   error TS5102 Option 'baseUrl' has been removed.
apps/docs/tsconfig.json(13,25): error TS5108 Option 'moduleResolution=node10' has been removed.
```

The existing `ignoreDeprecations: "6.0"` cannot help: these are removals, not deprecations, and that value is no longer accepted in 7.

### Changes

- **`baseUrl` → `paths: {"@site/*": ["./*"]}`.** Without `baseUrl`, `paths` resolves relative to the config file — which is what `@site/*` needed all along. This config declared **no `paths` at all**, so `@site/src/components/InstallTabs` never actually resolved; the config errors hid it by aborting before any file was checked. So this fixes a second, quieter bug.
- **`moduleResolution: node` → `bundler`**, consistent with `module: ESNext`.
- **Adds `include`, restores `node_modules` to `exclude`.** An explicit `exclude` replaces tsc's default rather than extending it, so node_modules was in scope.

### Why not extend `@docusaurus/tsconfig` like the sibling repos

That package sets `baseUrl` itself, which is unfixable from the consumer side on TS 7 — the option is gone, and no flag suppresses a removal. The sibling repos get away with `ignoreDeprecations: "6.0"` only because they're still on TS 6. This config stays standalone until Docusaurus ships a TS 7-compatible tsconfig.

Verified: `tsc --noEmit -p apps/docs/tsconfig.json` clean, `pnpm typecheck` and `pnpm check` unaffected.