### PR TITLE
fix(security): gate Dependabot auto-merge on the dev-minor group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,16 @@ updates:
       prefix: chore
       include: scope
     groups:
-      # Safe tier: runtime + dev minor/patch auto-merge on green (see the
-      # dependabot-automerge workflow). Grouped so react/react-dom move together.
+      # Runtime minor/patch. Grouped so react/react-dom move together, but NOT
+      # auto-merged — these ship to consumers of a published package, so they
+      # get a human (see the dependabot-automerge workflow).
       production-minor:
         dependency-type: production
         update-types:
           - minor
           - patch
+      # The only tier that auto-merges on green — dev tooling never reaches a
+      # consumer of the published package.
       dev-minor:
         dependency-type: development
         update-types:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,10 +17,14 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-merge patch and minor updates
+      # Belt and braces: the dev-minor group is already declared minor+patch in
+      # dependabot.yml, but this workflow is the security gate and shouldn't
+      # trust a config file a consumer repo can edit independently.
+      - name: Auto-merge dev-dependency patch and minor updates
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.dependency-group == 'dev-minor' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -25,17 +25,32 @@ Dependabot opens roughly **3–4 PRs per cycle** instead of one per package:
 
 | Group | Contents | Update types | Auto-merge |
 | --- | --- | --- | --- |
-| `production-minor` | runtime `dependencies` | minor, patch | ✅ on green |
+| `production-minor` | runtime `dependencies` | minor, patch | ❌ manual |
 | `dev-minor` | `devDependencies` | minor, patch | ✅ on green |
 | `major-updates` | all packages | major | ❌ manual |
-| `github-actions` | workflow actions | all | ✅ on green |
+| `github-actions` | workflow actions | all | ❌ manual |
 
-## 2. Auto-merge — safe tier only
+## 2. Auto-merge — dev dependencies only
 
-Patch and minor updates (prod and dev) **merge themselves once CI is green** —
-no human in the loop. Implemented by `.github/workflows/dependabot-automerge.yml`
-using `dependabot/fetch-metadata` + `gh pr merge --auto --squash`, gated to
-`version-update:semver-patch` and `version-update:semver-minor`.
+Patch and minor updates **of `devDependencies`** merge themselves once CI is
+green — no human in the loop. Implemented by
+`.github/workflows/dependabot-automerge.yml` using `dependabot/fetch-metadata` +
+`gh pr merge --auto --squash`, gated on **both** `dependency-group == 'dev-minor'`
+and `version-update:semver-patch` / `version-update:semver-minor`.
+
+Everything else waits for a human, and the gate **fails closed**: a PR outside a
+group reports an empty `dependency-group` and so never matches.
+
+> **Production bumps are deliberately excluded.** A minor bump to a runtime
+> dependency of a published package ships to every consumer on the next release.
+> Auto-merging those on green CI alone means the 7-day `cooldown` is the only
+> thing between a compromised upstream release and `main`. GitHub Actions bumps
+> are excluded for the same reason — a compromised action runs in CI holding
+> `GITHUB_TOKEN`.
+>
+> The gate names the group that `dependabot.yml` declares, so the two files are
+> a paired unit: rename a group in one and auto-merge silently stops (which is
+> the safe direction, but still drift — `doctor` flags it).
 
 > **Requires branch protection.** `gh pr merge --auto` only gates correctly when
 > the repo has auto-merge enabled and `main` has required status checks

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -295,7 +295,15 @@ export async function checkDependabot(dir: string): Promise<CheckResult> {
 				}
 			}
 			const automergePath = path.join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
-			if (!(await fs.pathExists(automergePath))) {
+			if (await fs.pathExists(automergePath)) {
+				// Pre-#423 workflows gated on the semver type alone, so production
+				// bumps of a published package merged with nobody in the loop. The
+				// canonical gate also requires the dev-minor group.
+				const automerge = await fs.readFile(automergePath, 'utf8')
+				if (!automerge.includes("dependency-group == 'dev-minor'")) {
+					deltas.push('auto-merge workflow merges production bumps (missing dev-minor group gate)')
+				}
+			} else {
 				deltas.push('missing dependabot-automerge workflow')
 			}
 			if (deltas.length > 0) {

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -31,13 +31,16 @@ export function dependabotConfig(ecosystem: string | null): string {
       prefix: chore
       include: scope
     groups:
-      # Safe tier: runtime + dev minor/patch auto-merge on green (see the
-      # dependabot-automerge workflow). Grouped so react/react-dom move together.
+      # Runtime minor/patch. Grouped so react/react-dom move together, but NOT
+      # auto-merged — these ship to consumers of a published package, so they
+      # get a human (see the dependabot-automerge workflow).
       production-minor:
         dependency-type: production
         update-types:
           - minor
           - patch
+      # The only tier that auto-merges on green — dev tooling never reaches a
+      # consumer of the published package.
       dev-minor:
         dependency-type: development
         update-types:
@@ -68,10 +71,16 @@ ${manifest}  - package-ecosystem: github-actions
 export const DEPENDABOT_CONFIG = dependabotConfig('npm')
 
 /**
- * Auto-merges patch + minor Dependabot PRs once CI is green. Requires branch
- * protection with required status checks on the target branch — without it,
- * \`gh pr merge --auto\` never fires. Majors are excluded (they land in the
- * major-updates group for manual triage).
+ * Auto-merges patch + minor Dependabot PRs **from the `dev-minor` group only**
+ * once CI is green. Requires branch protection with required status checks on
+ * the target branch — without it, \`gh pr merge --auto\` never fires.
+ *
+ * Everything else falls through to a human: production bumps ship to consumers
+ * of a published package (#423), majors are breaking by definition, and an
+ * ungrouped PR reports an empty \`dependency-group\`, so the gate fails closed.
+ *
+ * The group name is the one \`dependabotConfig()\` writes — the two files are a
+ * paired unit and have to move together.
  */
 export const DEPENDABOT_AUTOMERGE_WORKFLOW = `name: Dependabot auto-merge
 
@@ -92,10 +101,14 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
 
-      - name: Auto-merge patch and minor updates
+      # Belt and braces: the dev-minor group is already declared minor+patch in
+      # dependabot.yml, but this workflow is the security gate and shouldn't
+      # trust a config file a consumer repo can edit independently.
+      - name: Auto-merge dev-dependency patch and minor updates
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.dependency-group == 'dev-minor' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: \${{ github.event.pull_request.html_url }}

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -949,6 +949,27 @@ describe('doctor security checks', () => {
 		expect(results.find((r) => r.check === 'Dependabot')?.status).toBe('drift')
 	})
 
+	// #423: a repo that took the scaffolded pair before the dev-minor gate is
+	// still auto-merging production bumps — flag it so `fix dependabot` lands.
+	it('reports Dependabot drift when the auto-merge workflow has the old broad gate', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateDependabotConfig(dir)
+		const workflow = join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+		await fs.writeFile(
+			workflow,
+			(await fs.readFile(workflow, 'utf8')).replace(
+				/\s*steps\.metadata\.outputs\.dependency-group == 'dev-minor' &&/,
+				''
+			)
+		)
+		const results = await runDoctor(dir)
+		const dep = results.find((r) => r.check === 'Dependabot')
+		expect(dep?.status).toBe('drift')
+		expect(dep?.detail).toMatch(/production bumps/)
+		expect(dep?.hint).toMatch(/fix dependabot/)
+	})
+
 	it('reports Dependabot ok with the canonical config + auto-merge workflow', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -51,6 +51,36 @@ describe('generateDependabotConfig', () => {
 			'.github/workflows/dependabot-automerge.yml',
 		])
 	})
+
+	// #423: production bumps ship to consumers of a published package, so the
+	// auto-merge gate is the dev-minor group *and* the semver type.
+	it('gates auto-merge on the dev-minor group as well as the semver type', async () => {
+		const dir = newTmpDir()
+		await generateDependabotConfig(dir)
+		const content = await fs.readFile(
+			join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+			'utf-8'
+		)
+		expect(content).toMatch(/steps\.metadata\.outputs\.dependency-group == 'dev-minor' &&/)
+		expect(content).toMatch(/update-type == 'version-update:semver-patch'/)
+		expect(content).toMatch(/update-type == 'version-update:semver-minor'/)
+		expect(content).not.toMatch(/'production-minor'/)
+	})
+
+	// The gate names a group that the paired dependabot.yml has to declare —
+	// rename one without the other and auto-merge silently stops firing.
+	it('gates on a group the paired dependabot.yml actually declares', async () => {
+		const dir = newTmpDir()
+		await generateDependabotConfig(dir)
+		const config = await fs.readFile(join(dir, '.github', 'dependabot.yml'), 'utf-8')
+		const workflow = await fs.readFile(
+			join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+			'utf-8'
+		)
+		const group = workflow.match(/dependency-group == '([^']+)'/)?.[1]
+		expect(group).toBeDefined()
+		expect(config).toMatch(new RegExp(`^\\s*${group}:`, 'm'))
+	})
 })
 
 describe('generateCodeQLWorkflow', () => {


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account by an agent; not a human message.*

Closes #423

## What changed

`generateDependabotConfig()`'s auto-merge workflow gated only on the semver type, so minor/patch bumps of **runtime** dependencies merged to `main` on green CI alone. For a published package that is its supply chain, and the 7-day `cooldown` was the only thing in the way.

```diff
-      - name: Auto-merge patch and minor updates
+      - name: Auto-merge dev-dependency patch and minor updates
         if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          steps.metadata.outputs.dependency-group == 'dev-minor' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor')
```

Applied to the generator, to this repo's own copies (dogfood), and to the strategy guide. No group was renamed — the pairing with `dependabot.yml` is unchanged.

## Decisions worth reviewing

**Both conditions, not group alone.** `dev-minor` is already declared `minor`+`patch` in the `dependabot.yml` this generator writes, so a group-only gate would be sufficient *given that pairing*. Kept both anyway: this workflow is the security gate, and the file it would be trusting lives in the consumer's repo where it can be edited independently of the workflow. Two extra lines to stop trusting a config we don't control is the right trade on a gate whose failure mode is an unreviewed publish.

**The gate fails closed.** A PR outside any group reports an empty `dependency-group` and never matches. That was the stated reason dev-only was pinned over private-only, and it holds here.

**GitHub Actions bumps now need a human too.** The `github-actions` ecosystem block has no `groups:`, so those PRs report an empty `dependency-group` and stop auto-merging. This is a narrowing beyond production npm deps and was not called out in the issue — flagging it explicitly. I think it's correct rather than collateral: a compromised action runs in CI holding `GITHUB_TOKEN`, which is not obviously a smaller blast radius than a runtime dep. If you'd rather keep them flowing, the carve-out is one `||` on `package-ecosystem`. Docs table updated to say ❌ manual either way.

**`doctor` — extended the existing check, not a new one.** The suggestion was a separate clearly-named check; I put it in `checkDependabot` as a named delta instead:

```
Dependabot  drift  .github/dependabot.yml drifts from canonical
                   (auto-merge workflow merges production bumps (missing dev-minor group gate))
```

Reason: a second check would emit a second `drift` row for the same file pair with the same remedy (`fix dependabot` rewrites both). Happy to split it if you'd rather see it standalone.

## Release type

`fix:` → patch. This **narrows behaviour consumers currently rely on** — any repo that takes the update stops auto-merging production bumps it previously merged. I didn't mark it breaking because nothing in the public surface moves: same CLI flags, same `ProjectConfig` schema, same `filesWritten` list. Only the *content* of two scaffolded files, which `fix dependabot` exists to rewrite. If you read a scaffolded-output change of this size as major-worthy, say so and I'll redo the subject as `feat!:`.

Also worth noting the issue thread: your comment said "dev-only and private-only", and the triage comment that lifted the hold pinned **dev-only** only. This PR implements dev-only. Private-only is not foreclosed and would layer on top.

## Verification

`biome check src scripts`, `tsc --noEmit`, and the full vitest suite (918 passed, 18 skipped) all clean. Three new tests: the gate's shape, that the gated group name is one the paired `dependabot.yml` actually declares, and the new `doctor` drift row.
