### PR TITLE
fix(doctor): stop requiring sync-changelog on Changesets repos

### DIFF
--- a/apps/docs/docs/reference/docusaurus.md
+++ b/apps/docs/docs/reference/docusaurus.md
@@ -59,7 +59,9 @@ When a Docusaurus site exists (`apps/docs/docusaurus.config.ts` or
 `apps/doc/…`), `doctor` reports a **Docs site** check that verifies:
 
 - `scripts/sync-changelog.mjs` exists and is chained into the docs app's
-  `build`/`start` scripts.
+  `build`/`start` scripts. Skipped when `.changeset/config.json` is present —
+  Changesets writes per-package changelogs, so there is no root `CHANGELOG.md`
+  to sync.
 - The Pages deploy workflow uploads `apps/doc*/build` (not `dist`).
 
 Repos without a docs site don't see the check — it's opt-in.

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -757,6 +757,11 @@ export async function checkSizeLimit(dir: string, pkg: Pkg | null): Promise<Chec
 	}
 }
 
+/** Changesets is in use when its config file is present. */
+export function usesChangesets(dir: string): Promise<boolean> {
+	return fs.pathExists(path.join(dir, '.changeset', 'config.json'))
+}
+
 const SEMANTIC_RELEASE_FILES = [
 	'.releaserc',
 	'.releaserc.json',
@@ -788,7 +793,7 @@ export async function checkSemanticRelease(dir: string, pkg: Pkg | null): Promis
 		}
 	}
 
-	const hasChangesets = await fs.pathExists(path.join(dir, '.changeset', 'config.json'))
+	const hasChangesets = await usesChangesets(dir)
 	const hasReleasePlease = await fs.pathExists(path.join(dir, 'release-please-config.json'))
 	const hasSemanticRelease = inPkg || !!configFile
 
@@ -1320,9 +1325,13 @@ export async function checkDocsSite(dir: string, docsAppDir: string): Promise<Ch
 	const check = 'Docs site'
 	const deltas: string[] = []
 
+	// sync-changelog pumps a root CHANGELOG.md into the site — a semantic-release
+	// shape. Changesets writes per-package changelogs and leaves the (private)
+	// root package without one, so don't require the script there (#425). If a
+	// Changesets repo keeps the script anyway, it still has to be wired.
 	const syncPath = path.join(dir, 'scripts', 'sync-changelog.mjs')
 	if (!(await fs.pathExists(syncPath))) {
-		deltas.push('scripts/sync-changelog.mjs missing')
+		if (!(await usesChangesets(dir))) deltas.push('scripts/sync-changelog.mjs missing')
 	} else {
 		const pkgPath = path.join(dir, docsAppDir, 'package.json')
 		if (await fs.pathExists(pkgPath)) {

--- a/tests/cli/docs-site.test.ts
+++ b/tests/cli/docs-site.test.ts
@@ -122,6 +122,28 @@ describe('generateDocsSite', () => {
 		expect(docs?.status).toBe('ok')
 	})
 
+	// A Changesets repo writes per-package changelogs and its root package is
+	// private, so there is no root CHANGELOG.md for sync-changelog to pump (#425).
+	it('does not require sync-changelog on a Changesets repo (#425)', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), PKG)
+		await generateDocsSite(PKG, dir)
+		await fs.remove(join(dir, 'scripts/sync-changelog.mjs'))
+		const docsPkgPath = join(dir, 'apps/docs/package.json')
+		const docsPkg = await fs.readJson(docsPkgPath)
+		docsPkg.scripts = { build: 'docusaurus build', start: 'docusaurus start' }
+		await fs.writeJson(docsPkgPath, docsPkg)
+
+		// Without Changesets the same layout is still drift.
+		const before = (await runDoctor(dir)).find((r) => r.check === 'Docs site')
+		expect(before?.status).toBe('drift')
+		expect(before?.detail).toContain('sync-changelog.mjs missing')
+
+		await fs.outputJson(join(dir, '.changeset/config.json'), { changelog: '@changesets/cli' })
+		const after = (await runDoctor(dir)).find((r) => r.check === 'Docs site')
+		expect(after?.status).toBe('ok')
+	})
+
 	it('emits the shared badge row into the docs homepage (#169)', async () => {
 		const dir = newTmpDir()
 		await generateDocsSite(PKG, dir)


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

## Summary

- The `Docs site` doctor check hard-required `scripts/sync-changelog.mjs`, encoding the semantic-release layout (one root `CHANGELOG.md` synced into the site). Changesets writes per-package changelogs and leaves the private root package without one, so the check forced those repos to ship a stale page or go red in CI.
- Skip the requirement when `.changeset/config.json` is present. The release-tool detection the `semantic-release` check already does is extracted as `usesChangesets(dir)` and reused, rather than duplicated.
- A Changesets repo that keeps the script anyway still has to chain it into the docs app's `build`/`start` — only the "missing" assertion is relaxed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling

## Test plan

- [x] Existing tests pass (`pnpm test --run` — 909 passed, 18 skipped)
- [x] New tests added for new behaviour — `tests/cli/docs-site.test.ts` asserts the same unwired layout is `drift` without `.changeset/config.json` and `ok` with it
- [x] `pnpm run typecheck` clean

## Checklist

- [x] No `console.log` left in production code
- [x] No breaking changes
- [x] `pnpm check` (Biome) passes

Closes #425