### PR TITLE
fix(dependabot): refuse to silently delete repo-local ignore rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ npx @rtorcato/repo-tooling fix claude-skills --yes --json
 
 Fixers marked `explicitOnly` are exempt from `fix` all *and* from `fix --yes` — they only run when named as the target. Today that is `claude-skills`, the one fixer whose blast radius is outside the repo.
 
+A fixer may also **refuse** — the target file holds something the generator cannot reproduce, so overwriting would destroy it. Today that is `dependabot` against a config with repo-local `ignore:` rules (#422). A targeted `fix dependabot` then exits 1 with `error: dependabot-ignore-rules`; a bulk `fix --yes` records it `skipped` and carries on with the rest. Neither `--yes` nor `--json` overrides it — resolve the named rules by hand and re-run.
+
 ## Source-of-truth files in the repo
 
 - `src/cli/commands/setup.ts` — `ProjectConfig` interface and the setup orchestrator

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -89,6 +89,21 @@ CI. Closing stale PRs is the normal, expected hygiene step — not a loss of wor
 - `repo-tooling doctor` flags drift from the canonical config; `repo-tooling fix`
   re-applies it. A strategy change propagates to every repo via `fix`.
 
+## 7. Repo-local `ignore:` rules
+
+`fix dependabot` writes the file wholesale, and the canonical config has no
+`ignore:` block — so a hand-added ignore rule (a dependency held back on purpose,
+usually with the reason in a comment above it) would be deleted by the next `fix`
+with nothing left to report the loss.
+
+It isn't. `fix dependabot` **refuses** when the existing config carries `ignore:`
+rules, naming each one, and `doctor` reports them in the Dependabot detail line so
+they're visible beforehand. Deliberate ignore rules are not drift: the check still
+reads `ok`.
+
+To proceed anyway, deal with the block by hand — copy it back into the regenerated
+file, or delete it to accept the loss — then re-run `fix dependabot`.
+
 ## Canonical `dependabot.yml`
 
 ```yaml

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import { BLOCK_START, hasStaleAgentBlock } from '../cli/generators/agent-rules.js'
 import { BADGE_START, hasPublicOnlyBadges } from '../cli/generators/badges.js'
 import { claudeSkillStatus, SHIPPED_SKILL } from '../cli/generators/claude-skills.js'
+import { DEPENDABOT_CONFIG_PATHS, dependabotIgnoreRules } from '../cli/generators/security.js'
 import { type DetectedLanguage, detectNestedLanguages } from '../cli/utils/detect-language.js'
 import type { CheckResult } from './types.js'
 
@@ -280,7 +281,7 @@ export async function checkGitHubActions(
 }
 
 export async function checkDependabot(dir: string): Promise<CheckResult> {
-	for (const candidate of ['.github/dependabot.yml', '.github/dependabot.yaml']) {
+	for (const candidate of DEPENDABOT_CONFIG_PATHS) {
 		const candidatePath = path.join(dir, candidate)
 		if (await fs.pathExists(candidatePath)) {
 			// The canonical standard (apps/docs/docs/guides/dependabot-strategy.md) is
@@ -298,18 +299,29 @@ export async function checkDependabot(dir: string): Promise<CheckResult> {
 			if (!(await fs.pathExists(automergePath))) {
 				deltas.push('missing dependabot-automerge workflow')
 			}
+			// Repo-local `ignore:` rules aren't drift — they're deliberate, and the
+			// canonical config has no way to express them. Report them anyway so the
+			// reason `fix dependabot` refuses is visible before anyone runs it (#422).
+			const ignored = dependabotIgnoreRules(content)
+			const ignoreNote =
+				ignored.length === 0
+					? ''
+					: ` — ${ignored.length} local \`ignore:\` rule(s) the canonical config cannot express (${ignored.join(', ')}); \`fix dependabot\` refuses rather than drop them`
 			if (deltas.length > 0) {
 				return {
 					check: 'Dependabot',
 					status: 'drift',
-					detail: `${candidate} drifts from canonical (${deltas.join('; ')})`,
-					hint: 'Run `npx @rtorcato/repo-tooling fix dependabot` to apply the canonical grouping + auto-merge workflow',
+					detail: `${candidate} drifts from canonical (${deltas.join('; ')})${ignoreNote}`,
+					hint:
+						ignored.length > 0
+							? 'Run `npx @rtorcato/repo-tooling fix dependabot --diff` — it will refuse until the `ignore:` block is dealt with by hand'
+							: 'Run `npx @rtorcato/repo-tooling fix dependabot` to apply the canonical grouping + auto-merge workflow',
 				}
 			}
 			return {
 				check: 'Dependabot',
 				status: 'ok',
-				detail: `${candidate} + auto-merge workflow`,
+				detail: `${candidate} + auto-merge workflow${ignoreNote}`,
 			}
 		}
 	}

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -26,6 +26,7 @@ import { generateCommunityHealth } from '../cli/generators/community-health.js'
 import { generateCommitlintConfig } from '../cli/generators/git.js'
 import { generateCodeowners, generateEditorConfig } from '../cli/generators/misc.js'
 import {
+	findDependabotIgnoreRules,
 	generateCodeQLWorkflow,
 	generateDependabotConfig,
 	generateRenovateConfig,
@@ -178,6 +179,20 @@ export const BASE_FIXERS: Fixer[] = [
 		outputs: ['.github/dependabot.yml', '.github/workflows/dependabot-automerge.yml'],
 		canFixDrift: true,
 		async run({ targetDir }) {
+			// The template owns the whole file but emits no `ignore:` block, so
+			// regenerating deletes any repo-local ignore rule — silently, and with
+			// nothing in `doctor` to report the loss afterwards, because from the
+			// fixer's point of view the file then matches the standard exactly (#422).
+			// Refuse rather than warn: an unattended `fix --yes` would walk past a
+			// warning, and the rules are unrecoverable once written over.
+			const ignored = await findDependabotIgnoreRules(targetDir)
+			if (ignored) {
+				throw new FixerAbort(
+					'dependabot-ignore-rules',
+					`refusing to overwrite ${ignored.file} — it has ${ignored.rules.length} \`ignore:\` rule(s) the canonical config does not reproduce: ${ignored.rules.join(', ')}`,
+					`re-add the \`ignore:\` block after regenerating, or delete it from ${ignored.file} to accept the loss — then re-run \`fix dependabot\``
+				)
+			}
 			const { dependabotEcosystem } = await moduleFor(targetDir)
 			return { filesWritten: await generateDependabotConfig(targetDir, dependabotEcosystem) }
 		},

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -200,7 +200,15 @@ async function previewFixer(
 			},
 		})
 		// assumeYes: a preview must never prompt.
-		await fixer.run({ targetDir: tmpDir, pkg, result, lock, assumeYes: true })
+		try {
+			await fixer.run({ targetDir: tmpDir, pkg, result, lock, assumeYes: true })
+		} catch (err) {
+			// A fixer that refuses has nothing to preview. Swallow it here rather than
+			// reporting it twice — the real run happens moments later and its abort is
+			// what the caller prints.
+			if (!(err instanceof FixerAbort)) throw err
+			return []
+		}
 
 		const previews: PreviewEntry[] = []
 		const seen = new Set<string>()
@@ -530,10 +538,9 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			console.log(chalk.gray('   skipped\n'))
 			return
 		}
-		// ponytail: only the targeted path is guarded, because the only fixer that
-		// aborts is `claude-skills` and it is explicitOnly — the bulk loop below
-		// cannot reach it. A non-explicitOnly fixer that throws FixerAbort would
-		// surface as an unhandled rejection there; guard the loop when one exists.
+		// A targeted abort is fatal: the user named this fixer, so failing to run it
+		// is the whole outcome of the command. The bulk loop below takes the other
+		// branch and records a skip, since one refusal must not abandon the rest.
 		const outcome = await applyFixer(fixer, effectiveResult, targetDir, pkg, lock, dryRun, silent, {
 			skillsDir: options.skillsDir,
 			assumeYes,
@@ -615,10 +622,24 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			skippedCount++
 			continue
 		}
-		const outcome = await applyFixer(fixer, result, targetDir, pkg, lock, dryRun, silent, {
-			skillsDir: options.skillsDir,
-			assumeYes,
-		})
+		// A fixer that refuses (e.g. dependabot, when the existing config carries
+		// repo-local `ignore:` rules the template can't reproduce) is a skip, not a
+		// crash — the remaining findings still deserve their fixers. The reason goes
+		// to stderr so it survives `--json`.
+		let outcome: Awaited<ReturnType<typeof applyFixer>>
+		try {
+			outcome = await applyFixer(fixer, result, targetDir, pkg, lock, dryRun, silent, {
+				skillsDir: options.skillsDir,
+				assumeYes,
+			})
+		} catch (err) {
+			if (!(err instanceof FixerAbort)) throw err
+			actions.push(recordFor(fixer.target, result.check, result.status, 'skipped', [], conflict))
+			console.error(chalk.red(`    refused — ${err.message}`))
+			if (err.hint) console.error(chalk.gray(`    ${err.hint}`))
+			skippedCount++
+			continue
+		}
 		actions.push(
 			recordFor(
 				fixer.target,

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -67,6 +67,62 @@ ${manifest}  - package-ecosystem: github-actions
  * resolve a language module. */
 export const DEPENDABOT_CONFIG = dependabotConfig('npm')
 
+/** Where `.github/dependabot.yml` can live, in the order Dependabot resolves it. */
+export const DEPENDABOT_CONFIG_PATHS = [
+	'.github/dependabot.yml',
+	'.github/dependabot.yaml',
+] as const
+
+/**
+ * The `ignore:` rules an existing dependabot.yml carries, named by
+ * `dependency-name` (#422).
+ *
+ * `dependabotConfig()` owns the whole file but emits no `ignore:` block, and
+ * `ignore` is precisely the key that is inherently repo-local — a pin held back
+ * by hand, with the reason usually in a comment above it. So every rule this
+ * finds is one a regeneration would delete silently.
+ *
+ * ponytail: a line scanner, not a YAML parse — the repo ships no YAML parser and
+ * this only needs to answer "is there something here to lose, and what is it
+ * called". A rule split across lines (`-` alone, `dependency-name` beneath)
+ * reports as `<unnamed rule>`, which still stops the overwrite. Reach for a
+ * parser if the message ever has to reproduce the rules rather than name them.
+ */
+export function dependabotIgnoreRules(content: string): string[] {
+	const lines = content.split('\n')
+	const rules: string[] = []
+
+	for (const [index, line] of lines.entries()) {
+		const header = /^(\s*)ignore:\s*(#.*)?$/.exec(line)
+		if (!header) continue
+		const blockIndent = (header[1] ?? '').length
+
+		// Rules sit at the first list indent under `ignore:`; deeper `- ` lines are
+		// an entry's own values (`update-types:`) and must not count as rules.
+		let itemIndent: number | null = null
+		const names: string[] = []
+		let items = 0
+
+		for (const next of lines.slice(index + 1)) {
+			if (next.trim() === '') continue
+			const indent = next.search(/\S/)
+			if (indent <= blockIndent) break
+
+			if (/^\s*-\s/.test(next)) {
+				itemIndent ??= indent
+				if (indent === itemIndent) items++
+			}
+			const named = /(?:^|\s)dependency-name:\s*["']?([^"'#\s]+)/.exec(next)
+			if (named?.[1] && (itemIndent === null || indent >= itemIndent)) names.push(named[1])
+		}
+
+		while (names.length < items) names.push('<unnamed rule>')
+		rules.push(...names)
+	}
+
+	return rules
+}
+
 /**
  * Auto-merges patch + minor Dependabot PRs once CI is green. Requires branch
  * protection with required status checks on the target branch — without it,
@@ -107,6 +163,22 @@ export const DEPENDABOT_FILES = [
 	'.github/dependabot.yml',
 	'.github/workflows/dependabot-automerge.yml',
 ] as const
+
+/**
+ * The repo-local `ignore:` rules a regeneration would delete, with the file
+ * they live in — or null when there is nothing to lose (#422).
+ */
+export async function findDependabotIgnoreRules(
+	targetDir: string
+): Promise<{ file: string; rules: string[] } | null> {
+	for (const file of DEPENDABOT_CONFIG_PATHS) {
+		const candidate = path.join(targetDir, file)
+		if (!(await fs.pathExists(candidate))) continue
+		const rules = dependabotIgnoreRules(await fs.readFile(candidate, 'utf8'))
+		return rules.length > 0 ? { file, rules } : null
+	}
+	return null
+}
 
 /**
  * Scaffold the canonical Dependabot setup: the grouped \`dependabot.yml\` **and**

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -957,6 +957,40 @@ describe('doctor security checks', () => {
 		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('ok')
 	})
 
+	it('names repo-local ignore rules without calling them drift (#422)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateDependabotConfig(dir)
+		const configPath = join(dir, '.github', 'dependabot.yml')
+		const canonical = await fs.readFile(configPath, 'utf-8')
+		await fs.writeFile(
+			configPath,
+			canonical.replace(
+				'    groups:',
+				'    ignore:\n      - dependency-name: typescript\n        update-types:\n          - version-update:semver-major\n    groups:'
+			)
+		)
+		const dep = (await runDoctor(dir)).find((r) => r.check === 'Dependabot')
+		// A deliberate ignore rule is not drift — but it is why `fix` will refuse,
+		// so it has to be visible before anyone runs `fix`.
+		expect(dep?.status).toBe('ok')
+		expect(dep?.detail).toMatch(/typescript/)
+		expect(dep?.detail).toMatch(/refuses/)
+	})
+
+	it('warns about ignore rules alongside real drift', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(
+			join(dir, '.github', 'dependabot.yml'),
+			'version: 2\nupdates:\n  - package-ecosystem: npm\n    ignore:\n      - dependency-name: typescript\n'
+		)
+		const dep = (await runDoctor(dir)).find((r) => r.check === 'Dependabot')
+		expect(dep?.status).toBe('drift')
+		expect(dep?.detail).toMatch(/typescript/)
+		expect(dep?.hint).toMatch(/refuses|refuse/)
+	})
+
 	it('reports Dependabot ok when renovate.json exists (Renovate is an accepted alternative)', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -35,6 +35,18 @@ async function seedCanonicalDependabot(dir: string) {
 	)
 }
 
+// A hand-maintained ignore rule of the kind the canonical template can't
+// express, so regenerating would delete it silently (#422).
+const DEPENDABOT_WITH_IGNORE = `version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+`
+
 async function seedPackageJson(dir: string, extra: Record<string, unknown> = {}) {
 	await fs.writeJson(join(dir, 'package.json'), {
 		name: 'demo',
@@ -308,6 +320,94 @@ describe('fix targeted', () => {
 		expect(
 			await fs.pathExists(join(dir, '.github', 'workflows', 'dependabot-automerge.yml'))
 		).toBe(true)
+	})
+
+	it('fix dependabot refuses rather than drop repo-local ignore rules', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), DEPENDABOT_WITH_IGNORE)
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+			throw new Error('exit')
+		}) as never)
+		try {
+			await expect(fixCommand('dependabot', { directory: dir, yes: true })).rejects.toThrow('exit')
+			expect(exitSpy).toHaveBeenCalledWith(1)
+			// The file is untouched, and the message names the rule being protected.
+			expect(await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')).toBe(
+				DEPENDABOT_WITH_IGNORE
+			)
+			expect(errSpy.mock.calls.flat().join('\n')).toMatch(/typescript/)
+		} finally {
+			exitSpy.mockRestore()
+			errSpy.mockRestore()
+		}
+	})
+
+	it('fix dependabot --json reports the refusal as an error payload', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), DEPENDABOT_WITH_IGNORE)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+			throw new Error('exit')
+		}) as never)
+		try {
+			await expect(fixCommand('dependabot', { directory: dir, json: true })).rejects.toThrow('exit')
+			const parsed = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+			expect(parsed.error).toBe('dependabot-ignore-rules')
+			expect(parsed.hint).toBeTruthy()
+		} finally {
+			exitSpy.mockRestore()
+			logSpy.mockRestore()
+		}
+	})
+
+	it('fix dependabot --diff previews a refusal without crashing', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), DEPENDABOT_WITH_IGNORE)
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+			throw new Error('exit')
+		}) as never)
+		try {
+			// The preview shadow-runs the fixer, which aborts there too — it must
+			// fall through to the real run's error path, not an unhandled rejection.
+			await expect(
+				fixCommand('dependabot', { directory: dir, yes: true, diff: true })
+			).rejects.toThrow('exit')
+			expect(exitSpy).toHaveBeenCalledWith(1)
+		} finally {
+			exitSpy.mockRestore()
+			logSpy.mockRestore()
+			errSpy.mockRestore()
+		}
+	})
+
+	it('fix --json skips the refusing fixer and still applies the rest', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.outputFile(join(dir, '.github', 'dependabot.yml'), DEPENDABOT_WITH_IGNORE)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		try {
+			// A bulk run must not abort on one refusal — nor overwrite the rules.
+			await fixCommand(undefined, { directory: dir, json: true })
+			const parsed = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+			const dependabot = parsed.actions.find(
+				(a: { target: string | null }) => a.target === 'dependabot'
+			)
+			expect(dependabot).toMatchObject({ status: 'skipped', filesWritten: [] })
+			expect(parsed.actions.some((a: { status: string }) => a.status === 'applied')).toBe(true)
+			expect(await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')).toBe(
+				DEPENDABOT_WITH_IGNORE
+			)
+		} finally {
+			logSpy.mockRestore()
+			errSpy.mockRestore()
+		}
 	})
 
 	it('fix unknown-target exits non-zero', async () => {

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -2,6 +2,9 @@ import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import {
+	DEPENDABOT_CONFIG,
+	dependabotIgnoreRules,
+	findDependabotIgnoreRules,
 	generateCodeQLWorkflow,
 	generateDependabotConfig,
 	generateSecurityConfigs,
@@ -50,6 +53,84 @@ describe('generateDependabotConfig', () => {
 			'.github/dependabot.yml',
 			'.github/workflows/dependabot-automerge.yml',
 		])
+	})
+})
+
+describe('dependabotIgnoreRules', () => {
+	// The rule that went missing in rtorcato/browser-common (#422) — apps/docs is
+	// pinned to TypeScript ~5.6.3 by hand, and regenerating deleted the pin.
+	const BROWSER_COMMON = `version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    ignore:
+      # apps/docs is deliberately pinned to TypeScript ~5.6.3 — TS 7 removed
+      # \`baseUrl\`, so a TS major is a migration to do by hand.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+    groups:
+      major-updates:
+        update-types:
+          - major
+`
+
+	it('names each ignored dependency', () => {
+		expect(dependabotIgnoreRules(BROWSER_COMMON)).toEqual(['typescript'])
+	})
+
+	it('does not count an entry’s own update-types list as extra rules', () => {
+		// `- version-update:semver-major` is a list item too, just a deeper one.
+		expect(dependabotIgnoreRules(BROWSER_COMMON)).toHaveLength(1)
+	})
+
+	it('finds rules under every ecosystem block, quoted or not', () => {
+		const content = `updates:
+  - package-ecosystem: npm
+    ignore:
+      - dependency-name: "eslint"
+      - dependency-name: 'react'
+        versions: ['>=19']
+  - package-ecosystem: github-actions
+    ignore:
+      - dependency-name: actions/checkout
+`
+		expect(dependabotIgnoreRules(content)).toEqual(['eslint', 'react', 'actions/checkout'])
+	})
+
+	it('still reports a rule whose dependency-name it cannot read', () => {
+		const content = `    ignore:
+      - versions:
+          - 4.x
+`
+		expect(dependabotIgnoreRules(content)).toEqual(['<unnamed rule>'])
+	})
+
+	it('finds nothing in the canonical config, an empty list, or a comment', () => {
+		expect(dependabotIgnoreRules(DEPENDABOT_CONFIG)).toEqual([])
+		expect(dependabotIgnoreRules('    ignore: []\n')).toEqual([])
+		expect(dependabotIgnoreRules('    # ignore:\n    #  - dependency-name: x\n')).toEqual([])
+	})
+})
+
+describe('findDependabotIgnoreRules', () => {
+	it('returns null when the repo has no config, and when the config has no rules', async () => {
+		const dir = newTmpDir()
+		expect(await findDependabotIgnoreRules(dir)).toBeNull()
+		await generateDependabotConfig(dir)
+		expect(await findDependabotIgnoreRules(dir)).toBeNull()
+	})
+
+	it('reports the .yaml spelling too', async () => {
+		const dir = newTmpDir()
+		await fs.outputFile(
+			join(dir, '.github', 'dependabot.yaml'),
+			'updates:\n  - package-ecosystem: npm\n    ignore:\n      - dependency-name: typescript\n'
+		)
+		expect(await findDependabotIgnoreRules(dir)).toEqual({
+			file: '.github/dependabot.yaml',
+			rules: ['typescript'],
+		})
 	})
 })
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

Closes #422

## What

`fix dependabot` wrote `.github/dependabot.yml` wholesale from `dependabotConfig()`, which emits no `ignore:` block. Any hand-added ignore rule was therefore deleted on the next run, silently — and `doctor` reported nothing afterwards, because the file then matches the standard exactly. The drift *is* the standard.

`ignore` is the one key that is inherently repo-local, so a template owning the whole file can never carry it.

## Scope — Option 3 only

The issue offered three options; a triage comment on the issue pinned **Option 3 (detect and refuse)**. Refusing rather than warning is the load-bearing choice: an unattended `fix --yes` walks straight past a warning, and the rules are unrecoverable once written over.

**Option 2 — owning an `ignore` input in `.repo-tooling.json` — remains open as a follow-up.** It is the tidier long-term fit (the file stays fully generated, and the constraint becomes reviewable), but it is a `ProjectConfig` schema change plus a migration story for every repo that already hand-edited the file, and it closes the data-loss window no faster than this does.

## Behaviour

| Path | Before | After |
|---|---|---|
| `fix dependabot` | overwrites, rules gone | exits 1, names each rule, file untouched |
| `fix dependabot --json` | same | `{"error": "dependabot-ignore-rules", "hint": ...}` |
| `fix --yes` (bulk) | overwrites | records the target `skipped`, applies every other fixer |
| `fix dependabot --diff` | — | previews the refusal instead of crashing in the shadow run |
| `doctor` | silent | names the rules in the Dependabot detail line |

`doctor` deliberately does **not** call an ignore block drift. A hand-held pin is correct, not a defect — it is just the reason `fix` refuses, so it has to be visible before anyone runs `fix`. A repo with canonical grouping plus an ignore rule still reads `ok`.

Nothing here is specific to `typescript` or to any one repo: `dependabotIgnoreRules()` names whatever `dependency-name`s it finds under any `ignore:` block, in any ecosystem, and reports a rule as `<unnamed rule>` when it cannot read a name — which still stops the overwrite.

## Notes for review

- The detector is a line scanner, not a YAML parse — the package ships no YAML parser, and this only needs to answer "is there something to lose, and what is it called". Marked with a `ponytail:` comment naming the ceiling.
- `fix.ts` needed two new catch sites. The bulk loop previously had no `FixerAbort` guard (its comment said as much) because the only aborting fixer was `explicitOnly` and unreachable there; `dependabot` is neither. One refusal must not abandon the rest of the run.

## Verification

`vitest run` — 928 passed, 18 skipped; `tsc --noEmit`; `biome check src scripts` clean. New coverage: parser unit tests (browser-common's real rule, nested `update-types`, multi-ecosystem, quoted names, unnamed rules, `ignore: []`, commented-out blocks), the four `fix` paths above, and two `doctor` cases.
