### PR TITLE
chore(deps): bump @rtorcato/shared-docs to ^1.7.0

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,7 +29,7 @@
 		"@docusaurus/module-type-aliases": "^3.10.2",
 		"@docusaurus/tsconfig": "^3.10.2",
 		"@docusaurus/types": "^3.10.2",
-		"@rtorcato/shared-docs": "^1.4.3",
+		"@rtorcato/shared-docs": "^1.7.0",
 		"@types/react": "^19.0.0",
 		"typescript": "~7.0.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,8 +209,8 @@ importers:
         specifier: ^3.10.2
         version: 3.10.2(esbuild@0.28.1)(postcss@8.5.19)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@rtorcato/shared-docs':
-        specifier: ^1.4.3
-        version: 1.4.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^1.7.0
+        version: 1.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -3413,8 +3413,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rtorcato/shared-docs@1.4.3':
-    resolution: {integrity: sha512-vxoYedHpSe6VovYFDp/+9zrOUVbu4lgxAd9ck2Ckc856o3NrxeOD5NAHuqYeXj4Vi7C+/h+/L6HzKwrhU+zi7Q==}
+  '@rtorcato/shared-docs@1.7.0':
+    resolution: {integrity: sha512-9QapDG7+TknF9yCuREyDPTLhYMMXzO89y4OS4Ly5f1er5F+sjjlz7P2RCD7fhY1AyKrijfmqBngv/yPkVlz7Cw==}
     engines: {node: '>=22'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -14998,7 +14998,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
-  '@rtorcato/shared-docs@1.4.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@rtorcato/shared-docs@1.7.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

Picks up the two family changes the docs site was missing:

- **1.6.0** added `@rtorcato/infra-x` to `FAMILY`, so the nav dropdown, footer, and sibling grid never rendered it.
- **1.7.0** renamed `db-x` and `infra-x` to `@rtorcato/db-x` / `@rtorcato/infra-x`. `Siblings.tsx` renders `name` verbatim, so `db-x` showed bare next to cards that all read `@rtorcato/…`.

`pnpm-workspace.yaml` needed **no** `minimumReleaseAgeExclude` entry — its existing `'@rtorcato/*'` wildcard already covers this package, so nothing was written and nothing had to be backed out.

## Verification

The lockfile resolves `@rtorcato/shared-docs@1.7.0`. I confirmed against the published 1.7.0 tarball that `dist/family.js` carries the `@rtorcato/infra-x` entry.

I could **not** run \`pnpm --filter '*docs*' build\` locally: this worktree's \`node_modules\` is a symlink into the main checkout, so \`pnpm install\` wanted to purge the shared directory. I used \`pnpm install --lockfile-only\` instead and left the build to CI. Worth a look at the rendered sibling grid before merge.

## Release impact

\`chore(deps):\` — \`shared-docs\` is a devDependency of the private docs app, so this publishes nothing from this repo.

Closes #430