### PR TITLE
chore(repo): dogfood .repo-tooling.json in this repo

### DIFF
--- a/.repo-tooling.json
+++ b/.repo-tooling.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://rtorcato.github.io/repo-tooling/schemas/lockfile.json",
+  "version": 2,
+  "config": {
+    "projectName": "@rtorcato/repo-tooling",
+    "projectType": "library",
+    "typescript": {
+      "enabled": true,
+      "config": "base"
+    },
+    "linting": {
+      "tool": "biome",
+      "eslintConfig": "base"
+    },
+    "formatting": {
+      "tool": "biome"
+    },
+    "testing": {
+      "framework": "vitest",
+      "environment": "node"
+    },
+    "gitHooks": true,
+    "commitLint": true,
+    "semanticRelease": true,
+    "securityAutomation": true,
+    "bundler": "none",
+    "language": "js"
+  },
+  "writtenBy": "@rtorcato/repo-tooling@3.11.0",
+  "writtenAt": "2026-08-20T17:32:17.649Z"
+}


### PR DESCRIPTION
🤖 *Authored by Claude (AI agent) on rtorcato's behalf, via the repo-tooling `ai-issue-loop`.*

Adds `.repo-tooling.json` to this repo, which shipped the lockfile format but never carried one. Without it, `demoteDeclined()` short-circuits (`src/cli/commands/doctor.ts:191`) and every intentional opt-out here reads as "not configured" forever.

Generated with the CLI's own writer — `writeLockfile()` + `inferProjectConfig()` off the freshly built `dist` — rather than hand-written JSON. `fix lockfile` itself is blocked in this repo by the self-repo guard in `src/cli/index.ts:370` (whose `REPO_TOOLING_ALLOW_SELF` escape hatch is deliberately scoped to read-only `doctor`), so the fixer's exact code path was invoked directly instead of relaxing that guard.

Two corrections to the inferred config, because the inference was wrong for this repo:

- **`bundler: "none"`** — inference says `tsup` (it is a devDependency, as a shipped preset), but this repo builds with plain `tsc` (`build-cli`). A recorded `tsup` would make `fix --resync` scaffold a `tsup.config.ts` that does not belong here.
- **`language: "js"`** — v2 lockfiles record it; `inferProjectConfig` omits it.

## Verification

`doctor` before → after (nothing else moved, 56 checks both runs):

| Check | Before | After |
|---|---|---|
| lockfile | `optional-missing` | `ok` — `.repo-tooling.json v2 (written by @rtorcato/repo-tooling@3.11.0)` |
| ESLint | `optional-missing` | `ok` — intentionally declined |
| Prettier | `optional-missing` | `ok` — intentionally declined |

The two demotions are accurate: this repo lints and formats itself with Biome.

`vitest run` 933/933 pass, `biome check src scripts` clean, `node scripts/dogfood.mjs` clean.

## Deliberately out of scope

Issue #431 lists three asks; **this PR implements only item 2**. `Closes #431` should not be read as items 1 and 3 being done:

- **Item 1 (sweep the other repos)** — not done. It means committing to nine other repositories; an agent working in this repo has no business writing to them. Worth a separate, per-repo pass.
- **Item 3 (promote the check from `optional-missing` to `drift`)** — not done. The issue itself flags it as an unresolved judgement call about check severity and suggests splitting it out. Still open for a decision.

Closes #431
