### PR TITLE
feat(doctor): detect Biome $schema drift from the installed CLI

### DIFF
--- a/apps/docs/biome.json
+++ b/apps/docs/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "root": false,
   "extends": ["@rtorcato/repo-tooling/biome"],
   "files": {

--- a/biome.json
+++ b/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "extends": ["@rtorcato/repo-tooling/biome"]
 }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -42,6 +42,7 @@ import type { CheckResult, CheckStatus } from '../../base/types.js'
 import {
 	allDeps,
 	checkAreTheTypesWrong,
+	checkBiome,
 	checkClaudeWorktreeSettings,
 	checkConfigSchemaVersions,
 	checkDocsSite,
@@ -385,7 +386,12 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 	results.push(await checkNodeVersionPin(targetDir))
 	results.push(await checkNodeVersionConsistency(targetDir, pkg))
 	for (const spec of FILE_CHECKS) {
-		results.push(await checkFile(targetDir, spec))
+		// Biome is the one spec that needs the directory as well as the file
+		// contents — it compares the `$schema` version against the installed
+		// CLI (#424). Dispatched here so it keeps its place in the output.
+		results.push(
+			spec.check === 'Biome' ? await checkBiome(targetDir) : await checkFile(targetDir, spec)
+		)
 	}
 	results.push(await checkLintStaged(targetDir, pkg))
 	results.push(await checkVerifyScript(targetDir, pkg))

--- a/src/cli/generators/linting.ts
+++ b/src/cli/generators/linting.ts
@@ -59,6 +59,22 @@ async function readJsonOrNull(filepath: string): Promise<Record<string, unknown>
 }
 
 /**
+ * The `@biomejs/biome` actually installed under `targetDir`, or null when
+ * node_modules isn't populated. This is the binary that will parse the config
+ * and emit the schema-mismatch warning, so it is the only version worth
+ * comparing a written `$schema` against — a declared range like `^2.5.0` says
+ * nothing about which 2.x resolved (#424).
+ */
+export async function installedBiomeVersion(targetDir: string): Promise<string | null> {
+	const installed = await readJsonOrNull(
+		path.join(targetDir, 'node_modules', '@biomejs', 'biome', 'package.json')
+	)
+	const match =
+		typeof installed?.version === 'string' ? /(\d+\.\d+\.\d+)/.exec(installed.version) : null
+	return match?.[1] ?? null
+}
+
+/**
  * The Biome version the scaffolded `$schema` URL should name (#363).
  *
  * A hardcoded version drifts the moment the consumer's Biome moves, and Biome
@@ -69,22 +85,19 @@ async function readJsonOrNull(filepath: string): Promise<Record<string, unknown>
  * best statement of intent when node_modules isn't populated yet.
  */
 export async function resolveBiomeSchemaVersion(targetDir: string): Promise<string> {
-	const installed = await readJsonOrNull(
-		path.join(targetDir, 'node_modules', '@biomejs', 'biome', 'package.json')
-	)
+	const installed = await installedBiomeVersion(targetDir)
+	if (installed) return installed
+
 	const pkg = await readJsonOrNull(path.join(targetDir, 'package.json'))
 	const deps = {
 		...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
 		...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
 	}
 
-	// Both an exact version ("2.5.7") and a range ("^2.5.0") carry the x.y.z we
-	// need, so one pattern covers every source.
-	for (const candidate of [installed?.version, deps['@biomejs/biome']]) {
-		const match = typeof candidate === 'string' ? /(\d+\.\d+\.\d+)/.exec(candidate) : null
-		if (match?.[1]) return match[1]
-	}
-	return BIOME_SCHEMA_FALLBACK
+	// A range ("^2.5.0") carries the x.y.z we need just as an exact version does.
+	const declared = deps['@biomejs/biome']
+	const match = typeof declared === 'string' ? /(\d+\.\d+\.\d+)/.exec(declared) : null
+	return match?.[1] ?? BIOME_SCHEMA_FALLBACK
 }
 
 /**

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import type { BadgeAudience, FileCheck, GitHooksProfile } from '../../base/checks.js'
-import { hookHasUncommented } from '../../base/checks.js'
+import { checkFile, hookHasUncommented } from '../../base/checks.js'
+import { installedBiomeVersion } from '../../cli/generators/linting.js'
 import {
 	CLAUDE_SETTINGS_FILE,
 	readClaudeSettings,
@@ -185,6 +186,56 @@ function matchesTsConfig(contents: string): boolean {
 	)
 }
 
+export const BIOME_FILE_CHECK: FileCheck = {
+	check: 'Biome',
+	candidates: ['biome.json', 'biome.jsonc'],
+	expected: `extends "${PACKAGE}/biome" or inlines the preset, with the linter on`,
+	matcher: matchesBiomeConfig,
+	optional: true,
+	hint: 'Run `npx @rtorcato/repo-tooling fix biome` to scaffold',
+}
+
+/**
+ * The Biome check plus the one thing a contents-only matcher can't see: whether
+ * the `$schema` URL still names the Biome that will read it (#424).
+ *
+ * `fix biome` writes the URL from the version resolved at scaffold time, and
+ * nothing re-checked it afterwards — so once the repo's Biome moved on, every
+ * single invocation (the pre-commit hook included) printed "The configuration
+ * schema version does not match the CLI version", while doctor stayed clean.
+ *
+ * Compared against the *installed* package only, never the declared range: an
+ * exact match is what Biome itself demands, and `^2.5.0` doesn't say which 2.x
+ * resolved. With no node_modules there is nothing to be wrong about, so the
+ * check says nothing rather than guessing.
+ */
+export async function checkBiome(dir: string): Promise<CheckResult> {
+	const result = await checkFile(dir, BIOME_FILE_CHECK)
+	if (result.status !== 'ok') return result
+
+	const installed = await installedBiomeVersion(dir)
+	if (!installed) return result
+
+	// The same candidate checkFile settled on — first one that exists wins.
+	for (const candidate of BIOME_FILE_CHECK.candidates) {
+		const filepath = path.join(dir, candidate)
+		if (!(await fs.pathExists(filepath))) continue
+
+		const url = readSchemaUrl(await fs.readFile(filepath, 'utf8'))
+		const targeted = url?.includes('biomejs.dev') ? schemaUrlVersion(url)?.join('.') : null
+		if (targeted && targeted !== installed) {
+			return {
+				check: BIOME_FILE_CHECK.check,
+				status: 'drift',
+				detail: `${candidate} targets Biome ${targeted} but @biomejs/biome ${installed} is installed`,
+				hint: 'Run `npx @rtorcato/repo-tooling fix biome` to rewrite the $schema URL',
+			}
+		}
+		return result
+	}
+	return result
+}
+
 export const FILE_CHECKS: FileCheck[] = [
 	{
 		check: 'TypeScript',
@@ -193,14 +244,7 @@ export const FILE_CHECKS: FileCheck[] = [
 		matcher: matchesTsConfig,
 		hint: 'Run `npx @rtorcato/repo-tooling fix tsconfig` to scaffold',
 	},
-	{
-		check: 'Biome',
-		candidates: ['biome.json', 'biome.jsonc'],
-		expected: `extends "${PACKAGE}/biome" or inlines the preset, with the linter on`,
-		matcher: matchesBiomeConfig,
-		optional: true,
-		hint: 'Run `npx @rtorcato/repo-tooling fix biome` to scaffold',
-	},
+	BIOME_FILE_CHECK,
 	{
 		check: 'ESLint',
 		candidates: ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs'],

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -22,6 +22,14 @@ async function seedPackageJson(dir: string, withDep = true) {
 	})
 }
 
+/** Just enough of node_modules for the Biome check to resolve a CLI version. */
+async function seedInstalledBiome(dir: string, version: string) {
+	await fs.outputJson(join(dir, 'node_modules', '@biomejs', 'biome', 'package.json'), {
+		name: '@biomejs/biome',
+		version,
+	})
+}
+
 // The language-agnostic suite, declared once in doctor's runBaseChecks. Before
 // #309 the JS path re-listed it inline, so anything added to base silently
 // skipped JS repos — and the hook/commit/badge checks lived in the JS module, so
@@ -258,6 +266,37 @@ describe('doctor', () => {
 
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'Biome')?.status).toBe('drift')
+	})
+
+	// #424: the config matched the preset, so doctor called it ok while every
+	// Biome run printed "The configuration schema version does not match the CLI
+	// version". The written `$schema` has to be re-checked against the installed
+	// binary, not just written once and trusted forever.
+	it('reports drift when the biome $schema names a different version than the installed CLI', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await seedInstalledBiome(dir, '2.5.5')
+		await fs.writeJson(join(dir, 'biome.json'), {
+			$schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
+			extends: ['@rtorcato/repo-tooling/biome'],
+		})
+
+		const biome = (await runDoctor(dir)).find((r) => r.check === 'Biome')
+		expect(biome?.status).toBe('drift')
+		expect(biome?.detail).toContain('2.4.16')
+		expect(biome?.detail).toContain('2.5.5')
+	})
+
+	it('reports ok when the biome $schema matches the installed CLI', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await seedInstalledBiome(dir, '2.5.5')
+		await fs.writeJson(join(dir, 'biome.json'), {
+			$schema: 'https://biomejs.dev/schemas/2.5.5/schema.json',
+			extends: ['@rtorcato/repo-tooling/biome'],
+		})
+
+		expect((await runDoctor(dir)).find((r) => r.check === 'Biome')?.status).toBe('ok')
 	})
 
 	it('reports drift for a biome.json that is too corrupt to parse', async () => {


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

## Problem

The Biome check only asserted the `$schema` string contained `biomejs.dev/schemas/`, so once `fix biome` had written a version it was never compared against anything again. A repo whose Biome moved on stayed clean in `doctor` while every single Biome invocation — the Husky pre-commit hook included — printed:

```
i The configuration schema version does not match the CLI version 2.5.5
  Expected: 2.5.5
  Found:    2.4.16
```

Informational, so nothing fails — which is the problem. It is recurring noise on a file the consumer never wrote by hand.

## Change

`checkBiome` runs the existing file check and, when it passes, parses the version out of the `$schema` URL and compares it to the `@biomejs/biome` actually installed under the target directory, reporting `drift` when they differ.

The comparison is against the **installed package only**, never the declared range: an exact match is what Biome itself demands, and `^2.5.0` says nothing about which 2.x resolved. With no `node_modules` there is nothing to be wrong about, so the check stays quiet rather than guessing — which is also why every existing tmp-dir test is unaffected.

`installedBiomeVersion` is lifted out of `resolveBiomeSchemaVersion` so the generator and the check read the version from one place.

No new fixer logic: `fix biome` already regenerates the URL from the resolved version, and its existing `canFixDrift: true` path picks the finding up.

## Dogfood

This repo was exactly the described drift — `biome.json` and `apps/docs/biome.json` both targeted 2.5.0 against an installed 2.5.5. `pnpm dogfood` fails on the new finding, so both are bumped to 2.5.5. The shipped preset (`tooling/biome/biome.json`) is deliberately left at 2.5.0, since it is compared against the `^2.5.0` peer floor by a different check.

## Verification

`pnpm run check`, `pnpm run typecheck`, `pnpm test --run` (928 passing), `pnpm run build-cli`, and `pnpm dogfood` are all clean. Two tests added to `tests/cli/commands/doctor.test.ts` cover the drift and the matching case.

Closes #424
