### PR TITLE
feat(claude): ship sync-agents.mjs as a copy asset

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -27,7 +27,9 @@ npx @rtorcato/repo-tooling copy biome     # → biome.json
 npx @rtorcato/repo-tooling copy tsconfig  # → tsconfig.json
 ```
 
-Available presets: `biome`, `tsconfig`, `bun`, `nx`, `changesets`, `release-please`, `oxlint`, `claude-skill`, `mcp-example`, `docusaurus-sync-changelog`, `docusaurus-theme-tokens`, `docusaurus-theme`.
+Available presets: `biome`, `tsconfig`, `bun`, `nx`, `changesets`, `release-please`, `oxlint`, `claude-skill`, `claude-sync-agents`, `mcp-example`, `docusaurus-sync-changelog`, `docusaurus-theme-tokens`, `docusaurus-theme`.
+
+`claude-sync-agents` copies `scripts/sync-agents.mjs`, which regenerates `AGENTS.md` from `skills/<package>/SKILL.md` so the two can't drift. It is zero-config — the skill directory comes from the root `package.json` `name` with the npm scope stripped (`@rtorcato/js-common` → `skills/js-common/`). Wire `node scripts/sync-agents.mjs --check` into CI to fail on a stale `AGENTS.md`.
 
 `copy` is for configs you must *own* rather than extend — Biome doesn't support configuration extension, and TypeScript configs resolve more reliably when local. Most other configs (ESLint, Prettier, Vitest, etc.) can be imported or extended directly — see the [Configuration Reference](../reference/biome.md) for usage.
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
 		"tooling/semantic-release/*.mjs",
 		"tooling/semantic-release/*.d.mts",
 		"tooling/claude/*.md",
+		"tooling/claude/*.mjs",
 		"tooling/mcp/mcp.json.example",
 		"tooling/swift/*.yml",
 		"tooling/swift/*.json",

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -18,6 +18,7 @@ export type PresetName =
 	| 'perlcritic'
 	| 'perltidy'
 	| 'claude-skill'
+	| 'claude-sync-agents'
 	| 'mcp-example'
 	| 'docusaurus-sync-changelog'
 	| 'docusaurus-theme-tokens'
@@ -112,6 +113,11 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		target: '.claude/skills/repo-tooling.md',
 		desc: 'Claude Code skill for driving the repo-tooling CLI',
 		legacyTarget: '.claude/skills/js-tooling.md',
+	},
+	'claude-sync-agents': {
+		source: 'tooling/claude/sync-agents.mjs',
+		target: 'scripts/sync-agents.mjs',
+		desc: 'Canonical SKILL.md → AGENTS.md sync script (zero-config; --check mode for CI)',
 	},
 	'mcp-example': {
 		source: 'tooling/mcp/mcp.json.example',

--- a/tests/cli/claude-helpers.test.ts
+++ b/tests/cli/claude-helpers.test.ts
@@ -1,0 +1,59 @@
+import { execFile } from 'node:child_process'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { copyPreset } from '../../src/cli/utils/copy-preset.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const execFileAsync = promisify(execFile)
+const newTmpDir = useTmpDir()
+
+/** A repo laid out the way the asset expects: scoped name + matching skills dir. */
+async function seedSkillRepo(name: string, skillDir: string): Promise<string> {
+	const dir = newTmpDir()
+	await fs.writeJson(join(dir, 'package.json'), { name, version: '0.0.0' })
+	await fs.outputFile(
+		join(dir, `skills/${skillDir}/SKILL.md`),
+		'---\nname: demo\ndescription: a demo skill\n---\n\n# Demo\n\nBody text.\n'
+	)
+	await copyPreset('claude-sync-agents', dir)
+	return dir
+}
+
+const runSync = (dir: string, ...args: string[]) =>
+	execFileAsync(process.execPath, [join(dir, 'scripts/sync-agents.mjs'), ...args])
+
+describe('copy claude-sync-agents', () => {
+	it('lands at scripts/sync-agents.mjs', async () => {
+		const dir = await seedSkillRepo('@rtorcato/js-common', 'js-common')
+		expect(await fs.pathExists(join(dir, 'scripts/sync-agents.mjs'))).toBe(true)
+	})
+
+	it('derives the skill path from a scoped package name and strips frontmatter', async () => {
+		const dir = await seedSkillRepo('@rtorcato/js-common', 'js-common')
+		await runSync(dir)
+		const agents = await fs.readFile(join(dir, 'AGENTS.md'), 'utf-8')
+		expect(agents).toBe(
+			'<!-- Generated from skills/js-common/SKILL.md by scripts/sync-agents.mjs — do not edit by hand; run `pnpm sync:agents`. -->\n\n# Demo\n\nBody text.\n'
+		)
+	})
+
+	it('derives the skill path from an unscoped package name too', async () => {
+		// api-common publishes unscoped; the same copied file must work there.
+		const dir = await seedSkillRepo('api-common', 'api-common')
+		await runSync(dir)
+		expect(await fs.readFile(join(dir, 'AGENTS.md'), 'utf-8')).toContain(
+			'Generated from skills/api-common/SKILL.md'
+		)
+	})
+
+	it('--check passes when in sync and exits 1 when stale', async () => {
+		const dir = await seedSkillRepo('@rtorcato/js-common', 'js-common')
+		await runSync(dir)
+		await expect(runSync(dir, '--check')).resolves.toBeTruthy()
+
+		await fs.appendFile(join(dir, 'AGENTS.md'), 'hand-edited\n')
+		await expect(runSync(dir, '--check')).rejects.toMatchObject({ code: 1 })
+	})
+})

--- a/tooling/claude/sync-agents.mjs
+++ b/tooling/claude/sync-agents.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Canonical sync-agents for @rtorcato/* repos (shipped by @rtorcato/repo-tooling
+// — copy via `repo-tooling copy claude-sync-agents`).
+//
+// Regenerates AGENTS.md from the repo's SKILL.md body so the two can never
+// drift. SKILL.md (with its YAML frontmatter) is the single source of truth;
+// AGENTS.md is its frontmatter-stripped mirror for non-Claude AI tools.
+//
+//   node scripts/sync-agents.mjs           # write AGENTS.md
+//   node scripts/sync-agents.mjs --check   # exit 1 if AGENTS.md is stale (used by CI)
+//
+// Zero-config: the skill directory is derived from the root package.json `name`
+// with any npm scope stripped — `@rtorcato/js-common` → `skills/js-common/`.
+// That is the convention across the family, so this file is copied unmodified.
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const { name } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+const skillRelative = `skills/${name.replace(/^@[^/]+\//, '')}/SKILL.md`
+const SKILL = join(root, skillRelative)
+const AGENTS = join(root, 'AGENTS.md')
+
+const HEADER = `<!-- Generated from ${skillRelative} by scripts/sync-agents.mjs — do not edit by hand; run \`pnpm sync:agents\`. -->\n\n`
+
+// Strip the leading YAML frontmatter block, keep the markdown body.
+const body = readFileSync(SKILL, 'utf8').replace(/^---\n[\s\S]*?\n---\n+/, '')
+const expected = HEADER + body
+
+if (process.argv.includes('--check')) {
+	let current = ''
+	try {
+		current = readFileSync(AGENTS, 'utf8')
+	} catch {
+		// AGENTS.md missing → treat as stale below.
+	}
+	if (current !== expected) {
+		console.error(`AGENTS.md is out of sync with ${skillRelative} — run \`pnpm sync:agents\`.`)
+		process.exit(1)
+	}
+	console.log(`AGENTS.md is in sync with ${skillRelative}.`)
+} else {
+	writeFileSync(AGENTS, expected)
+	console.log(`Wrote AGENTS.md from ${skillRelative}`)
+}


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

`api-common`, `browser-common` and `js-common` each carry a hand-maintained copy of `scripts/sync-agents.mjs`. Diffing them, every difference is the package name spliced into a path and two log lines — the logic is byte-identical. This ships one canonical copy.

## What's here

- `tooling/claude/sync-agents.mjs` — the asset, modelled on `tooling/docusaurus/sync-changelog.mjs`. First script asset under `tooling/claude/`.
- Registered as `claude-sync-agents` in `src/cli/utils/copy-preset.ts` → `scripts/sync-agents.mjs`.
- `package.json` `files` gains `tooling/claude/*.mjs` — the existing entry was `*.md` only, so without this the asset would not ship.
- `tests/cli/claude-helpers.test.ts` — copies the asset into a seeded tmp repo and **runs it with node**, asserting the generated `AGENTS.md` bytes, the unscoped-name path, and that `--check` exits 1 on a stale file.
- Docs: preset list + a short paragraph in `apps/docs/docs/guides/cli.md`.

## Zero-config, as the issue proposed

The skill path comes from the root `package.json` `name` with any npm scope stripped, so the same bytes work unmodified in each repo:

```js
const skillRelative = `skills/${name.replace(/^@[^/]+\//, '')}/SKILL.md`
```

Verified the derived header matches each repo's current `AGENTS.md` first line exactly:

| repo | `package.json` name | derived | current `AGENTS.md` header |
|---|---|---|---|
| js-common | `@rtorcato/js-common` | `skills/js-common/SKILL.md` | ✅ identical |
| browser-common | `@rtorcato/browser-common` | `skills/browser-common/SKILL.md` | ✅ identical |
| api-common | `api-common` (unscoped) | `skills/api-common/SKILL.md` | ✅ identical |

So all three can delete their copies and re-copy with no diff.

## The `SKILL_PATH` override — skipped

The issue flagged it as conditional on api-common's layout. Checked: `api-common/skills/api-common/` is keyed on the root package name like the others, and its unscoped name still derives correctly. Nothing needs the override, so it isn't there. Easy to add later if a consumer diverges.

## Scope

This repo only. No changes to api-common / browser-common / js-common — their adoption is tracked separately per the issue.

`pnpm check`, `pnpm typecheck` and the full suite (912 passed) are green locally.

Closes #427