### PR TITLE
chore(claude): raise the ai-issue-loop in-flight cap to 6

### DIFF
--- a/apps/docs/docs/guides/ai-issue-loop.md
+++ b/apps/docs/docs/guides/ai-issue-loop.md
@@ -162,7 +162,7 @@ Two details worth knowing because they fail *silently* when got wrong:
 
 These exist because the loop runs unattended against a monthly usage cap.
 
-- **4 issues in flight**, counted from open `ai-wip` issues.
+- **6 issues in flight**, counted from open `ai-wip` issues.
 - **Reviewers see the diff only** — `gh pr view`, `gh pr diff`, the issue body.
   No repo-wide exploration.
 - **2 fix rounds per PR.** On the third `ai-changes`, stop and mark

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -126,7 +126,7 @@ done, but open the comments first.
 
 These exist because the loop runs unattended against a monthly usage cap.
 
-- **4 issues in flight**, counted from open issues labelled `ai-wip`.
+- **6 issues in flight**, counted from open issues labelled `ai-wip`.
 - **Reviewers see the diff only** — `gh pr view` + `gh pr diff` + the issue body.
   No repo-wide exploration, no Explore agents.
 - **2 fix rounds per PR.** On the 3rd `ai-changes`, stop and mark `ai-blocked`.
@@ -367,7 +367,7 @@ concurrency slots, so it must run before Pass 4.
 
 **Then reap the stalled.** Nothing can time out an agent: the Agent tool takes no
 timeout, and an agent whose session died leaves its labels behind with no process
-to finish them. Four of those and the loop is permanently full while looking
+to finish them. Six of those and the loop is permanently full while looking
 merely busy. So instead of a timeout, check how long a label has sat without its
 expected transition — GitHub timestamps every application, so this needs no state
 of our own:
@@ -433,9 +433,9 @@ from "nobody has started" — and a 15-minute tick is comfortably shorter than a
 review. A tick landing in that gap spawns a duplicate of every reviewer in flight:
 two agents read the same diff and post two review comments under the owner's
 avatar, and the verdicts race, one applying `ai-ok-code` while the other applies
-`ai-changes` and leaves the PR contradictory for Pass 1 to interpret. On a 4-PR
-queue that is 8 duplicated reviewers against the monthly cap the limits section
-exists to protect.
+`ai-changes` and leaves the PR contradictory for Pass 1 to interpret. On a full
+queue that is a dozen duplicated reviewers against the monthly cap the limits
+section exists to protect.
 
 Two labels rather than one, because the reviewers are spawned independently and a
 single flag could not say *which* was already running. The reviewer clears its own
@@ -638,7 +638,7 @@ Otherwise spawn one background implementer agent:
 ### Pass 4 — pick up
 
 ```bash
-slots = 4 - (open issues labelled ai-wip)
+slots = 6 - (open issues labelled ai-wip)
 ```
 
 If `slots <= 0`, skip this pass.


### PR DESCRIPTION
🤖 *Authored by Claude (AI agent) on rtorcato's behalf.*

## Summary

Syncs the shipped skill's in-flight cap to 6, matching the operator's configured value. Four places, because the number appears as prose, as arithmetic, and as a rationale:

- `skills/ai-issue-loop/SKILL.md:129` — the limits list
- `skills/ai-issue-loop/SKILL.md:370` — Pass 2's stall-reaping rationale, which counts to the cap ("N of those and the loop is permanently full"). Leaving it at four would have contradicted the new limit.
- `skills/ai-issue-loop/SKILL.md:641` — Pass 4's `slots` arithmetic, the only line that actually changes behaviour
- `apps/docs/docs/guides/ai-issue-loop.md:165` — the mirrored limits list in the published guide

Also replaces Pass 3's "on a 4-PR queue that is 8 duplicated reviewers" with a cap-independent phrasing, so it does not go stale again the next time this moves.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / tooling

## Test plan

- [x] Pre-commit passed
- [x] `grep` confirms no remaining references to the old cap in either file

## Notes

`chore:` — this is published skill content, but the change is a configuration default rather than a behaviour fix, and it cuts no release.