### PR TITLE
feat(doctor): audit ai-issue-loop label colours and descriptions

### DIFF
--- a/apps/docs/docs/guides/ai-issue-loop.md
+++ b/apps/docs/docs/guides/ai-issue-loop.md
@@ -83,6 +83,16 @@ that state, so a missed tick, a crash, or a restart costs nothing.
 | `ai-changes` | PR | A reviewer requested changes. |
 | `ai-notes` | PR | Passed, but a reviewer left something to read before merging. |
 
+Colours carry meaning here — `ai-ready` is green and `ai-blocked` red precisely
+so the two states a maintainer must tell apart are legible at a glance. `doctor`
+audits colour and description as the **`AI loop labels`** check, and `fix labels`
+repairs drift with `gh label edit`. The distinction matters: the skill's
+bootstrap block uses `gh label create`, which errors as a no-op on a label that
+already exists — so it can add a missing label but can never repair a
+hand-created one. A repo with fewer than two of these labels is reported as *not
+applicable* rather than drift: not running the loop is a choice, and neither the
+check nor the fixer pushes labels into a repo that opted out.
+
 ```
 issue: ai-ready ─pickup─> ai-wip ─> PR opened, labelled ai-review
 PR: ai-review ─> ai-reviewing-* ─┬─> ai-ok-code + ai-ok-sec ─┬─ issue PR  ─> assigned to you

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -96,6 +96,19 @@ gh label create ai-changes -c '#d93f0b' -d 'Reviewer requested changes'
 gh label create ai-notes   -c '#fbca04' -d 'Passed, but a reviewer left something to read before merging'
 ```
 
+Bootstrap only. `gh label create` **cannot repair a label that already exists** —
+re-running this block against a hand-created `ai-ready` leaves whatever colour
+the web picker gave it, which is how six repos ended up with `ai-ready` rendering
+identically to `ai-blocked` (rtorcato/repo-tooling#446). To repair drift:
+
+```bash
+npx @rtorcato/repo-tooling doctor --json   # "AI loop labels" reports colour/description drift
+npx @rtorcato/repo-tooling fix labels      # repairs it with `gh label edit`
+```
+
+`src/base/labels.ts` in repo-tooling owns the canonical table and a test asserts
+this block matches it, so the two cannot diverge.
+
 Also once per repo, keep the status file out of git:
 
 ```bash

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -37,6 +37,7 @@ import { detectLanguage } from '../cli/utils/detect-language.js'
 import type { Lockfile } from '../cli/utils/lockfile.js'
 import { resolveLanguageModule } from '../languages/registry.js'
 import { applyGithubSettings } from './github-settings.js'
+import { applyLoopLabels } from './labels.js'
 import { closeCompletedMilestones } from './milestones.js'
 import type { CheckResult } from './types.js'
 
@@ -277,6 +278,20 @@ export const BASE_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			return { filesWritten: await closeCompletedMilestones(targetDir) }
+		},
+	},
+	{
+		target: 'labels',
+		description:
+			'Repair ai-issue-loop label colours and descriptions on GitHub via `gh label edit` (mutates the remote repo, not files). No-ops on a repo that does not use the loop',
+		appliesTo: ['AI loop labels'],
+		outputs: ['GitHub labels (remote, via gh label edit)'],
+		// safe-add for the same reason github-settings is: it exempts this fixer
+		// from the `--diff` shadow-run, which executes run() for a mere preview.
+		riskLevel: 'safe-add',
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await applyLoopLabels(targetDir) }
 		},
 	},
 	{

--- a/src/base/labels.ts
+++ b/src/base/labels.ts
@@ -1,0 +1,234 @@
+import path from 'node:path'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import { type GhExec, realGhExec } from './github-settings.js'
+import type { CheckResult } from './types.js'
+
+/**
+ * `ai-issue-loop` label hygiene (#446). Same class of GitHub-side drift as
+ * github-settings.ts and milestones.ts, on the same `gh` seam.
+ *
+ * The bug this exists for: the skill's bootstrap uses `gh label create`, which
+ * *errors as a no-op* when the label already exists. It can add a missing label
+ * but can never repair an existing one, so a hand-created `ai-ready` keeps
+ * whatever colour the web picker gave it forever. Measured across eight repos,
+ * six had `ai-ready` at `B60205` — byte-identical to `ai-blocked`, so "an agent
+ * should pick this up" and "an agent gave up" rendered the same. Repair here
+ * goes through `gh label edit`, which is the whole point of the fixer.
+ *
+ * This table is the single source of truth for the label set. The bootstrap
+ * block in skills/ai-issue-loop/SKILL.md is asserted against it in
+ * tests/base/labels.test.ts, so the two cannot drift apart.
+ */
+
+const CHECK = 'AI loop labels'
+
+export interface LabelSpec {
+	name: string
+	/** Six hex digits, no leading `#`, lowercase — what `gh` writes. */
+	color: string
+	description: string
+}
+
+export const LOOP_LABELS: readonly LabelSpec[] = [
+	{
+		name: 'holding',
+		color: '5319e7',
+		description: 'Gate/holding issue — human judgement, never auto-picked',
+	},
+	{ name: 'ai-ready', color: '0e8a16', description: 'Eligible for an AI agent to implement' },
+	{ name: 'ai-wip', color: 'fbca04', description: 'Claimed by an agent; worktree exists' },
+	{ name: 'ai-blocked', color: 'b60205', description: 'Agent gave up; needs a human' },
+	{ name: 'ai-review', color: '1d76db', description: 'PR awaiting agent review' },
+	{ name: 'ai-reviewing-code', color: 'c5def5', description: 'code-reviewer claimed and running' },
+	{ name: 'ai-reviewing-sec', color: 'c5def5', description: 'security-expert claimed and running' },
+	{ name: 'ai-ok-code', color: '0e8a16', description: 'code-reviewer passed' },
+	{ name: 'ai-ok-sec', color: '0e8a16', description: 'security-expert passed' },
+	{ name: 'ai-changes', color: 'd93f0b', description: 'Reviewer requested changes' },
+	{
+		name: 'ai-notes',
+		color: 'fbca04',
+		description: 'Passed, but a reviewer left something to read before merging',
+	},
+]
+
+/**
+ * How many of the set have to exist before this repo counts as running the
+ * loop. A repo with none has opted out, not drifted — creating eleven labels it
+ * will never use is the nag this threshold exists to prevent. One alone is the
+ * observed half-state (`cf-common` has only `ai-ready`, applied by hand), which
+ * is likewise not evidence the pipeline runs there.
+ */
+const IN_USE_THRESHOLD = 2
+
+interface GhLabel {
+	name: string
+	color: string
+	description: string
+}
+
+const skip = (reason: string): CheckResult => ({
+	check: CHECK,
+	status: 'ok',
+	detail: `skipped — ${reason}`,
+})
+
+/**
+ * Case-insensitive, `#`-insensitive. The drift that started this was uppercase
+ * `B60205` against lowercase `b60205` — GitHub's colour picker writes uppercase,
+ * `gh` writes lowercase, and the two render identically. Comparing raw would
+ * report every hand-created label as drift forever and have the fixer PATCH a
+ * colour that was already correct.
+ */
+const normalizeColor = (c: string) => c.trim().replace(/^#/, '').toLowerCase()
+
+async function readLabels(gh: GhExec): Promise<Map<string, GhLabel> | null> {
+	const r = await gh(['label', 'list', '--json', 'name,color,description', '--limit', '200'])
+	if (!r.ok) return null
+	try {
+		const parsed = JSON.parse(r.stdout)
+		if (!Array.isArray(parsed)) return null
+		const byName = new Map<string, GhLabel>()
+		for (const l of parsed) {
+			if (typeof l?.name !== 'string') continue
+			byName.set(l.name, {
+				name: l.name,
+				color: typeof l.color === 'string' ? l.color : '',
+				description: typeof l.description === 'string' ? l.description : '',
+			})
+		}
+		return byName
+	} catch {
+		return null
+	}
+}
+
+interface LabelDeltas {
+	present: LabelSpec[]
+	missing: LabelSpec[]
+	wrongColor: Array<{ spec: LabelSpec; actual: string }>
+	wrongDescription: LabelSpec[]
+}
+
+export function classifyLabels(existing: Map<string, GhLabel>): LabelDeltas {
+	const deltas: LabelDeltas = { present: [], missing: [], wrongColor: [], wrongDescription: [] }
+	for (const spec of LOOP_LABELS) {
+		const actual = existing.get(spec.name)
+		if (!actual) {
+			deltas.missing.push(spec)
+			continue
+		}
+		deltas.present.push(spec)
+		if (normalizeColor(actual.color) !== normalizeColor(spec.color))
+			deltas.wrongColor.push({ spec, actual: normalizeColor(actual.color) })
+		if (actual.description.trim() !== spec.description) deltas.wrongDescription.push(spec)
+	}
+	return deltas
+}
+
+const names = (specs: LabelSpec[]) => specs.map((s) => `\`${s.name}\``).join(', ')
+
+export async function checkLoopLabels(dir: string, exec?: GhExec): Promise<CheckResult> {
+	// Cheap gate first: no .git → never spawn (keeps tmp-dir doctor runs offline).
+	if (!(await fs.pathExists(path.join(dir, '.git')))) return skip('not a git repository')
+	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin, dir))
+	const existing = await readLabels(gh)
+	if (!existing) return skip('could not read labels')
+
+	const { present, missing, wrongColor, wrongDescription } = classifyLabels(existing)
+	if (present.length < IN_USE_THRESHOLD)
+		return {
+			check: CHECK,
+			status: 'ok',
+			detail: 'not applicable — repo does not use the ai-issue-loop labels',
+		}
+
+	const deltas: string[] = []
+	for (const { spec, actual } of wrongColor)
+		deltas.push(`\`${spec.name}\` is #${actual}, should be #${spec.color}`)
+	if (wrongDescription.length) deltas.push(`wrong description: ${names(wrongDescription)}`)
+	if (missing.length) deltas.push(`missing: ${names(missing)}`)
+
+	if (deltas.length)
+		return {
+			check: CHECK,
+			status: 'drift',
+			detail: deltas.join('; '),
+			hint: 'Run `npx @rtorcato/repo-tooling fix labels` to repair them with `gh label edit` — `gh label create` cannot change an existing label, which is how this drifted',
+		}
+	return {
+		check: CHECK,
+		status: 'ok',
+		detail: `${present.length} ai-issue-loop label(s) match spec`,
+	}
+}
+
+/**
+ * Repairs colour and description with `gh label edit`, and creates the labels
+ * the set is missing. Only on a repo already running the loop (the same
+ * `IN_USE_THRESHOLD` gate the check uses) — otherwise a plain `fix --yes` would
+ * push eleven labels into every repo it touches.
+ *
+ * Idempotent: an aligned repo is a no-op, and a label whose only difference is
+ * the hex case is not touched at all.
+ *
+ * Advisories go to `console.error`; stdout carries the `--json` payload (#357).
+ */
+export async function applyLoopLabels(dir: string, exec?: GhExec): Promise<string[]> {
+	if (!(await fs.pathExists(path.join(dir, '.git')))) {
+		console.error(chalk.gray('   skipped — not a git repository'))
+		return []
+	}
+	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin, dir))
+	const existing = await readLabels(gh)
+	if (!existing) {
+		console.error(chalk.gray('   skipped — could not read labels'))
+		return []
+	}
+
+	const { present, missing, wrongColor, wrongDescription } = classifyLabels(existing)
+	if (present.length < IN_USE_THRESHOLD) {
+		console.error(chalk.gray('   skipped — repo does not use the ai-issue-loop labels'))
+		return []
+	}
+
+	// One edit per drifted label, whichever field drifted — the API takes both.
+	const toEdit = new Set([...wrongColor.map((w) => w.spec), ...wrongDescription])
+	const applied: string[] = []
+	for (const spec of toEdit) {
+		// `edit`, not `create`: create errors as a no-op on an existing label, so a
+		// fixer built on it would silently repair nothing (#446).
+		const r = await gh([
+			'label',
+			'edit',
+			spec.name,
+			'--color',
+			spec.color,
+			'--description',
+			spec.description,
+		])
+		if (r.ok) applied.push(`repaired label "${spec.name}"`)
+		else
+			console.error(
+				chalk.yellow(`   could not repair "${spec.name}": ${r.stderr.trim() || 'gh error'}`)
+			)
+	}
+	for (const spec of missing) {
+		const r = await gh([
+			'label',
+			'create',
+			spec.name,
+			'--color',
+			spec.color,
+			'--description',
+			spec.description,
+		])
+		if (r.ok) applied.push(`created label "${spec.name}"`)
+		else
+			console.error(
+				chalk.yellow(`   could not create "${spec.name}": ${r.stderr.trim() || 'gh error'}`)
+			)
+	}
+	if (applied.length === 0) console.error(chalk.gray('   labels already match spec'))
+	return applied
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -13,6 +13,7 @@ import { SWIFT_GIT_HOOKS, runSwiftChecks } from '../../languages/swift/checks.js
 import { readSwiftPackage, renderSwiftWorkflow } from '../../languages/swift/ci.js'
 import { type DetectedLanguage, detectLanguage } from '../utils/detect-language.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
+import { checkLoopLabels } from '../../base/labels.js'
 import { checkMilestones } from '../../base/milestones.js'
 import { checkGitIdentity } from '../../base/git-identity.js'
 import { checkCopiedAssets } from '../utils/copied-assets.js'
@@ -253,6 +254,8 @@ async function runBaseChecks(
 	results.push(...(await checkGitHubSettings(dir)))
 	// Milestone hygiene (#397) — same seam, same self-skip.
 	results.push(await checkMilestones(dir))
+	// ai-issue-loop label colours/descriptions (#446) — same seam, same self-skip.
+	results.push(await checkLoopLabels(dir))
 	results.push(await checkGitLabCI(dir))
 	results.push(await checkCodeowners(dir))
 	results.push(await checkCommunityHealth(dir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -32,6 +32,7 @@ export const FIX_TARGETS: Record<string, string> = {
 	'Workflow permissions': 'github-settings',
 	'Code-scanning gate': 'github-settings',
 	Milestones: 'milestones',
+	'AI loop labels': 'labels',
 	CODEOWNERS: 'codeowners',
 	'GitLab CI': 'gitlab-ci',
 	Turborepo: 'turborepo',

--- a/tests/base/labels.test.ts
+++ b/tests/base/labels.test.ts
@@ -1,0 +1,182 @@
+import { readFileSync } from 'node:fs'
+import path, { join } from 'node:path'
+import fs from 'fs-extra'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GhExec, GhResult } from '../../src/base/github-settings.js'
+import { applyLoopLabels, checkLoopLabels, LOOP_LABELS } from '../../src/base/labels.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+function gitRepo(): string {
+	const dir = newTmpDir()
+	fs.ensureDirSync(join(dir, '.git'))
+	return dir
+}
+
+const ok = (stdout: string): GhResult => ({ ok: true, stdout, stderr: '', code: 0 })
+
+const spec = (name: string) => {
+	const found = LOOP_LABELS.find((l) => l.name === name)
+	if (!found) throw new Error(`no spec for ${name}`)
+	return found
+}
+
+/** A label exactly as the spec wants it, with optional overrides. */
+const label = (name: string, over: Partial<Record<string, unknown>> = {}) => ({
+	...spec(name),
+	...over,
+})
+
+/** Serves `gh label list`; edits/creates succeed unless `write` says otherwise. */
+function fakeGh(labels: unknown[], write?: GhResult): GhExec {
+	return vi.fn(async (args: string[]) => {
+		if (args[1] === 'list') return ok(JSON.stringify(labels))
+		if (args[1] === 'edit' || args[1] === 'create') return write ?? ok('')
+		return { ok: false, stdout: '', stderr: `unexpected ${args.join(' ')}`, code: 1 }
+	})
+}
+
+/** Every label at spec — the baseline a drift case deviates from. */
+const allCorrect = () => LOOP_LABELS.map((l) => ({ ...l }))
+
+describe('checkLoopLabels', () => {
+	it('never spawns gh outside a git repo', async () => {
+		const exec = fakeGh([])
+		expect((await checkLoopLabels(newTmpDir(), exec)).detail).toContain('not a git repository')
+		expect(exec).not.toHaveBeenCalled()
+	})
+
+	it('is not applicable on a repo with none of the labels — that is opting out', async () => {
+		const r = await checkLoopLabels(gitRepo(), fakeGh([{ name: 'bug', color: 'd73a4a' }]))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('not applicable')
+	})
+
+	it('is still not applicable with a single stray label', async () => {
+		const r = await checkLoopLabels(gitRepo(), fakeGh([label('ai-ready')]))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('not applicable')
+	})
+
+	it('is ok when every label matches spec', async () => {
+		const r = await checkLoopLabels(gitRepo(), fakeGh(allCorrect()))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('match spec')
+	})
+
+	it('treats an uppercase hex as a match, not drift', async () => {
+		const labels = allCorrect().map((l) => ({ ...l, color: l.color.toUpperCase() }))
+		expect((await checkLoopLabels(gitRepo(), fakeGh(labels))).status).toBe('ok')
+	})
+
+	it('ignores a leading # on the reported colour', async () => {
+		const labels = allCorrect().map((l) => ({ ...l, color: `#${l.color}` }))
+		expect((await checkLoopLabels(gitRepo(), fakeGh(labels))).status).toBe('ok')
+	})
+
+	it('flags the #446 drift: ai-ready wearing ai-blocked’s red', async () => {
+		const labels = allCorrect().map((l) => (l.name === 'ai-ready' ? { ...l, color: 'B60205' } : l))
+		const r = await checkLoopLabels(gitRepo(), fakeGh(labels))
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('`ai-ready` is #b60205, should be #0e8a16')
+	})
+
+	it('flags a drifted description', async () => {
+		const labels = allCorrect().map((l) =>
+			l.name === 'ai-ready' ? { ...l, description: 'Approved for AI-agent execution' } : l
+		)
+		const r = await checkLoopLabels(gitRepo(), fakeGh(labels))
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('wrong description')
+	})
+
+	it('flags a missing label once the repo is clearly running the loop', async () => {
+		const labels = allCorrect().filter((l) => l.name !== 'ai-notes')
+		const r = await checkLoopLabels(gitRepo(), fakeGh(labels))
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('missing: `ai-notes`')
+	})
+
+	it('self-skips when the label read fails', async () => {
+		const exec: GhExec = async () => ({ ok: false, stdout: '', stderr: 'gh error', code: 1 })
+		const r = await checkLoopLabels(gitRepo(), exec)
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('could not read labels')
+	})
+})
+
+describe('applyLoopLabels', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+	})
+
+	it('repairs with `gh label edit`, never `create` — create no-ops on an existing label', async () => {
+		const labels = allCorrect().map((l) => (l.name === 'ai-ready' ? { ...l, color: 'B60205' } : l))
+		const exec = fakeGh(labels)
+		expect(await applyLoopLabels(gitRepo(), exec)).toEqual(['repaired label "ai-ready"'])
+		expect(exec).toHaveBeenCalledWith([
+			'label',
+			'edit',
+			'ai-ready',
+			'--color',
+			'0e8a16',
+			'--description',
+			'Eligible for an AI agent to implement',
+		])
+		const wrote = vi.mocked(exec).mock.calls.filter((c) => c[0][1] === 'create')
+		expect(wrote).toEqual([])
+	})
+
+	it('does not touch a label whose only difference is hex case', async () => {
+		const labels = allCorrect().map((l) => ({ ...l, color: l.color.toUpperCase() }))
+		const exec = fakeGh(labels)
+		expect(await applyLoopLabels(gitRepo(), exec)).toEqual([])
+		expect(vi.mocked(exec).mock.calls.every((c) => c[0][1] === 'list')).toBe(true)
+	})
+
+	it('creates a missing label on a repo already running the loop', async () => {
+		const exec = fakeGh(allCorrect().filter((l) => l.name !== 'ai-notes'))
+		expect(await applyLoopLabels(gitRepo(), exec)).toEqual(['created label "ai-notes"'])
+	})
+
+	it('writes nothing to a repo that does not use the loop', async () => {
+		const exec = fakeGh([{ name: 'bug', color: 'd73a4a', description: '' }])
+		expect(await applyLoopLabels(gitRepo(), exec)).toEqual([])
+		expect(vi.mocked(exec).mock.calls.every((c) => c[0][1] === 'list')).toBe(true)
+	})
+
+	it('is a no-op outside a git repo', async () => {
+		const exec = fakeGh([])
+		expect(await applyLoopLabels(newTmpDir(), exec)).toEqual([])
+		expect(exec).not.toHaveBeenCalled()
+	})
+
+	it('reports a failed edit without claiming it applied', async () => {
+		const labels = allCorrect().map((l) => (l.name === 'ai-ready' ? { ...l, color: 'ffffff' } : l))
+		const exec = fakeGh(labels, { ok: false, stdout: '', stderr: 'HTTP 403', code: 1 })
+		expect(await applyLoopLabels(gitRepo(), exec)).toEqual([])
+	})
+})
+
+/**
+ * The single-source-of-truth guard. The skill's bootstrap block is the only
+ * other copy of this table, and it is the copy that drifted (#446) — so it is
+ * asserted against LOOP_LABELS rather than trusted.
+ */
+describe('skills/ai-issue-loop/SKILL.md bootstrap block', () => {
+	const skill = readFileSync(
+		path.resolve(import.meta.dirname, '../../skills/ai-issue-loop/SKILL.md'),
+		'utf8'
+	)
+	const LINE = /^gh label create\s+(\S+)\s+-c\s+'#([0-9a-fA-F]{6})'\s+-d\s+'(.*)'$/gm
+
+	it('matches LOOP_LABELS exactly', () => {
+		const fromSkill = [...skill.matchAll(LINE)].map(([, name, color, description]) => ({
+			name,
+			color: color?.toLowerCase(),
+			description,
+		}))
+		expect(fromSkill).toEqual(LOOP_LABELS.map((l) => ({ ...l })))
+	})
+})


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Posted under the owner's account; not a human message.*

Closes #446

## The bug

`gh label create` **errors as a no-op when the label already exists** — the skill's bootstrap block even tells the reader to ignore that error. So it can add a missing label but can never repair an existing one's colour or description. That is why `ai-ready` sat at `B60205` in six of eight repos, byte-identical to `ai-blocked`: the two states a maintainer most needs to tell apart rendered the same, and re-running the bootstrap would have changed nothing. Repair here goes through **`gh label edit`**.

## What landed

`src/base/labels.ts`, modelled on `src/base/milestones.ts` — same `gh` seam, same check/fix split, same self-skip conventions.

- **`AI loop labels`** doctor check. Read-only, `ok` outside a git repo or when `gh` can't answer. Reports wrong colour, wrong description, and missing labels.
- **`fix labels`** fixer. `gh label edit` for drift, `gh label create` only for labels the set is genuinely missing. Idempotent; `safe-add` risk level so the `--diff` shadow-run doesn't fire real writes during a preview, matching `github-settings` and `milestones`.

### Colour comparison is case-insensitive

Normalised (`#` stripped, lowercased) before comparing. GitHub's web picker writes uppercase, `gh` writes lowercase, and the two render identically — comparing raw would report every hand-created label as drift forever and have the fixer PATCH a colour that was already right. A label whose only difference is hex case is not reported and not touched; there is a test for each half.

### A repo that doesn't run the loop is *not applicable*, not drift

Fewer than two of the eleven labels present → `ok` with `not applicable — repo does not use the ai-issue-loop labels`, matching how `Release gate` says "not applicable" and `Milestones` skips a repo that uses none. The fixer honours the same gate, so a bare `fix --yes` cannot push eleven labels into a repo that opted out. One stray label (the observed `cf-common` / `db-common` half-state) is still not applicable.

## Source of truth — the choice you asked about

**`LOOP_LABELS` in `src/base/labels.ts` owns the table; `SKILL.md` keeps its bash block, and a test asserts the block matches the table exactly.**

Deleting the block was the tempting option, but it is the *only* bootstrap path for a repo with zero loop labels — precisely the repo `fix labels` deliberately refuses to touch. Removing it would trade one gap for another. Instead the block stays, gains a note that `create` cannot repair and that `fix labels` is what does, and `tests/base/labels.test.ts` parses it and compares it to `LOOP_LABELS`. The two cannot diverge without a red test.

Note the table has **eleven** labels, not the nine in the issue: `SKILL.md` is the live spec and also defines `ai-reviewing-code` / `ai-reviewing-sec`. Every colour and description is taken verbatim from that block — nothing was invented, which is the #422 caution about a `fix` command PUTting a wrong canonical value back into every repo.

## Verification

- `vitest run` — 988 passed, 18 skipped, 61 files. 17 of those are new.
- `tsc --noEmit --project src/cli/tsconfig.json` — clean.
- `biome check` on every touched file — clean.
- No label writes were run against any repository, this one included.