### PR TITLE
docs(ai-issue-loop): warn implementers not to run pnpm install

### DIFF
--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -694,6 +694,16 @@ Then spawn a background implementer agent:
 > 3. Read the repo's `CLAUDE.md` and obey it — especially any pre-commit build
 >    step or committed build output.
 > 4. Do the work. Conventional Commits within the branch.
+>
+>    **Do not run `pnpm install`.** This worktree's `node_modules` is a symlink to
+>    the main checkout, so pnpm sees a foreign directory it must purge first and
+>    aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. Dependencies are
+>    already present — run tests, lint and build directly. If the work *is* a
+>    dependency change, `pnpm install --lockfile-only` updates `pnpm-lock.yaml`
+>    without touching `node_modules`. When that leaves a verification step you
+>    cannot run, say so in the PR body — name the command you could not run and
+>    why — so the reviewer knows CI is the only check on it rather than assuming
+>    you ran it.
 > 5. Push and open the PR. The title must be a Conventional Commit — it becomes
 >    the squash subject on `main` and, in repos using semantic-release, decides
 >    whether a release goes out at all. Body must contain `Closes #<N>`.


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

Implements Option 1 from #438: document the constraint in the Pass 4 implementer prompt.

The Pass 4 worktree links `node_modules` from the main checkout (`SKILL.md:673`). That makes deps available without a per-worktree install, but it also makes `pnpm install` abort with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` — pnpm resolves the symlink, decides the shared directory is foreign and must be purged, and won't proceed without a TTY. Implementers found that out mid-task, fell back to `--lockfile-only`, and quietly shipped without the verification step the issue asked for (#432).

Step 4 of the implementer prompt now says up front: deps are already present, don't run `pnpm install`, use `--lockfile-only` when the lockfile must change, and name in the PR body any verification command that could not run as a result.

Options 2–4 in the issue are deliberately not implemented — Option 1 is what closes the silent-degradation defect.

Scoped to the Pass 4 prompt only; #439 is editing Pass 3 in the same file concurrently.

### Verification

`tests/cli/generators/claude-skills.test.ts` and `tests/cli/commands/fix.test.ts` (the two referencing this skill) pass — 121 tests. Pre-commit biome check + typecheck passed. `AGENTS.md` is generated from `skills/repo-tooling/SKILL.md`, not this skill, so it is unaffected and needs no regeneration.

Closes #438