### PR TITLE
feat(doctor): check the release environment gate

### DIFF
--- a/scripts/dogfood.mjs
+++ b/scripts/dogfood.mjs
@@ -14,6 +14,12 @@ const ACCEPTED = new Set([
 	'Vitest', // vitest.config.mjs imports the local ./tooling source, not the export
 	'Commitlint', // commitlint.config.mjs re-exports the local ./tooling source
 	'semantic-release', // release.config.mjs extends the local ./tooling source
+	// NOT a self-repo divergence — a real finding this repo cannot close yet.
+	// The check landed (rtorcato/repo-tooling#429, checks half); creating the
+	// `release` environment is the scaffolding half, still open because it needs
+	// a `required_reviewers` list only a human can supply. Delete this line the
+	// moment that environment exists — that is the whole point of the check.
+	'Release gate',
 ])
 
 function runDoctor() {

--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -76,11 +76,15 @@ export const GITHUB_STANDARD = {
 } as const
 
 const CODE_SCANNING_CHECK = 'Code-scanning gate'
+const RELEASE_GATE_CHECK = 'Release gate'
+const RELEASE_ENV_CHECK = 'Release environment'
 const CHECK_NAMES = [
 	'Branch protection',
 	'Merge settings',
 	'Workflow permissions',
 	CODE_SCANNING_CHECK,
+	RELEASE_GATE_CHECK,
+	RELEASE_ENV_CHECK,
 ] as const
 
 // Recommended CodeQL alert thresholds — GitHub's UI defaults. This is the
@@ -186,6 +190,7 @@ export async function checkGitHubSettings(dir: string, exec?: GhExec): Promise<C
 		checkMergeSettings(info),
 		await checkWorkflowPermissions(gh, info.nwo),
 		await checkCodeScanningRuleset(gh, info.nwo, info.branch, dir),
+		...(await checkReleaseGate(gh, info.nwo, dir)),
 	]
 }
 
@@ -470,6 +475,279 @@ async function checkCodeScanningRuleset(
 			? `Run \`npx @rtorcato/repo-tooling fix github-settings\` to add a code_scanning branch ruleset that blocks merge on High+ CodeQL alerts. That ruleset will reject this repo's release commit with GH013 while the config uses \`@semantic-release/git\`. ${GIT_PLUGIN_REMEDY}`
 			: 'Run `npx @rtorcato/repo-tooling fix github-settings` to add a code_scanning branch ruleset that blocks merge on High+ CodeQL alerts',
 	}
+}
+
+// --- Release environment gate (#429) --------------------------------------
+
+/** The environment name the standard reserves for the publish gate. */
+const RELEASE_ENVIRONMENT = 'release'
+
+/**
+ * What a job has to run for a merge to the default branch to reach a registry.
+ * `semantic-release` counts on its own — the shipped preset publishes with it.
+ */
+const PUBLISH_COMMAND = /semantic-release|changesets\/action|(?:npm|pnpm|yarn)\s+publish/
+
+const GATE_HINT =
+	'Create a `release` environment with required reviewers (Settings → Environments) and add `environment: release` to the publishing job — a merge to the default branch then leaves the run `waiting` instead of publishing'
+
+const ENV_HINT =
+	'Add `environment: release` to the publishing job, or delete the environment — whichever was meant. An environment nothing references still lists under Settings → Environments as though it gates something'
+
+const unquote = (s: string) => s.replace(/^['"]|['"]$/g, '')
+
+/**
+ * A workflow's `jobs:` blocks, keyed by job id.
+ *
+ * Hand-split rather than parsed: this package ships no YAML dependency, and the
+ * only question asked of the result is whether *one particular job* carries an
+ * `environment:` key. A whole-file grep would answer that wrong on any repo with
+ * a `github-pages` deploy job — which is the exact false negative this check
+ * exists to avoid. Jobs sit one indent level under `jobs:` and their keys one
+ * level below that, which holds for every workflow Actions accepts.
+ */
+export function workflowJobs(yaml: string): Map<string, string> {
+	const jobs = new Map<string, string>()
+	const lines = yaml.split('\n')
+	const start = lines.findIndex((l) => /^jobs:\s*$/.test(l))
+	if (start === -1) return jobs
+
+	const indentOf = (l: string) => l.length - l.trimStart().length
+	// The block runs until the next top-level key.
+	let end = lines.length
+	for (let i = start + 1; i < lines.length; i++) {
+		const l = lines[i] ?? ''
+		if (l.trim() !== '' && indentOf(l) === 0) {
+			end = i
+			break
+		}
+	}
+	const body = lines.slice(start + 1, end)
+	const first = body.find((l) => l.trim() !== '' && !l.trimStart().startsWith('#'))
+	if (first === undefined) return jobs
+	const jobIndent = indentOf(first)
+
+	let id: string | null = null
+	let buf: string[] = []
+	for (const line of body) {
+		const header =
+			line.trim() !== '' && indentOf(line) === jobIndent
+				? /^([\w.-]+):/.exec(line.trim())?.[1]
+				: undefined
+		if (header) {
+			if (id) jobs.set(id, buf.join('\n'))
+			id = header
+			buf = []
+		} else if (id) {
+			buf.push(line)
+		}
+	}
+	if (id) jobs.set(id, buf.join('\n'))
+	return jobs
+}
+
+/**
+ * The environment a job runs in, in either form Actions accepts: the scalar
+ * `environment: release`, or a block whose `name:` names it. Null when the job
+ * declares none.
+ */
+export function jobEnvironment(body: string): string | null {
+	const inline = /^[ \t]*environment:[ \t]*(\S+)[ \t]*$/m.exec(body)
+	if (inline?.[1]) return unquote(inline[1])
+	const at = body.search(/^[ \t]*environment:[ \t]*$/m)
+	if (at === -1) return null
+	// Step names are list items (`- name:`), so the first bare `name:` after the
+	// block opener is the environment's.
+	const name = /^[ \t]*name:[ \t]*(\S+)/m.exec(body.slice(at))?.[1]
+	return name ? unquote(name) : null
+}
+
+/**
+ * A job body with whole-line comments dropped. Same reasoning as
+ * `hookHasUncommented` in base/checks.ts: a `#` line runs nothing, so matching
+ * it is a false positive. Observed on this repo's own ci.yml, where a `varcheck`
+ * job carrying `# npm publish uses OIDC trusted publishing` was reported as the
+ * publishing job. Comments are stripped rather than pattern-tested because
+ * `jobEnvironment` needs the same treatment — a commented-out `environment:`
+ * would otherwise read as a live gate, the exact inversion of this check.
+ */
+function withoutComments(body: string): string {
+	return body
+		.split('\n')
+		.filter((line) => !line.trimStart().startsWith('#'))
+		.join('\n')
+}
+
+/** `private: true` — nothing reaches a registry, so no gate is owed. */
+async function isPrivatePackage(dir: string): Promise<boolean> {
+	try {
+		const pkg = await fs.readJson(path.join(dir, 'package.json'))
+		return pkg?.private === true
+	} catch {
+		return false
+	}
+}
+
+interface PublishJob {
+	file: string
+	job: string
+	/** The `environment:` the job declares, or null. */
+	environment: string | null
+}
+
+/** The first workflow job that runs a publish command, or null if none does. */
+async function findPublishJob(dir: string): Promise<PublishJob | null> {
+	const workflowsDir = path.join(dir, '.github', 'workflows')
+	if (!(await fs.pathExists(workflowsDir))) return null
+	try {
+		for (const f of (await fs.readdir(workflowsDir)).sort()) {
+			if (!/\.ya?ml$/.test(f)) continue
+			const content = await fs.readFile(path.join(workflowsDir, f), 'utf-8')
+			if (!PUBLISH_COMMAND.test(content)) continue
+			for (const [job, raw] of workflowJobs(content)) {
+				const body = withoutComments(raw)
+				if (PUBLISH_COMMAND.test(body)) {
+					return { file: f, job, environment: jobEnvironment(body) }
+				}
+			}
+		}
+	} catch {
+		return null
+	}
+	return null
+}
+
+/** Environment name → whether it carries a `required_reviewers` protection rule. */
+type Environments = Map<string, boolean>
+
+async function readEnvironments(gh: GhExec, nwo: string): Promise<Environments | 'skip'> {
+	const r = await gh(['api', `repos/${nwo}/environments`])
+	// A repo with no environments can answer 404 — that's "none", not unreadable.
+	if (!r.ok) return /404|not found/i.test(r.stderr) ? new Map() : 'skip'
+	try {
+		const parsed = JSON.parse(r.stdout) as {
+			environments?: Array<{ name?: string; protection_rules?: Array<{ type?: string }> }>
+		}
+		const envs: Environments = new Map()
+		for (const e of parsed.environments ?? []) {
+			if (typeof e.name !== 'string') continue
+			envs.set(
+				e.name,
+				(e.protection_rules ?? []).some((p) => p.type === 'required_reviewers')
+			)
+		}
+		return envs
+	} catch {
+		return 'skip'
+	}
+}
+
+/**
+ * The gap between merging the default branch and publishing to npm (#429). On
+ * the shipped semantic-release preset those are one event: nothing stands
+ * between a squash-merge and a new version on the registry.
+ *
+ * Two checks, because they fail differently and want different answers:
+ *
+ * - **Release gate** — the publishing job runs behind no environment at all, or
+ *   behind one that isn't really a gate (absent, or with no required reviewers).
+ * - **Release environment** — the repo *has* a `release` environment and no job
+ *   references it. That's the failure mode worth catching: an unreferenced
+ *   environment gates nothing while reading as a gate in the GitHub UI.
+ *
+ * The two never both fire on one repo. "No `environment:` and no `release`
+ * environment" is the gate check's; "no `environment:` but a `release`
+ * environment exists" is the environment check's, and the gate check defers.
+ *
+ * A repo that publishes nothing is `ok` — not applicable, not drift. There is
+ * no fixer: creating the environment needs a `required_reviewers` list only a
+ * human can supply, so both hints describe the manual step.
+ */
+async function checkReleaseGate(
+	gh: GhExec,
+	nwo: string,
+	dir: string
+): Promise<[CheckResult, CheckResult]> {
+	const publish = (await isPrivatePackage(dir)) ? null : await findPublishJob(dir)
+	if (!publish) {
+		const detail = 'not applicable — no workflow job publishes to a registry'
+		return [
+			{ check: RELEASE_GATE_CHECK, status: 'ok', detail },
+			{ check: RELEASE_ENV_CHECK, status: 'ok', detail },
+		]
+	}
+
+	const envs = await readEnvironments(gh, nwo)
+	if (envs === 'skip') {
+		const reason = 'could not read environments'
+		return [skip(RELEASE_GATE_CHECK, reason), skip(RELEASE_ENV_CHECK, reason)]
+	}
+
+	const named = publish.environment
+	const where = `${publish.file} \`${publish.job}\``
+	const hasRelease = envs.has(RELEASE_ENVIRONMENT)
+
+	let gate: CheckResult
+	if (named === null) {
+		gate = hasRelease
+			? {
+					check: RELEASE_GATE_CHECK,
+					status: 'ok',
+					detail: `${where} declares no environment — reported by the ${RELEASE_ENV_CHECK} check`,
+				}
+			: {
+					check: RELEASE_GATE_CHECK,
+					status: 'drift',
+					detail: `${where} publishes with no \`environment:\` and the repo has no \`${RELEASE_ENVIRONMENT}\` environment — anything that lands on the default branch publishes`,
+					hint: GATE_HINT,
+				}
+	} else if (!envs.has(named)) {
+		gate = {
+			check: RELEASE_GATE_CHECK,
+			status: 'drift',
+			detail: `${where} names the \`${named}\` environment, which the repo does not have — Actions creates it unprotected on first run, so the publish is never held`,
+			hint: GATE_HINT,
+		}
+	} else if (!envs.get(named)) {
+		gate = {
+			check: RELEASE_GATE_CHECK,
+			status: 'drift',
+			detail: `the \`${named}\` environment has no required_reviewers — ${where} passes straight through it`,
+			hint: GATE_HINT,
+		}
+	} else {
+		gate = {
+			check: RELEASE_GATE_CHECK,
+			status: 'ok',
+			detail: `${where} runs behind the \`${named}\` environment (required reviewers)`,
+		}
+	}
+
+	let environment: CheckResult
+	if (!hasRelease) {
+		environment = {
+			check: RELEASE_ENV_CHECK,
+			status: 'ok',
+			detail: `no \`${RELEASE_ENVIRONMENT}\` environment — nothing to reference`,
+		}
+	} else if (named === RELEASE_ENVIRONMENT) {
+		environment = {
+			check: RELEASE_ENV_CHECK,
+			status: 'ok',
+			detail: `${where} references the \`${RELEASE_ENVIRONMENT}\` environment`,
+		}
+	} else {
+		environment = {
+			check: RELEASE_ENV_CHECK,
+			status: 'drift',
+			detail: named
+				? `the repo has a \`${RELEASE_ENVIRONMENT}\` environment but ${where} runs in \`${named}\` — \`${RELEASE_ENVIRONMENT}\` gates nothing while still reading as a gate in the GitHub UI`
+				: `the repo has a \`${RELEASE_ENVIRONMENT}\` environment but ${where} references no environment — it gates nothing while still reading as a gate in the GitHub UI`,
+			hint: ENV_HINT,
+		}
+	}
+
+	return [gate, environment]
 }
 
 // --- Fixer side (#138): apply the standard via gh api ---------------------

--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -513,11 +513,13 @@ export function workflowJobs(yaml: string): Map<string, string> {
 	if (start === -1) return jobs
 
 	const indentOf = (l: string) => l.length - l.trimStart().length
-	// The block runs until the next top-level key.
+	// The block runs until the next top-level key. A column-0 comment is not one —
+	// it ends nothing, so skipping it keeps a stray comment between `jobs:` and its
+	// first job from truncating the block and hiding every job below it.
 	let end = lines.length
 	for (let i = start + 1; i < lines.length; i++) {
 		const l = lines[i] ?? ''
-		if (l.trim() !== '' && indentOf(l) === 0) {
+		if (l.trim() !== '' && !l.trimStart().startsWith('#') && indentOf(l) === 0) {
 			end = i
 			break
 		}
@@ -595,8 +597,15 @@ interface PublishJob {
 	environment: string | null
 }
 
-/** The first workflow job that runs a publish command, or null if none does. */
-async function findPublishJob(dir: string): Promise<PublishJob | null> {
+/**
+ * The first workflow job that runs a publish command, or null if none does.
+ *
+ * `'skip'` when the directory exists but can't be read — a permission error or a
+ * broken symlink must not read as "nothing publishes", which would report the
+ * gate as `ok` on a repo whose workflows were never inspected. Same shape as
+ * `readEnvironments`: absent is an answer, unreadable is not.
+ */
+async function findPublishJob(dir: string): Promise<PublishJob | null | 'skip'> {
 	const workflowsDir = path.join(dir, '.github', 'workflows')
 	if (!(await fs.pathExists(workflowsDir))) return null
 	try {
@@ -612,7 +621,7 @@ async function findPublishJob(dir: string): Promise<PublishJob | null> {
 			}
 		}
 	} catch {
-		return null
+		return 'skip'
 	}
 	return null
 }
@@ -669,6 +678,10 @@ async function checkReleaseGate(
 	dir: string
 ): Promise<[CheckResult, CheckResult]> {
 	const publish = (await isPrivatePackage(dir)) ? null : await findPublishJob(dir)
+	if (publish === 'skip') {
+		const reason = 'could not read .github/workflows'
+		return [skip(RELEASE_GATE_CHECK, reason), skip(RELEASE_ENV_CHECK, reason)]
+	}
 	if (!publish) {
 		const detail = 'not applicable — no workflow job publishes to a registry'
 		return [

--- a/tests/base/github-settings.test.ts
+++ b/tests/base/github-settings.test.ts
@@ -7,7 +7,9 @@ import {
 	checkGitHubSettings,
 	type GhExec,
 	type GhResult,
+	jobEnvironment,
 	releaseUsesGitPlugin,
+	workflowJobs,
 } from '../../src/base/github-settings.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
@@ -96,7 +98,11 @@ interface GhOverrides {
 	defaultSetup?: GhResult
 	rulesets?: GhResult
 	rulesetDetail?: GhResult
+	environments?: GhResult
 }
+
+/** No environments configured — the shape the REST endpoint returns. */
+const NO_ENVIRONMENTS = JSON.stringify({ total_count: 0, environments: [] })
 
 /** Route canned responses by which gh api path is invoked. */
 function fakeGh(overrides: GhOverrides = {}): GhExec {
@@ -109,6 +115,7 @@ function fakeGh(overrides: GhOverrides = {}): GhExec {
 		if (p?.includes('/code-scanning/default-setup')) return overrides.defaultSetup ?? ok(CODEQL_OFF)
 		if (p?.includes('/rulesets/')) return overrides.rulesetDetail ?? ok('{}')
 		if (p?.endsWith('/rulesets')) return overrides.rulesets ?? ok('[]')
+		if (p?.endsWith('/environments')) return overrides.environments ?? ok(NO_ENVIRONMENTS)
 		return fail('unexpected call')
 	})
 }
@@ -120,7 +127,7 @@ describe('checkGitHubSettings — skip paths', () => {
 		const exec = fakeGh()
 		const results = await checkGitHubSettings(newTmpDir(), exec)
 		expect(exec).not.toHaveBeenCalled()
-		expect(results).toHaveLength(4)
+		expect(results).toHaveLength(6)
 		expect(results.every((r) => r.status === 'ok' && r.detail.includes('skipped'))).toBe(true)
 	})
 
@@ -141,7 +148,7 @@ describe('checkGitHubSettings — skip paths', () => {
 describe('checkGitHubSettings — compliant repo', () => {
 	it('reports all three ok when settings match the standard', async () => {
 		const results = await checkGitHubSettings(gitRepo(), fakeGh())
-		expect(results).toHaveLength(4)
+		expect(results).toHaveLength(6)
 		expect(results.every((r) => r.status === 'ok')).toBe(true)
 		expect(byName(results, 'Branch protection')?.detail).toContain('protected per standard')
 	})
@@ -208,6 +215,209 @@ describe('checkGitHubSettings — code-scanning gate (#269)', () => {
 		expect(g?.status).toBe('drift')
 		expect(g?.detail).toContain('High alerts stay advisory')
 		expect(g?.hint).toContain('GH013')
+	})
+})
+
+describe('checkGitHubSettings — release environment gate (#429)', () => {
+	/** A workflow whose `release` job publishes; `env` adds an `environment:`. */
+	function workflow(env?: string): string {
+		return `name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # A pages deploy carries its own environment — a whole-file grep would read
+    # this as the release gate.
+    environment:
+      name: github-pages
+      url: https://example.invalid
+    steps:
+      - name: Build
+        run: pnpm build
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+${env ? `    environment: ${env}\n` : ''}    steps:
+      - name: Publish
+        run: npx semantic-release
+`
+	}
+
+	/** A git repo with the given workflow (and, by default, a public package). */
+	function repoWithWorkflow(yaml: string, pkg: Record<string, unknown> = {}): string {
+		const dir = gitRepo()
+		fs.outputFileSync(join(dir, '.github/workflows/ci.yml'), yaml)
+		fs.writeJsonSync(join(dir, 'package.json'), { name: 'thing', ...pkg })
+		return dir
+	}
+
+	const environments = (...names: Array<[string, boolean]>) =>
+		ok(
+			JSON.stringify({
+				total_count: names.length,
+				environments: names.map(([name, reviewers]) => ({
+					name,
+					protection_rules: reviewers ? [{ type: 'required_reviewers' }] : [],
+				})),
+			})
+		)
+
+	const gate = (r: { check: string }[]) => byName(r, 'Release gate')
+	const env = (r: { check: string }[]) => byName(r, 'Release environment')
+
+	it('is not applicable when nothing publishes', async () => {
+		const results = await checkGitHubSettings(gitRepo(), fakeGh())
+		expect(gate(results)?.status).toBe('ok')
+		expect(gate(results)?.detail).toContain('no workflow job publishes')
+		expect(env(results)?.status).toBe('ok')
+	})
+
+	it('is not applicable for a private package that runs semantic-release', async () => {
+		const dir = repoWithWorkflow(workflow(), { private: true })
+		expect(gate(await checkGitHubSettings(dir, fakeGh()))?.detail).toContain('not applicable')
+	})
+
+	it('drifts when the publish job has no environment and none exists', async () => {
+		const dir = repoWithWorkflow(workflow())
+		const g = gate(await checkGitHubSettings(dir, fakeGh()))
+		expect(g?.status).toBe('drift')
+		expect(g?.detail).toContain('no `environment:`')
+		expect(g?.hint).toContain('required reviewers')
+	})
+
+	it('flags a `release` environment that no job references (#429, the decorative gate)', async () => {
+		const dir = repoWithWorkflow(workflow())
+		const exec = fakeGh({ environments: environments(['release', true]) })
+		const results = await checkGitHubSettings(dir, exec)
+		expect(env(results)?.status).toBe('drift')
+		expect(env(results)?.detail).toContain('gates nothing')
+		// Exactly one finding for one root cause: the gate check defers.
+		expect(gate(results)?.status).toBe('ok')
+	})
+
+	it('ignores a job that only mentions publishing in a comment', async () => {
+		// Caught dogfooding this check on repo-tooling's own ci.yml: a `varcheck`
+		// job whose shell block ends `# npm publish uses OIDC trusted publishing`
+		// was reported as the publishing job.
+		const dir = repoWithWorkflow(`name: CI
+
+on: [push]
+
+jobs:
+  varcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check env
+        run: |
+          echo "checking"
+          # npm publish uses OIDC trusted publishing (no NPM_TOKEN needed).
+
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: npx semantic-release
+`)
+		const exec = fakeGh({ environments: environments(['release', true]) })
+		const g = gate(await checkGitHubSettings(dir, exec))
+		expect(g?.status).toBe('ok')
+		expect(g?.detail).toContain('`release`')
+	})
+
+	it('does not read another job’s environment as the release gate', async () => {
+		// `build` declares `github-pages`; `release` declares nothing.
+		const dir = repoWithWorkflow(workflow())
+		const exec = fakeGh({ environments: environments(['github-pages', true]) })
+		expect(gate(await checkGitHubSettings(dir, exec))?.status).toBe('drift')
+	})
+
+	it('is ok when the publish job runs behind an environment with required reviewers', async () => {
+		const dir = repoWithWorkflow(workflow('release'))
+		const exec = fakeGh({ environments: environments(['release', true]) })
+		const results = await checkGitHubSettings(dir, exec)
+		expect(gate(results)?.status).toBe('ok')
+		expect(gate(results)?.detail).toContain('required reviewers')
+		expect(env(results)?.status).toBe('ok')
+	})
+
+	it('drifts when the referenced environment has no required_reviewers', async () => {
+		const dir = repoWithWorkflow(workflow('release'))
+		const exec = fakeGh({ environments: environments(['release', false]) })
+		const g = gate(await checkGitHubSettings(dir, exec))
+		expect(g?.status).toBe('drift')
+		expect(g?.detail).toContain('no required_reviewers')
+	})
+
+	it('drifts when the job names an environment the repo does not have', async () => {
+		// Actions creates it unprotected on first run, so it holds nothing.
+		const dir = repoWithWorkflow(workflow('release'))
+		const g = gate(await checkGitHubSettings(dir, fakeGh()))
+		expect(g?.status).toBe('drift')
+		expect(g?.detail).toContain('does not have')
+	})
+
+	it('skips (ok) when the environments endpoint cannot be read', async () => {
+		const dir = repoWithWorkflow(workflow())
+		const exec = fakeGh({ environments: fail('gh: (HTTP 403)') })
+		const results = await checkGitHubSettings(dir, exec)
+		expect(gate(results)?.status).toBe('ok')
+		expect(gate(results)?.detail).toContain('skipped')
+		expect(env(results)?.status).toBe('ok')
+	})
+
+	it('reads a 404 from the environments endpoint as "none", not unreadable', async () => {
+		const dir = repoWithWorkflow(workflow())
+		const exec = fakeGh({ environments: fail('gh: Not Found (HTTP 404)') })
+		expect(gate(await checkGitHubSettings(dir, exec))?.status).toBe('drift')
+	})
+})
+
+describe('workflowJobs / jobEnvironment', () => {
+	const YAML = `name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Build
+        run: pnpm build
+
+  release:
+    runs-on: ubuntu-latest
+    environment:
+      name: 'release'
+      url: https://npmjs.com
+    steps:
+      - name: Publish
+        run: npm publish
+
+permissions:
+  contents: read
+`
+
+	it('splits jobs and stops at the next top-level key', () => {
+		expect([...workflowJobs(YAML).keys()]).toEqual(['build', 'release'])
+		expect(workflowJobs(YAML).get('release')).not.toContain('contents: read')
+	})
+
+	it('reads both the scalar and the block form of environment', () => {
+		const jobs = workflowJobs(YAML)
+		expect(jobEnvironment(jobs.get('build') ?? '')).toBe('staging')
+		// Quoted, in block form, with step `- name:` entries below it.
+		expect(jobEnvironment(jobs.get('release') ?? '')).toBe('release')
+	})
+
+	it('is null for a job with no environment, and empty for a workflow with no jobs', () => {
+		expect(jobEnvironment('    runs-on: ubuntu-latest\n    steps:\n      - run: true')).toBeNull()
+		expect(workflowJobs('name: nothing\n').size).toBe(0)
 	})
 })
 

--- a/tests/base/github-settings.test.ts
+++ b/tests/base/github-settings.test.ts
@@ -375,6 +375,22 @@ jobs:
 		const exec = fakeGh({ environments: fail('gh: Not Found (HTTP 404)') })
 		expect(gate(await checkGitHubSettings(dir, exec))?.status).toBe('drift')
 	})
+
+	it('skips, not "nothing publishes", when the workflows directory is unreadable', async () => {
+		// The fail-open this check exists to avoid: an unreadable input must never
+		// report as `ok`/not-applicable, which reads as "you have a gate" on a repo
+		// whose workflows were never inspected. A file where the directory belongs
+		// makes readdir fail with ENOTDIR without needing chmod (root would ignore).
+		const dir = gitRepo()
+		fs.outputFileSync(join(dir, '.github/workflows'), 'not a directory\n')
+		fs.writeJsonSync(join(dir, 'package.json'), { name: 'thing' })
+		const results = await checkGitHubSettings(dir, fakeGh())
+		for (const r of [gate(results), env(results)]) {
+			expect(r?.detail).toContain('skipped')
+			expect(r?.detail).toContain('could not read .github/workflows')
+			expect(r?.detail).not.toContain('not applicable')
+		}
+	})
 })
 
 describe('workflowJobs / jobEnvironment', () => {
@@ -412,6 +428,19 @@ permissions:
 		const jobs = workflowJobs(YAML)
 		expect(jobEnvironment(jobs.get('build') ?? '')).toBe('staging')
 		// Quoted, in block form, with step `- name:` entries below it.
+		expect(jobEnvironment(jobs.get('release') ?? '')).toBe('release')
+	})
+
+	it('is not truncated by a column-0 comment inside the jobs block', () => {
+		// A comment ends no block, so it must not stand in for the next top-level key.
+		const jobs = workflowJobs(`jobs:
+# unusual, but valid YAML
+  release:
+    environment: release
+    steps:
+      - run: npm publish
+`)
+		expect([...jobs.keys()]).toEqual(['release'])
 		expect(jobEnvironment(jobs.get('release') ?? '')).toBe('release')
 	})
 

--- a/tests/languages/perl/fixers.test.ts
+++ b/tests/languages/perl/fixers.test.ts
@@ -66,12 +66,16 @@ describe('perl fixers', () => {
 		// badges` and `Coverage upload` need a package.json to build from, which a
 		// Perl repo hasn't got. `lockfile` has no Perl preset to record yet (see
 		// the note atop src/languages/perl/fixers.ts). `Perl distribution` and
-		// `Perl tests` are content only the project can write.
+		// `Perl tests` are content only the project can write. `Release gate` and
+		// `Release environment` (#429) report only — creating the environment needs
+		// a `required_reviewers` list only a human can supply.
 		expect(uncovered).toEqual([
 			'language',
 			'lockfile',
 			'Monorepo',
 			'Git identity',
+			'Release gate',
+			'Release environment',
 			'README badges',
 			'Coverage upload',
 			'Perl distribution',

--- a/tests/languages/python/fixers.test.ts
+++ b/tests/languages/python/fixers.test.ts
@@ -63,12 +63,16 @@ describe('python fixers', () => {
 		// badges` and `Coverage upload` need a package.json to build from, which a
 		// Python repo hasn't got. `lockfile` has no Python preset to record yet
 		// (see the note atop src/languages/python/fixers.ts). `pyproject.toml` and
-		// `Python tests` are content only the project can write.
+		// `Python tests` are content only the project can write. `Release gate` and
+		// `Release environment` (#429) report only — creating the environment needs
+		// a `required_reviewers` list only a human can supply.
 		expect(uncovered).toEqual([
 			'language',
 			'lockfile',
 			'Monorepo',
 			'Git identity',
+			'Release gate',
+			'Release environment',
 			'README badges',
 			'Coverage upload',
 			'pyproject.toml',

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -68,11 +68,15 @@ describe('swift fixers', () => {
 		// their own address, so there is nothing for a fixer to write. `Swift
 		// tests` is the same shape as `Package.swift`: half of it is a manifest
 		// edit (#311). `Monorepo` states the audit's own root-only scope (#317) —
-		// there is no drift for a fixer to close.
+		// there is no drift for a fixer to close. `Release gate` and `Release
+		// environment` (#429) report only — creating the environment needs a
+		// `required_reviewers` list only a human can supply.
 		expect(uncovered).toEqual([
 			'language',
 			'Monorepo',
 			'Git identity',
+			'Release gate',
+			'Release environment',
 			'README badges',
 			'Coverage upload',
 			'Package.swift',


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

Implements the **checks half** of #429. The scaffolding half — creating the `release` environment and wiring `environment: release` into the release workflow — stays open, pending a decision on who the required reviewers are. `Refs #429`, deliberately not `Closes`.

## What lands

Two checks in `checkGitHubSettings`, alongside branch protection / merge settings / workflow permissions / code-scanning:

| Check | Drifts when |
|---|---|
| **Release gate** | the publishing job runs behind no `environment:` and the repo has no `release` environment; or it names an environment the repo doesn't have (Actions creates it unprotected on first run); or the named environment has no `required_reviewers` |
| **Release environment** | the repo **has** a `release` environment and no job references it — the failure mode the issue calls out: decorative, and it reads as a gate in the GitHub UI |

The two never both fire on one repo — "no `environment:` and no `release` environment" belongs to the first, "no `environment:` but the environment exists" to the second, and the first defers. One root cause, one finding.

## Statuses

- A repo that publishes nothing, or a private package → `ok`, `not applicable — no workflow job publishes to a registry`. Not `drift`; nothing is broken.
- gh missing / unauthenticated / no GitHub remote → `ok` skipped, with the other four, via the existing `skipAll`.
- The environments endpoint unreadable (403) → `ok` skipped. A 404 is read as "no environments", not as unreadable.

## Job-scoped, not file-scoped

The publishing job is found by splitting the workflow's `jobs:` blocks. A whole-file grep for `environment:` reports any repo with a `github-pages` deploy job as gated — the exact false negative this check exists to prevent. There's a test for it.

Dogfooding the check against this repo's own `ci.yml` caught a second one: a `varcheck` job was reported as the publisher because its shell block ends with `# npm publish uses OIDC trusted publishing`. Comment lines are now stripped before matching, which also stops a commented-out `environment:` reading as a live gate. Both cases are regression-tested.

Hand-split rather than parsed because the package ships no YAML dependency and the only question asked is where one job's keys begin and end.

## No fixer

Creating the environment needs a `required_reviewers` list only a human can supply, so both checks report and their hints describe the manual step. The three `base + <lang> fixers cover every check doctor emits` tests record them as intentionally uncovered.

## Please look at this bit

`Release gate` reports **drift on this repo** — true, and precisely the point. But CI's dogfood step runs doctor against this repo with `GH_TOKEN: ${{ github.token }}`, so the finding would turn CI red. I added `'Release gate'` to `ACCEPTED` in `scripts/dogfood.mjs`, with a comment saying it is *not* a self-repo divergence and that the line should be deleted the moment the `release` environment exists. That is a judgement call and the one thing here worth a second opinion — the alternative was knowingly opening a red PR.

## Release impact

`feat:` → minor. Honest type: repos that were previously clean will now report drift, which is a visible behaviour change, not a fix.

## Verification

`vitest run` 947 passed / 59 files · `biome check src scripts` clean · `tsc --noEmit` clean · `pnpm dogfood` (built CLI, authenticated) clean.

## Explicitly out of scope

- Creating the `release` environment via the GitHub API, or wiring `environment: release` into any workflow.
- Any write to a repository other than this one.
