### PR TITLE
feat(docusaurus): add docs-generator helpers as a copy asset

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -27,7 +27,7 @@ npx @rtorcato/repo-tooling copy biome     # → biome.json
 npx @rtorcato/repo-tooling copy tsconfig  # → tsconfig.json
 ```
 
-Available presets: `biome`, `tsconfig`, `bun`, `nx`, `changesets`, `release-please`, `oxlint`, `claude-skill`, `claude-sync-agents`, `mcp-example`, `docusaurus-sync-changelog`, `docusaurus-theme-tokens`, `docusaurus-theme`.
+Available presets: `biome`, `tsconfig`, `bun`, `nx`, `changesets`, `release-please`, `oxlint`, `claude-skill`, `claude-sync-agents`, `mcp-example`, `docusaurus-sync-changelog`, `docusaurus-docs-helpers`, `docusaurus-theme-tokens`, `docusaurus-theme`.
 
 `claude-sync-agents` copies `scripts/sync-agents.mjs`, which regenerates `AGENTS.md` from `skills/<package>/SKILL.md` so the two can't drift. It is zero-config — the skill directory comes from the root `package.json` `name` with the npm scope stripped (`@rtorcato/js-common` → `skills/js-common/`). Wire `node scripts/sync-agents.mjs --check` into CI to fail on a stale `AGENTS.md`.
 

--- a/apps/docs/docs/reference/docusaurus.md
+++ b/apps/docs/docs/reference/docusaurus.md
@@ -33,6 +33,29 @@ hooks reliably, so chain it in `build`/`start` rather than relying on `prebuild`
 }
 ```
 
+## `copy docusaurus-docs-helpers`
+
+Drops `scripts/docs-helpers.mjs` into your repo:
+
+```bash
+npx @rtorcato/repo-tooling copy docusaurus-docs-helpers
+```
+
+The pure pieces of a docs generator for a subpath-exports package, so the
+generator script above them stays small and project-specific:
+
+| Export | What it does |
+| --- | --- |
+| `escapeForMarkdownTable(text)` | Makes a JSDoc summary safe for a table cell — escapes `<` outside code spans (so `` `Success<T>` `` survives and `<<b>>` can't leave a live `<b>`), and escapes `\` and `\|` in one pass. |
+| `collectExportNames(file)` | Recursively parses `export function\|const\|class\|type\|interface\|enum`, `export { … }`, and both re-export forms, following relative specifiers into the files they name. For `export { foo as bar }` the exported name is `bar`. |
+| `spliceGeneratedBlock(existing, block)` | Rewrites only the region between `MARKER_START` and `MARKER_END`, so hand-written prose around it survives. Returns `null` for a page with no markers — a fully hand-written page is left alone. |
+
+Wire it into whatever generator your repo needs:
+
+```js
+import { collectExportNames, escapeForMarkdownTable, spliceGeneratedBlock } from './docs-helpers.mjs'
+```
+
 ## `copy docusaurus-theme-tokens`
 
 Drops the shared design-token base into `apps/docs/src/css/_jt-tokens.css`:

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
 		"tooling/docusaurus/index.mjs",
 		"tooling/docusaurus/index.d.mts",
 		"tooling/docusaurus/sync-changelog.mjs",
+		"tooling/docusaurus/docs-helpers.mjs",
 		"tooling/docusaurus/theme-tokens.css",
 		"tooling/docusaurus/theme.css",
 		"tooling/biome/biome.json",

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -21,6 +21,7 @@ export type PresetName =
 	| 'claude-sync-agents'
 	| 'mcp-example'
 	| 'docusaurus-sync-changelog'
+	| 'docusaurus-docs-helpers'
 	| 'docusaurus-theme-tokens'
 	| 'docusaurus-theme'
 
@@ -128,6 +129,11 @@ export const PRESETS: Record<PresetName, PresetDefinition> = {
 		source: 'tooling/docusaurus/sync-changelog.mjs',
 		target: 'scripts/sync-changelog.mjs',
 		desc: 'Canonical CHANGELOG → docs sync script for Docusaurus sites',
+	},
+	'docusaurus-docs-helpers': {
+		source: 'tooling/docusaurus/docs-helpers.mjs',
+		target: 'scripts/docs-helpers.mjs',
+		desc: 'Docs-generator helpers (markdown-table escaping, export parser, generated-block splice)',
 	},
 	'docusaurus-theme-tokens': {
 		source: 'tooling/docusaurus/theme-tokens.css',

--- a/tests/cli/docusaurus-docs-helpers.test.ts
+++ b/tests/cli/docusaurus-docs-helpers.test.ts
@@ -1,0 +1,166 @@
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import fs from 'fs-extra'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { copyPreset } from '../../src/cli/utils/copy-preset.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+interface DocsHelpers {
+	escapeForMarkdownTable: (text: string) => string
+	collectExportNames: (file: string) => Set<string>
+	spliceGeneratedBlock: (existing: string, block: string) => string | null
+	MARKER_START: string
+	MARKER_END: string
+}
+
+/** Exercise the asset as consumers get it: copied out, then imported. */
+let helpers: DocsHelpers
+let copiedTo: string
+
+beforeAll(async () => {
+	const dir = newTmpDir()
+	const result = await copyPreset('docusaurus-docs-helpers', dir)
+	copiedTo = result.target
+	helpers = (await import(pathToFileURL(result.targetPath).href)) as DocsHelpers
+})
+
+describe('copy docusaurus-docs-helpers', () => {
+	it('lands at scripts/docs-helpers.mjs', () => {
+		expect(copiedTo).toBe('scripts/docs-helpers.mjs')
+	})
+})
+
+describe('escapeForMarkdownTable', () => {
+	it('escapes angle brackets outside code spans and leaves them inside', () => {
+		// Escaping beats stripping: a one-pass `/<[^>]*>/` strip leaves `<b>`
+		// behind here, and deletes the `<T>` from an unbackticked `Success<T>`.
+		expect(helpers.escapeForMarkdownTable('a <<b>> c')).toBe('a &lt;&lt;b>> c')
+		expect(helpers.escapeForMarkdownTable('returns Success<T>')).toBe('returns Success&lt;T>')
+		expect(helpers.escapeForMarkdownTable('use `Success<T>` here')).toBe('use `Success<T>` here')
+		expect(helpers.escapeForMarkdownTable('a | b')).toBe('a \\| b')
+	})
+
+	it('escapes a backslash so it cannot re-expose the pipe it precedes', () => {
+		// Escaping only `|` would yield `a\\|b` — an escaped backslash plus a
+		// live pipe, which still breaks the row.
+		expect(helpers.escapeForMarkdownTable('a\\|b')).toBe('a\\\\\\|b')
+	})
+})
+
+describe('spliceGeneratedBlock', () => {
+	const page = [
+		'# Colors',
+		'',
+		'Hand-written intro.',
+		'',
+		'<<START>>',
+		'old reference',
+		'<<END>>',
+		'',
+		'- [random](./random.md)',
+		'',
+	].join('\n')
+
+	it('replaces only the marked block, leaving the guide alone', () => {
+		const source = page
+			.replace('<<START>>', helpers.MARKER_START)
+			.replace('<<END>>', helpers.MARKER_END)
+		const next = helpers.spliceGeneratedBlock(
+			source,
+			`${helpers.MARKER_START}\nnew reference\n${helpers.MARKER_END}`
+		)
+
+		expect(next).toContain('Hand-written intro.')
+		expect(next).toContain('- [random](./random.md)')
+		expect(next).toContain('new reference')
+		expect(next).not.toContain('old reference')
+	})
+
+	it('returns null for a page with no markers, so it is left untouched', () => {
+		expect(helpers.spliceGeneratedBlock('# Fully hand-written\n', 'anything')).toBeNull()
+	})
+})
+
+describe('collectExportNames', () => {
+	/** Write `files` (path → source) into a fresh dir and return that dir. */
+	async function seed(files: Record<string, string>): Promise<string> {
+		const dir = newTmpDir()
+		for (const [name, src] of Object.entries(files)) {
+			await fs.outputFile(join(dir, name), src)
+		}
+		return dir
+	}
+
+	it('picks up declaration, brace and aliased exports', async () => {
+		const dir = await seed({
+			'index.ts': [
+				'export function alpha() {}',
+				'export const beta = 1',
+				'export class Gamma {}',
+				'export type Delta = string',
+				'export interface Epsilon {}',
+				'export enum Zeta {}',
+				'const inner = 2',
+				'export { inner as eta }',
+			].join('\n'),
+		})
+
+		expect([...helpers.collectExportNames(join(dir, 'index.ts'))].sort()).toEqual([
+			'Delta',
+			'Epsilon',
+			'Gamma',
+			'Zeta',
+			'alpha',
+			'beta',
+			'eta',
+		])
+	})
+
+	it('takes the alias, not the local name, for an aliased re-export', async () => {
+		// The bug this asset exists to retire: `.split(/\s+as\s+/)[0]` yields
+		// `foo`, a symbol no consumer can import — `bar` is the exported name.
+		const dir = await seed({
+			'index.ts': "export { foo as bar } from './impl.js'\n",
+			'impl.ts': 'export function foo() {}\n',
+		})
+
+		const names = helpers.collectExportNames(join(dir, 'index.ts'))
+		expect(names.has('bar')).toBe(true)
+	})
+
+	it('follows both re-export forms into relative files and skips bare specifiers', async () => {
+		const dir = await seed({
+			'index.ts': [
+				"export * from './star.js'",
+				"export { picked } from './named.js'",
+				"export * from 'node:fs'",
+			].join('\n'),
+			'star.ts': 'export const fromStar = 1\n',
+			'named.ts': 'export const picked = 1\nexport const notReexported = 2\n',
+		})
+
+		const names = helpers.collectExportNames(join(dir, 'index.ts'))
+		expect(names.has('fromStar')).toBe(true)
+		expect(names.has('picked')).toBe(true)
+	})
+
+	it('resolves a directory re-export via its index.ts', async () => {
+		const dir = await seed({
+			'index.ts': "export * from './nested/index.js'\n",
+			'nested/index.ts': 'export const deep = 1\n',
+		})
+
+		expect(helpers.collectExportNames(join(dir, 'index.ts')).has('deep')).toBe(true)
+	})
+
+	it('survives an import cycle and a missing file', async () => {
+		const dir = await seed({
+			'a.ts': "export const a = 1\nexport * from './b.js'\n",
+			'b.ts': "export const b = 1\nexport * from './a.js'\nexport * from './gone.js'\n",
+		})
+
+		expect([...helpers.collectExportNames(join(dir, 'a.ts'))].sort()).toEqual(['a', 'b'])
+	})
+})

--- a/tooling/docusaurus/docs-helpers.mjs
+++ b/tooling/docusaurus/docs-helpers.mjs
@@ -1,0 +1,109 @@
+// Canonical docs-generator helpers for @rtorcato/* repos (shipped by
+// @rtorcato/repo-tooling — copy via `repo-tooling copy docusaurus-docs-helpers`).
+//
+// The pure pieces every subpath-exports package's doc generator needs, so the
+// generator script above them stays small and project-specific:
+//
+//   escapeForMarkdownTable(text)          — make a JSDoc summary safe for a table cell
+//   collectExportNames(file)              — recursive `export` parser over a module graph
+//   spliceGeneratedBlock(existing, block) — rewrite only the fenced generated region
+//
+// Zero-config and side-effect free: no paths, no package names, no I/O beyond
+// reading the files you hand it, so this file is copied unmodified.
+//
+//   import {
+//     collectExportNames,
+//     escapeForMarkdownTable,
+//     MARKER_END,
+//     MARKER_START,
+//     spliceGeneratedBlock,
+//   } from './docs-helpers.mjs'
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+
+const EXPORT_NAMED =
+	/export\s+(?:async\s+)?(?:function|const|let|class|type|interface|enum)\s+([A-Za-z_$][\w$]*)/g
+const EXPORT_BRACE = /export\s*\{\s*([^}]+)\}/g
+// Both re-export forms, any specifier — `export * from …` and
+// `export { … } from …`. Non-relative specifiers are filtered below rather than
+// in the pattern, so a bare-package re-export is recognised and then skipped
+// instead of silently parsed as nothing.
+const REEXPORT_FROM = /export\s+(?:\*|\{[^}]*\})\s+from\s+['"]([^'"]+)['"]/g
+
+/**
+ * Escape `text` so it survives a markdown table cell.
+ *
+ * Neutralises raw HTML-ish tags outside code spans, which would otherwise
+ * confuse Docusaurus's MDX parser — but keeps them inside backticks, where
+ * `Success<T>` and `<br>` are the point. Then escapes pipes everywhere, since
+ * one anywhere in the cell breaks the row.
+ *
+ * Escaping the `<` beats stripping `/<[^>]*>/`: a one-pass tag strip can leave
+ * a tag behind on nested input (`<<b>>` -> `<b>`) and silently eats text like
+ * `Success<T>` when the JSDoc forgot the backticks.
+ *
+ * Escape the backslash in the same pass as the pipe, not after it: escaping
+ * only `|` turns the input `a\|b` into `a\\|b`, which markdown reads as an
+ * escaped backslash followed by a live pipe, and the row breaks anyway.
+ */
+export function escapeForMarkdownTable(text) {
+	return text
+		.split(/(`[^`]*`)/)
+		.map((part, i) => (i % 2 === 1 ? part : part.replace(/</g, '&lt;')))
+		.join('')
+		.replace(/[\\|]/g, '\\$&')
+}
+
+/**
+ * Collect every name `file` exports, following relative re-exports into the
+ * files they name. Returns the accumulating `names` set; `seen` guards against
+ * an import cycle re-entering a file.
+ *
+ * For an aliased export the *alias* is the exported name — `export { foo as
+ * bar }` exports `bar`, which is what a consumer imports — so this takes the
+ * last segment, not the first.
+ */
+export function collectExportNames(file, names = new Set(), seen = new Set()) {
+	if (seen.has(file) || !existsSync(file)) return names
+	seen.add(file)
+	const src = readFileSync(file, 'utf8')
+
+	for (const m of src.matchAll(EXPORT_NAMED)) names.add(m[1])
+	for (const m of src.matchAll(EXPORT_BRACE)) {
+		for (const part of m[1].split(',')) {
+			const name = part
+				.trim()
+				.split(/\s+as\s+/)
+				.pop()
+				?.trim()
+			if (name) names.add(name)
+		}
+	}
+	for (const m of src.matchAll(REEXPORT_FROM)) {
+		if (!m[1].startsWith('.')) continue
+		const base = resolve(dirname(file), m[1].replace(/\.js$/, ''))
+		for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
+			if (existsSync(candidate)) {
+				collectExportNames(candidate, names, seen)
+				break
+			}
+		}
+	}
+	return names
+}
+
+export const MARKER_START =
+	'<!-- generated:exports — do not edit; `pnpm docs:generate` rewrites this block -->'
+export const MARKER_END = '<!-- /generated:exports -->'
+
+/**
+ * Splice `block` into `existing` between the markers. Returns null when the
+ * page has no markers, which means "hand-written, leave it alone".
+ */
+export function spliceGeneratedBlock(existing, block) {
+	const start = existing.indexOf(MARKER_START)
+	const end = existing.indexOf(MARKER_END)
+	if (start === -1 || end === -1 || end < start) return null
+	return existing.slice(0, start) + block + existing.slice(end + MARKER_END.length)
+}


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

Closes #426

## What

Adds `copy docusaurus-docs-helpers` → `scripts/docs-helpers.mjs`, registered next to `docusaurus-sync-changelog` and `claude-sync-agents`.

**Shape: a copy-asset, not an importable module.** Consumers edit the generator's config (which subpaths, where the docs live), so a copied script fits better than a fixed API — and it matches the sibling assets.

## The three helpers

| Export | Behaviour preserved |
| --- | --- |
| `escapeForMarkdownTable(text)` | Escapes `<` *outside* code spans, so `` `Success<T>` `` survives and `<<b>>` can't leave a live `<b>` behind. Escapes `\` and `\|` in **one pass** — escaping only `\|` turns `a\|b` into an escaped backslash plus a live pipe, which still breaks the row. |
| `collectExportNames(file)` | The recursive export parser, following relative re-exports into the files they name. |
| `spliceGeneratedBlock(existing, block)` + `MARKER_START`/`MARKER_END` | Rewrites only the fenced region; returns `null` for a page with no markers, so a fully hand-written page is left alone. |

## Bug fixed while porting

js-common's two copies of the parser have diverged, and this ports the correct half of each:

- **Alias handling.** `generate-module-docs.mjs` uses `.split(/\s+as\s+/)[0]`, so `export { foo as bar }` yields `foo` — a symbol no consumer can import; `bar` is the exported name. Ported as `.pop()`, with a test named for exactly that case.
- **`REEXPORT_FROM`.** Ported from `check-readme-exports.mjs`, which matches `export *` **and** `export { … } from` with any specifier, rather than `export *` with `./relative` paths only.

## Notes

- `MARKER_START` / `MARKER_END` are byte-identical to js-common's, so pages it has already generated keep splicing after adoption.
- Nothing org-specific is baked into the asset — no package names, no paths, no I/O beyond reading the files it is handed.
- **js-common's adoption is a follow-up in that repo**: deleting its two copies and rewiring `check-readme-exports.mjs` and `generate-module-docs.mjs` onto this single parser is out of scope here.

## Tests

10 new tests in `tests/cli/docusaurus-docs-helpers.test.ts`, exercising the asset the way consumers get it (copied out, then imported): the copy target, both `escapeForMarkdownTable` behaviours, the splice and its `null` case, and the parser across declaration/brace/aliased exports, both re-export forms, a bare specifier, a directory `index.ts`, an import cycle, and a missing file.

Full suite: 925 passed / 18 skipped. Biome and `tsc --noEmit` clean.