### PR TITLE
feat(doctor): tell a stale copied asset from a deliberate local fork

### DIFF
--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -33,6 +33,18 @@ Available presets: `biome`, `tsconfig`, `bun`, `nx`, `changesets`, `release-plea
 
 `copy` is for configs you must *own* rather than extend — Biome doesn't support configuration extension, and TypeScript configs resolve more reliably when local. Most other configs (ESLint, Prettier, Vitest, etc.) can be imported or extended directly — see the [Configuration Reference](../reference/biome.md) for usage.
 
+### Copied assets don't drift silently
+
+A copy used to be a one-shot: nothing looked at the file again, so a repo could sit on an ancient copy of `scripts/sync-changelog.mjs` for a year without a signal. `copy` now records the asset's hash at copy time in `.repo-tooling.json`, and doctor's **Copied assets** check reads it back:
+
+| State | Means | doctor |
+|---|---|---|
+| `stale` | Untouched since the copy, but the package ships a newer version | `drift` — `fix copied-assets` re-copies it, and can't lose anything, because nothing local is in it |
+| `modified` | The file differs from what was copied — someone forked it deliberately | reported, never overwritten; a human decision |
+| untracked | No recorded hash: the copy predates this, or the repo has no `.repo-tooling.json` | reported, never `drift` — a missing record isn't evidence of drift |
+
+`copy` never creates a lockfile just to have somewhere to write. Run `fix lockfile` first if you want a repo's copies tracked.
+
 ## list / ls
 
 Prints all available tooling configurations.

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -30,6 +30,7 @@ import {
 	generateDependabotConfig,
 	generateRenovateConfig,
 } from '../cli/generators/security.js'
+import { classifyCopiedAssets } from '../cli/utils/copied-assets.js'
 import { copyPreset } from '../cli/utils/copy-preset.js'
 import { detectLanguage } from '../cli/utils/detect-language.js'
 import type { Lockfile } from '../cli/utils/lockfile.js'
@@ -139,6 +140,25 @@ async function resolveInstallDir(explicit: string | undefined, assumeYes: boolea
 }
 
 export const BASE_FIXERS: Fixer[] = [
+	{
+		target: 'copied-assets',
+		description:
+			'Re-copy presets that are unchanged since they were copied but older than the version this package ships',
+		appliesTo: ['Copied assets'],
+		outputs: ['(the stale copied presets, re-copied in place)'],
+		canFixDrift: true,
+		async run({ targetDir }) {
+			// Only the `stale` ones: their content provably still matches what was
+			// copied, so overwriting loses nothing. `modified` assets are somebody's
+			// deliberate fork and stay a human decision (#428).
+			const stale = (await classifyCopiedAssets(targetDir)).filter((a) => a.state === 'stale')
+			const filesWritten: string[] = []
+			for (const asset of stale) {
+				filesWritten.push((await copyPreset(asset.preset, targetDir)).target)
+			}
+			return { filesWritten }
+		},
+	},
 	{
 		target: 'editorconfig',
 		description: 'Scaffold .editorconfig (UTF-8, LF, tab indent)',

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -15,6 +15,7 @@ import { type DetectedLanguage, detectLanguage } from '../utils/detect-language.
 import { checkGitHubSettings } from '../../base/github-settings.js'
 import { checkMilestones } from '../../base/milestones.js'
 import { checkGitIdentity } from '../../base/git-identity.js'
+import { checkCopiedAssets } from '../utils/copied-assets.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
 import {
@@ -233,6 +234,9 @@ async function runBaseChecks(
 ): Promise<CheckResult[]> {
 	const results: CheckResult[] = []
 	results.push(checkLockfile(lock))
+	// Any language can have copied presets (swiftlint, ruff, perlcriticrc), so
+	// this rides with the base suite rather than a module's (#428).
+	results.push(await checkCopiedAssets(dir))
 	results.push(await checkNestedLanguages(dir, opts.language))
 	results.push(await checkGitIdentity(dir))
 	results.push(await checkEditorConfig(dir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -50,6 +50,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'AI setup': 'ai',
 	'Claude worktree settings': 'ai',
 	'Claude skills': 'claude-skills',
+	'Copied assets': 'copied-assets',
 }
 
 /**

--- a/src/cli/utils/copied-assets.ts
+++ b/src/cli/utils/copied-assets.ts
@@ -1,0 +1,93 @@
+/**
+ * Drift detection for copied presets (#428).
+ *
+ * `copy <preset>` used to be a one-shot: it wrote the file and nothing ever
+ * looked at it again, so eight copies of `sync-changelog.mjs` drifted into six
+ * versions with no signal. The fix is one recorded fact — the asset's pristine
+ * hash at copy time, in `.repo-tooling.json` — which is enough to separate the
+ * two cases that matter:
+ *
+ * - file ≠ recorded hash → `modified`. Someone edited it on purpose (js-common
+ *   forked this very script and documented why in its header). Reported, never
+ *   overwritten, never counted as drift.
+ * - file = recorded hash, but the shipped asset has moved on → `stale`. Nothing
+ *   local is in it, so re-copying is lossless.
+ * - no recorded hash → `unknown`. Copies predating this, and repos with no
+ *   lockfile at all. Absence of a record is not evidence of drift, so this
+ *   never fails a build.
+ */
+import path from 'node:path'
+import type { CheckResult } from '../../base/types.js'
+import { getPackageRoot, hashFile, PRESETS, type PresetName } from './copy-preset.js'
+import { readLockfile } from './lockfile.js'
+
+export interface CopiedAssetStatus {
+	preset: PresetName
+	target: string
+	state: 'ok' | 'modified' | 'stale' | 'unknown'
+}
+
+type AssetState = CopiedAssetStatus['state']
+
+/**
+ * Classify every preset whose target file exists in `dir`. Presets that were
+ * never copied here are absent from the result rather than reported missing —
+ * `copy` is opt-in, and doctor already has checks for the files that aren't.
+ */
+export async function classifyCopiedAssets(dir: string): Promise<CopiedAssetStatus[]> {
+	const lock = await readLockfile(dir)
+	const packageRoot = getPackageRoot()
+	const statuses: CopiedAssetStatus[] = []
+
+	for (const name of Object.keys(PRESETS) as PresetName[]) {
+		const preset = PRESETS[name]
+		const current = await hashFile(path.join(dir, preset.target))
+		if (current === null) continue
+
+		const recorded = lock?.assets?.[name]
+		// Unmodified since the copy, so whether it's stale is purely a question of
+		// what this package ships now. A source we can't read (shouldn't happen)
+		// falls back to the recorded hash — "no news", not drift.
+		const shipped = recorded
+			? ((await hashFile(path.join(packageRoot, preset.source))) ?? recorded)
+			: null
+
+		let state: AssetState = 'ok'
+		if (!recorded) state = 'unknown'
+		else if (recorded !== current) state = 'modified'
+		else if (shipped !== recorded) state = 'stale'
+
+		statuses.push({ preset: name, target: preset.target, state })
+	}
+
+	return statuses
+}
+
+const listOf = (s: CopiedAssetStatus[]) => s.map((a) => a.preset).join(', ')
+
+export async function checkCopiedAssets(dir: string): Promise<CheckResult> {
+	const check = 'Copied assets'
+	const all = await classifyCopiedAssets(dir)
+	if (all.length === 0) {
+		return { check, status: 'optional-missing', detail: 'no copied presets found' }
+	}
+
+	const by = (state: AssetState) => all.filter((a) => a.state === state)
+	const stale = by('stale')
+	const modified = by('modified')
+	const unknown = by('unknown')
+
+	const parts = [`${by('ok').length} in sync`]
+	if (modified.length > 0) parts.push(`${modified.length} locally modified: ${listOf(modified)}`)
+	if (unknown.length > 0) parts.push(`${unknown.length} untracked: ${listOf(unknown)}`)
+
+	if (stale.length === 0) {
+		return { check, status: 'ok', detail: parts.join('; ') }
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: `${stale.length} stale: ${listOf(stale)}; ${parts.join('; ')}`,
+		hint: 'Run `npx @rtorcato/repo-tooling fix copied-assets` to re-copy them. They still match what was copied, so nothing local is lost — locally modified assets are left alone.',
+	}
+}

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto'
 import path from 'node:path'
 import fs from 'fs-extra'
+import { recordAssetHash } from './lockfile.js'
 
 export type PresetName =
 	| 'biome'
@@ -153,6 +155,17 @@ export interface CopyPresetResult {
 	desc: string
 }
 
+/** sha256 of a file's bytes, or null when it doesn't exist / can't be read. */
+export async function hashFile(filepath: string): Promise<string | null> {
+	try {
+		return createHash('sha256')
+			.update(await fs.readFile(filepath))
+			.digest('hex')
+	} catch {
+		return null
+	}
+}
+
 export async function copyPreset(
 	name: PresetName,
 	targetDir: string = process.cwd()
@@ -169,6 +182,11 @@ export async function copyPreset(
 		const legacyPath = path.join(targetDir, preset.legacyTarget)
 		if (legacyPath !== targetPath) await fs.remove(legacyPath)
 	}
+
+	// Stamp what was copied, so doctor can later tell a local edit from a copy
+	// the package has moved past (#428). No-ops when the repo has no lockfile.
+	const hash = await hashFile(sourcePath)
+	if (hash) await recordAssetHash(targetDir, name, hash)
 
 	return {
 		source: preset.source,

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -15,13 +15,23 @@ export const LEGACY_TOOL_NAME = 'js-tooling'
 export const LEGACY_LOCKFILE_NAME = `.${LEGACY_TOOL_NAME}.json`
 // v2 added ProjectConfig.language (multi-language seam, #140). v1 files are
 // migrated to v2 on read, defaulting language to 'js'.
-export const LOCKFILE_VERSION = 2
+// v3 added `assets` — the pristine hash of each copied preset (#428). Older
+// files carry no hashes, which reads as "not tracked", never as drift.
+export const LOCKFILE_VERSION = 3
 const LOCKFILE_SCHEMA_URL = 'https://rtorcato.github.io/repo-tooling/schemas/lockfile.json'
 
 export interface Lockfile {
 	$schema?: string
 	version: number
 	config: ProjectConfig
+	/**
+	 * Preset name → sha256 of the asset's *pristine* content at copy time (#428).
+	 * Lets doctor tell a deliberate local fork (`modified` — file differs from
+	 * this hash) from a copy the package has since moved past (`stale` — file
+	 * still matches this hash, but the shipped asset doesn't). A preset with no
+	 * entry here is simply untracked; absence is not evidence of drift.
+	 */
+	assets?: Record<string, string>
 	writtenBy: string
 	writtenAt: string
 }
@@ -29,7 +39,7 @@ export interface Lockfile {
 /**
  * Upgrade an older lockfile in-memory. Only touches files older than the
  * current version, so a newer-than-supported file is left as-is for
- * checkLockfile to flag. The file is rewritten to v2 next time it's saved.
+ * checkLockfile to flag. The file is rewritten to v3 next time it's saved.
  */
 function migrate(lock: Lockfile): Lockfile {
 	if (lock.version >= LOCKFILE_VERSION) return lock
@@ -37,6 +47,7 @@ function migrate(lock: Lockfile): Lockfile {
 		...lock,
 		version: LOCKFILE_VERSION,
 		config: { language: 'js', ...lock.config },
+		assets: lock.assets ?? {},
 	}
 }
 
@@ -60,16 +71,27 @@ export async function readLockfile(dir: string): Promise<Lockfile | null> {
 	}
 }
 
-export async function writeLockfile(dir: string, config: ProjectConfig): Promise<string> {
+/**
+ * @param assets Recorded asset hashes to write. Omit to carry the existing
+ *   file's hashes forward — every caller that only means to update `config`
+ *   would otherwise silently drop them.
+ */
+export async function writeLockfile(
+	dir: string,
+	config: ProjectConfig,
+	assets?: Record<string, string>
+): Promise<string> {
 	const { valid, errors } = validateProjectConfig(config)
 	if (!valid) {
 		throw new Error(`Refusing to write invalid lockfile:\n  - ${errors.join('\n  - ')}`)
 	}
+	const carried = assets ?? (await readLockfile(dir))?.assets
 	const filepath = path.join(dir, LOCKFILE_NAME)
 	const lockfile: Lockfile = {
 		$schema: LOCKFILE_SCHEMA_URL,
 		version: LOCKFILE_VERSION,
 		config,
+		...(carried && Object.keys(carried).length > 0 ? { assets: carried } : {}),
 		writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
 		writtenAt: new Date().toISOString(),
 	}
@@ -93,5 +115,18 @@ export async function updateLockfileConfig(
 	if (!existing) return false
 	const merged: ProjectConfig = { ...existing.config, ...patch }
 	await writeLockfile(dir, merged)
+	return true
+}
+
+/**
+ * Record the pristine hash of a just-copied preset (#428). Returns false when
+ * the repo has no lockfile — four family repos don't, and creating one as a
+ * side effect of `copy` would be a surprise. Those repos keep reporting the
+ * asset as untracked, which is the honest answer.
+ */
+export async function recordAssetHash(dir: string, preset: string, hash: string): Promise<boolean> {
+	const existing = await readLockfile(dir)
+	if (!existing) return false
+	await writeLockfile(dir, existing.config, { ...existing.assets, [preset]: hash })
 	return true
 }

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -14,6 +14,7 @@ import {
 	DEPENDABOT_AUTOMERGE_WORKFLOW,
 	DEPENDABOT_CONFIG,
 } from '../../../src/cli/generators/security.js'
+import { LOCKFILE_VERSION } from '../../../src/cli/utils/lockfile.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 vi.mock('inquirer', () => ({
@@ -1060,7 +1061,7 @@ describe('fix + lockfile', () => {
 		await seedPackageJson(dir)
 		await fixCommand('lockfile', { directory: dir, yes: true })
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.version).toBe(2)
+		expect(lock.version).toBe(LOCKFILE_VERSION)
 		expect(lock.config.projectName).toBe('demo')
 		expect(lock.config.linting.tool).toBe('biome')
 	})

--- a/tests/cli/utils/copied-assets.test.ts
+++ b/tests/cli/utils/copied-assets.test.ts
@@ -1,0 +1,144 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { runDoctor } from '../../../src/cli/commands/doctor.js'
+import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
+import { checkCopiedAssets, classifyCopiedAssets } from '../../../src/cli/utils/copied-assets.js'
+import { copyPreset, hashFile } from '../../../src/cli/utils/copy-preset.js'
+import { readLockfile, recordAssetHash, writeLockfile } from '../../../src/cli/utils/lockfile.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const CONFIG: ProjectConfig = {
+	projectName: 'demo',
+	projectType: 'library',
+	language: 'js',
+	typescript: { enabled: true, config: 'base' },
+	linting: { tool: 'biome' },
+	formatting: { tool: 'biome' },
+	testing: { framework: 'vitest', environment: 'node' },
+	gitHooks: true,
+	commitLint: true,
+	semanticRelease: true,
+	securityAutomation: true,
+	bundler: 'tsup',
+}
+
+/** A repo with a lockfile, so `copy` has somewhere to record hashes. */
+async function seedRepo(): Promise<string> {
+	const dir = newTmpDir()
+	await fs.writeJson(join(dir, 'package.json'), { name: 'demo', version: '0.0.0' })
+	await writeLockfile(dir, CONFIG)
+	return dir
+}
+
+const stateOf = (statuses: { preset: string; state: string }[], preset: string) =>
+	statuses.find((s) => s.preset === preset)?.state
+
+describe('classifyCopiedAssets', () => {
+	it('reports ok for an asset copied and left alone', async () => {
+		const dir = await seedRepo()
+		await copyPreset('oxlint', dir)
+
+		// The hash landed in the lockfile rather than nowhere.
+		const lock = await readLockfile(dir)
+		expect(lock?.assets?.oxlint).toMatch(/^[0-9a-f]{64}$/)
+
+		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('ok')
+	})
+
+	it('reports modified when the copy was edited afterwards', async () => {
+		const dir = await seedRepo()
+		await copyPreset('oxlint', dir)
+		await fs.appendFile(join(dir, '.oxlintrc.json'), '\n// local fork\n')
+
+		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('modified')
+	})
+
+	it('reports stale when the file still matches the record but the package has moved on', async () => {
+		const dir = await seedRepo()
+		// An older generation of the asset: untouched since it was copied (the
+		// record matches it byte for byte), but not what the package ships now.
+		const target = join(dir, '.oxlintrc.json')
+		await fs.writeFile(target, '{ "rules": {} }\n')
+		const hash = await hashFile(target)
+		await recordAssetHash(dir, 'oxlint', hash as string)
+
+		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('stale')
+	})
+
+	it('reports unknown for a copy made before hashes were recorded', async () => {
+		const dir = await seedRepo()
+		await copyPreset('oxlint', dir)
+		// Strip the record, leaving the pre-#428 shape: the file is there, its
+		// provenance isn't.
+		const lock = await readLockfile(dir)
+		await writeLockfile(dir, lock?.config as ProjectConfig, {})
+
+		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('unknown')
+	})
+
+	it('reports unknown when the repo has no lockfile at all', async () => {
+		const dir = newTmpDir()
+		await copyPreset('oxlint', dir)
+		// `copy` did not conjure a lockfile just to have somewhere to write.
+		expect(await readLockfile(dir)).toBeNull()
+
+		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('unknown')
+	})
+
+	it('ignores presets that were never copied here', async () => {
+		const dir = await seedRepo()
+		await copyPreset('oxlint', dir)
+		const presets = (await classifyCopiedAssets(dir)).map((s) => s.preset)
+		expect(presets).toContain('oxlint')
+		expect(presets).not.toContain('perltidy')
+	})
+})
+
+describe('checkCopiedAssets', () => {
+	it('is drift only for stale assets, and names the fix', async () => {
+		const dir = await seedRepo()
+		const target = join(dir, '.oxlintrc.json')
+		await fs.writeFile(target, '{ "rules": {} }\n')
+		await recordAssetHash(dir, 'oxlint', (await hashFile(target)) as string)
+
+		const result = await checkCopiedAssets(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toMatch(/1 stale: oxlint/)
+		expect(result.hint).toMatch(/fix copied-assets/)
+	})
+
+	it('stays ok for a deliberate local fork, and says so', async () => {
+		const dir = await seedRepo()
+		await copyPreset('oxlint', dir)
+		await fs.appendFile(join(dir, '.oxlintrc.json'), '\n// local fork\n')
+
+		const result = await checkCopiedAssets(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toMatch(/locally modified: oxlint/)
+	})
+
+	it('never fails a build over an untracked copy', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { name: 'demo', version: '0.0.0' })
+		await copyPreset('oxlint', dir)
+
+		const result = await checkCopiedAssets(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toMatch(/1 untracked: oxlint/)
+	})
+
+	it('is optional-missing in a repo with no copied presets', async () => {
+		const dir = newTmpDir()
+		expect((await checkCopiedAssets(dir)).status).toBe('optional-missing')
+	})
+
+	it('is surfaced by doctor', async () => {
+		const dir = await seedRepo()
+		await copyPreset('oxlint', dir)
+		const result = (await runDoctor(dir)).find((r) => r.check === 'Copied assets')
+		expect(result?.status).toBe('ok')
+	})
+})

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -7,6 +7,7 @@ import {
 	LOCKFILE_NAME,
 	LOCKFILE_VERSION,
 	readLockfile,
+	recordAssetHash,
 	updateLockfileConfig,
 	writeLockfile,
 } from '../../../src/cli/utils/lockfile.js'
@@ -61,7 +62,7 @@ describe('readLockfile', () => {
 		expect(lock?.config.projectName).toBe('demo')
 	})
 
-	it('migrates a v1 file to v2, defaulting language to js', async () => {
+	it('migrates a v1 file, defaulting language to js', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, LOCKFILE_NAME), {
 			version: 1,
@@ -71,9 +72,24 @@ describe('readLockfile', () => {
 		})
 
 		const lock = await readLockfile(dir)
-		expect(lock?.version).toBe(2)
+		expect(lock?.version).toBe(LOCKFILE_VERSION)
 		expect(lock?.config.language).toBe('js')
 		// Existing fields survive the migration untouched.
+		expect(lock?.config.projectName).toBe('demo')
+	})
+
+	it('migrates a v2 file to v3 with no recorded asset hashes (#428)', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, LOCKFILE_NAME), {
+			version: 2,
+			config: baseConfig({ language: 'js' }),
+			writtenBy: 'old',
+			writtenAt: '2024-01-01T00:00:00.000Z',
+		})
+
+		const lock = await readLockfile(dir)
+		expect(lock?.version).toBe(3)
+		expect(lock?.assets).toEqual({})
 		expect(lock?.config.projectName).toBe('demo')
 	})
 })
@@ -132,5 +148,25 @@ describe('updateLockfileConfig', () => {
 		const dir = newTmpDir()
 		const updated = await updateLockfileConfig(dir, { gitHooks: false })
 		expect(updated).toBe(false)
+	})
+
+	it('leaves recorded asset hashes alone (#428)', async () => {
+		const dir = newTmpDir()
+		await writeLockfile(dir, baseConfig())
+		await recordAssetHash(dir, 'oxlint', 'abc123')
+
+		await updateLockfileConfig(dir, { gitHooks: false })
+
+		const lock = await readLockfile(dir)
+		expect(lock?.assets).toEqual({ oxlint: 'abc123' })
+		expect(lock?.config.gitHooks).toBe(false)
+	})
+})
+
+describe('recordAssetHash', () => {
+	it('returns false without creating a lockfile when the repo has none', async () => {
+		const dir = newTmpDir()
+		expect(await recordAssetHash(dir, 'oxlint', 'abc123')).toBe(false)
+		expect(await fs.pathExists(join(dir, LOCKFILE_NAME))).toBe(false)
 	})
 })


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account by an agent; not a human message.*

Closes #428

Implements the lockfile-hash option pinned in triage — the only one of the three that classifies a deliberate fork correctly.

## What changed

`copy <preset>` now records the asset's pristine sha256 in `.repo-tooling.json` under a new `assets` map. `doctor`'s **Copied assets** check compares three hashes and reports:

| State | Condition | doctor status |
|---|---|---|
| `stale` | file matches the record, shipped asset differs | `drift` — `fix copied-assets` re-copies |
| `modified` | file differs from the record | `ok`, named in the detail, left alone |
| untracked | no recorded hash | `ok`, named in the detail, never drift |
| `ok` | file matches the record and the shipped asset | `ok` |

`js-common`'s deliberate fork of `sync-changelog.mjs` lands in `modified` and stays there — it is reported once per run and never nagged as fixable.

## No-record behaviour

Four family repos have no `.repo-tooling.json`, and every copy made before this lands has no recorded hash. Both report as untracked, which is `ok` and cannot fail a build. `copy` deliberately does **not** create a lockfile as a side effect — `recordAssetHash` returns `false` and the copy still succeeds.

## Lockfile migration

`LOCKFILE_VERSION` 2 → 3 through the existing `migrate()`: a v2 file gains `assets: {}` on read, everything else untouched. `writeLockfile` gained an optional third argument and otherwise carries existing hashes forward, so `updateLockfileConfig` (called from a dozen fixers) can't silently drop them.

## The one risk worth naming

Bumping the version means an *older* CLI reading a v3 lockfile reports the existing `lockfile` check as `drift` ("newer than this CLI supports"). That is the designed behaviour of the version field rather than a regression, and the fix is the upgrade the message already suggests.

## Tests

`tests/cli/utils/copied-assets.test.ts` covers all four states plus the two no-record shapes (record stripped, and no lockfile at all), that untracked never fails a build, and that the check reaches `runDoctor`. `tests/cli/utils/lockfile.test.ts` covers the v2→v3 migration, hash preservation across `updateLockfileConfig`, and that `recordAssetHash` creates no file.

947 tests pass; `biome check` and `tsc --noEmit` clean.