### PR TITLE
fix(dependabot): stop the dev-minor auto-merge reaching peerDependencies

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -17,11 +17,50 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/checkout@v7
+
+      # The group name is Dependabot's opinion, not a safety property: a package
+      # in both devDependencies and peerDependencies is classified "development"
+      # and lands in dev-minor, while peerDependencies ship to consumers of a
+      # published package (#458). So resolve every bumped name against the
+      # tracked manifests and stand down if any of them reaches a consumer.
+      #
+      # npm-specific by design. A repo with no package.json (Swift, Python) finds
+      # nothing here and falls back to the group + semver gate below.
+      - name: Check whether any bumped package ships to consumers
+        id: gate
+        env:
+          NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+
+          # A private workspace publishes nothing, so its deps reach nobody.
+          ships=$(git ls-files -- 'package.json' '*/package.json' | while read -r f; do
+            if [ "$(jq -r '.private // false' "$f")" = 'true' ]; then continue; fi
+            jq -r '((.dependencies // {}) + (.optionalDependencies // {}) + (.peerDependencies // {})) | keys[]' "$f"
+          done | sort -u)
+
+          safe=true
+          # No names reported means we cannot verify anything — fail closed.
+          if [ -z "${NAMES//[, ]/}" ]; then
+            echo "::notice::no dependency names reported — leaving this PR for a human"
+            safe=false
+          fi
+          for name in ${NAMES//,/ }; do
+            if printf '%s\n' "$ships" | grep -qxF -- "$name"; then
+              echo "::notice::$name ships to consumers — leaving this PR for a human"
+              safe=false
+              break
+            fi
+          done
+          echo "safe=$safe" >> "$GITHUB_OUTPUT"
+
       # Belt and braces: the dev-minor group is already declared minor+patch in
       # dependabot.yml, but this workflow is the security gate and shouldn't
       # trust a config file a consumer repo can edit independently.
       - name: Auto-merge dev-dependency patch and minor updates
         if: |
+          steps.gate.outputs.safe == 'true' &&
           steps.metadata.outputs.dependency-group == 'dev-minor' &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor')

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -26,7 +26,7 @@ Dependabot opens roughly **3–4 PRs per cycle** instead of one per package:
 | Group | Contents | Update types | Auto-merge |
 | --- | --- | --- | --- |
 | `production-minor` | runtime `dependencies` | minor, patch | ❌ manual |
-| `dev-minor` | `devDependencies` | minor, patch | ✅ on green |
+| `dev-minor` | `devDependencies` | minor, patch | ✅ on green, if nothing in it ships |
 | `major-updates` | all packages | major | ❌ manual |
 | `github-actions` | workflow actions | all | ❌ manual |
 
@@ -40,6 +40,20 @@ and `version-update:semver-patch` / `version-update:semver-minor`.
 
 Everything else waits for a human, and the gate **fails closed**: a PR outside a
 group reports an empty `dependency-group` and so never matches.
+
+> **The group name is not the gate.** `dependency-type: development` is
+> Dependabot's classification, and it files a package listed in *both*
+> `devDependencies` and `peerDependencies` as development — so it lands in
+> `dev-minor` while still being part of what a published package hands its
+> consumers. This repo has 32 such packages; 13 of them once rode a single
+> "dev-only" group PR. The workflow therefore resolves every bumped name against
+> the tracked manifests (`dependencies` + `optionalDependencies` +
+> `peerDependencies` of every non-private `package.json`) and stands down if any
+> of them ships. A PR reporting no dependency names at all is also refused —
+> nothing verified means nothing waved through.
+>
+> This step is npm-specific. A repo with no `package.json` finds nothing and
+> falls back to the group + semver gate alone.
 
 > **Production bumps are deliberately excluded.** A minor bump to a runtime
 > dependency of a published package ships to every consumer on the next release.

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -304,6 +304,15 @@ export async function checkDependabot(dir: string): Promise<CheckResult> {
 				if (!automerge.includes("dependency-group == 'dev-minor'")) {
 					deltas.push('auto-merge workflow merges production bumps (missing dev-minor group gate)')
 				}
+				// #458: the group gate alone lets peerDependencies through, because
+				// Dependabot files a package that is both dev and peer under
+				// "development". The canonical workflow re-checks the names against the
+				// manifests; a workflow without that step is the #423 hole reopened.
+				if (!automerge.includes("steps.gate.outputs.safe == 'true'")) {
+					deltas.push(
+						'auto-merge workflow trusts the dev-minor group name (missing peerDependencies check)'
+					)
+				}
 			} else {
 				deltas.push('missing dependabot-automerge workflow')
 			}

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -39,8 +39,11 @@ export function dependabotConfig(ecosystem: string | null): string {
         update-types:
           - minor
           - patch
-      # The only tier that auto-merges on green — dev tooling never reaches a
-      # consumer of the published package.
+      # The tier that can auto-merge on green. "development" is Dependabot's
+      # classification, not a safety property: a package listed in both
+      # devDependencies and peerDependencies lands here, and peer deps are part
+      # of a published package's contract (#458). The auto-merge workflow
+      # re-checks every name against the manifests rather than trusting this.
       dev-minor:
         dependency-type: development
         update-types:
@@ -137,6 +140,13 @@ export function dependabotIgnoreRules(content: string): string[] {
  *
  * The group name is the one \`dependabotConfig()\` writes — the two files are a
  * paired unit and have to move together.
+ *
+ * **The group name alone is not enough** (#458). Dependabot classifies a package
+ * listed in both \`devDependencies\` and \`peerDependencies\` as *development*, so
+ * it lands in \`dev-minor\` — and \`peerDependencies\` are part of what a published
+ * package hands its consumers. This repo had 32 such packages, and 13 of them
+ * rode a single "dev-only" group PR. So the workflow resolves every bumped name
+ * against the tracked manifests and stands down if any of them ships.
  */
 export const DEPENDABOT_AUTOMERGE_WORKFLOW = `name: Dependabot auto-merge
 
@@ -157,11 +167,50 @@ jobs:
         with:
           github-token: \${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/checkout@v7
+
+      # The group name is Dependabot's opinion, not a safety property: a package
+      # in both devDependencies and peerDependencies is classified "development"
+      # and lands in dev-minor, while peerDependencies ship to consumers of a
+      # published package (#458). So resolve every bumped name against the
+      # tracked manifests and stand down if any of them reaches a consumer.
+      #
+      # npm-specific by design. A repo with no package.json (Swift, Python) finds
+      # nothing here and falls back to the group + semver gate below.
+      - name: Check whether any bumped package ships to consumers
+        id: gate
+        env:
+          NAMES: \${{ steps.metadata.outputs.dependency-names }}
+        run: |
+          set -euo pipefail
+
+          # A private workspace publishes nothing, so its deps reach nobody.
+          ships=$(git ls-files -- 'package.json' '*/package.json' | while read -r f; do
+            if [ "$(jq -r '.private // false' "$f")" = 'true' ]; then continue; fi
+            jq -r '((.dependencies // {}) + (.optionalDependencies // {}) + (.peerDependencies // {})) | keys[]' "$f"
+          done | sort -u)
+
+          safe=true
+          # No names reported means we cannot verify anything — fail closed.
+          if [ -z "\${NAMES//[, ]/}" ]; then
+            echo "::notice::no dependency names reported — leaving this PR for a human"
+            safe=false
+          fi
+          for name in \${NAMES//,/ }; do
+            if printf '%s\\n' "$ships" | grep -qxF -- "$name"; then
+              echo "::notice::$name ships to consumers — leaving this PR for a human"
+              safe=false
+              break
+            fi
+          done
+          echo "safe=$safe" >> "$GITHUB_OUTPUT"
+
       # Belt and braces: the dev-minor group is already declared minor+patch in
       # dependabot.yml, but this workflow is the security gate and shouldn't
       # trust a config file a consumer repo can edit independently.
       - name: Auto-merge dev-dependency patch and minor updates
         if: |
+          steps.gate.outputs.safe == 'true' &&
           steps.metadata.outputs.dependency-group == 'dev-minor' &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor')

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -581,7 +581,6 @@ describe('doctor extended checks', () => {
 		expect((await worktreeCheck(dir))?.status).toBe('drift')
 	})
 
-
 	it('detects lint-staged in package.json', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, 'package.json'), {
@@ -967,6 +966,28 @@ describe('doctor security checks', () => {
 		const dep = results.find((r) => r.check === 'Dependabot')
 		expect(dep?.status).toBe('drift')
 		expect(dep?.detail).toMatch(/production bumps/)
+		expect(dep?.hint).toMatch(/fix dependabot/)
+	})
+
+	// #458: the group gate alone lets peerDependencies through, because a package
+	// that is both dev and peer is filed by Dependabot as "development". A repo
+	// that took the #423 pair but not this one still has the hole.
+	it('reports Dependabot drift when the auto-merge workflow trusts the group name', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateDependabotConfig(dir)
+		const workflow = join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+		await fs.writeFile(
+			workflow,
+			(await fs.readFile(workflow, 'utf8')).replace(
+				/\s*steps\.gate\.outputs\.safe == 'true' &&/,
+				''
+			)
+		)
+		const results = await runDoctor(dir)
+		const dep = results.find((r) => r.check === 'Dependabot')
+		expect(dep?.status).toBe('drift')
+		expect(dep?.detail).toMatch(/peerDependencies/)
 		expect(dep?.hint).toMatch(/fix dependabot/)
 	})
 
@@ -1564,7 +1585,10 @@ describe('checkBuildApprovals', () => {
 
 	it('accepts a decision either way — declining a build is still deciding', async () => {
 		const dir = newTmpDir()
-		const pkg = { name: 'demo', devDependencies: { esbuild: '^0.25.0', '@prisma/client': '^5.0.0' } }
+		const pkg = {
+			name: 'demo',
+			devDependencies: { esbuild: '^0.25.0', '@prisma/client': '^5.0.0' },
+		}
 		await seedDep(dir, 'esbuild', { postinstall: 'node install.js' })
 		await seedDep(dir, '@prisma/client', { postinstall: 'prisma generate' })
 		await fs.writeFile(
@@ -1584,7 +1608,10 @@ describe('checkBuildApprovals', () => {
 	})
 
 	it('stays quiet when nothing is installed to inspect', async () => {
-		const result = await checkBuildApprovals(newTmpDir(), { name: 'demo', devDependencies: { x: '1' } })
+		const result = await checkBuildApprovals(newTmpDir(), {
+			name: 'demo',
+			devDependencies: { x: '1' },
+		})
 		expect(result.status).toBe('ok')
 		expect(result.detail).toContain('no installed dependencies')
 	})

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import {
+	DEPENDABOT_AUTOMERGE_WORKFLOW,
 	DEPENDABOT_CONFIG,
 	dependabotIgnoreRules,
 	findDependabotIgnoreRules,
@@ -83,6 +84,104 @@ describe('generateDependabotConfig', () => {
 		const group = workflow.match(/dependency-group == '([^']+)'/)?.[1]
 		expect(group).toBeDefined()
 		expect(config).toMatch(new RegExp(`^\\s*${group}:`, 'm'))
+	})
+})
+
+// #458: `dependency-type: development` is Dependabot's classification, not a
+// safety property — a package in both devDependencies and peerDependencies is
+// filed as development and lands in dev-minor, while peerDependencies are part
+// of what a published package hands its consumers. This repo had 32 such
+// packages and 13 rode a single "dev-only" group PR.
+//
+// The gate is shell, so the test runs the shell. A string assertion would pass
+// on a script that never sets `safe` at all.
+describe('the auto-merge consumer-facing gate', () => {
+	/** The `run:` body of the `id: gate` step, dedented to a runnable script. */
+	function gateScript(): string {
+		const step = DEPENDABOT_AUTOMERGE_WORKFLOW.split(/^ {6}- name: Check whether/m)[1]
+		const body = step?.match(/ {8}run: \|\n([\s\S]*?)\n(?= {6}(?:#|-))/)?.[1]
+		if (!body) throw new Error('could not extract the gate script from the workflow')
+		return body
+			.split('\n')
+			.map((l) => l.replace(/^ {10}/, ''))
+			.join('\n')
+	}
+
+	/**
+	 * Run the gate against a throwaway git repo. `git ls-files` only sees tracked
+	 * files, so the manifests have to be added — which is also the real behaviour
+	 * we depend on.
+	 */
+	async function runGate(
+		manifests: Record<string, unknown>,
+		names: string
+	): Promise<'true' | 'false'> {
+		const dir = newTmpDir()
+		for (const [file, json] of Object.entries(manifests)) {
+			await fs.outputJson(join(dir, file), json)
+		}
+		const out = join(dir, 'gh-output')
+		await fs.writeFile(out, '')
+		await fs.writeFile(join(dir, 'gate.sh'), gateScript())
+
+		const { execFile } = await import('node:child_process')
+		const { promisify } = await import('node:util')
+		const run = promisify(execFile)
+		await run('git', ['init', '-q'], { cwd: dir })
+		await run('git', ['add', '-A'], { cwd: dir })
+		await run('bash', ['gate.sh'], {
+			cwd: dir,
+			env: { ...process.env, NAMES: names, GITHUB_OUTPUT: out },
+		})
+		const written = await fs.readFile(out, 'utf-8')
+		return written.trim().endsWith('safe=true') ? 'true' : 'false'
+	}
+
+	const MANIFEST = {
+		'package.json': {
+			name: 'published',
+			devDependencies: { knip: '^5.0.0', typescript: '^5.0.0' },
+			peerDependencies: { typescript: '^5.0.0' },
+			dependencies: { chalk: '^5.0.0' },
+		},
+	}
+
+	it('passes a bump that reaches no consumer', async () => {
+		expect(await runGate(MANIFEST, 'knip')).toBe('true')
+	})
+
+	// The whole point: `typescript` is a devDependency *and* a peerDependency, so
+	// Dependabot files it under dev-minor. It still ships.
+	it('stands down when a bumped package is a peerDependency', async () => {
+		expect(await runGate(MANIFEST, 'knip,typescript')).toBe('false')
+	})
+
+	it('stands down on a runtime dependency', async () => {
+		expect(await runGate(MANIFEST, 'chalk')).toBe('false')
+	})
+
+	// A private workspace publishes nothing, so its deps reach nobody — flagging
+	// them would train the reader to ignore the gate.
+	it('ignores the manifests of private workspaces', async () => {
+		const withDocs = {
+			...MANIFEST,
+			'apps/docs/package.json': { name: 'docs', private: true, dependencies: { react: '^19.0.0' } },
+		}
+		expect(await runGate(withDocs, 'react')).toBe('true')
+	})
+
+	it('reads workspace manifests that do publish', async () => {
+		const withPkg = {
+			...MANIFEST,
+			'packages/ui/package.json': { name: 'ui', peerDependencies: { react: '^19.0.0' } },
+		}
+		expect(await runGate(withPkg, 'react')).toBe('false')
+	})
+
+	// Nothing to check means nothing was verified. Failing open here would be the
+	// #423 hole reopened, quietly.
+	it('fails closed when no dependency names are reported', async () => {
+		expect(await runGate(MANIFEST, '')).toBe('false')
 	})
 })
 


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on rtorcato's behalf. Posted under the owner's account; there is no separate GitHub account for AI agents.*

Closes #458.

## The hole

`dependency-type: development` is Dependabot's classification, not a safety property. A package listed in **both** `devDependencies` and `peerDependencies` is filed as *development*, so it lands in the `dev-minor` group — while `peerDependencies` are part of what a published package hands its consumers.

This repo has **32** such packages:

```
$ jq -r '(.peerDependencies|keys) - ((.peerDependencies|keys) - (.devDependencies|keys)) | length' package.json
32
```

PR #455 bumped 18 in one `dev-minor` group PR, **13 of them peers of the published package**. The #423 gate would have auto-merged the lot on green CI alone. It only didn't because the branch was conflicting, so GitHub could not compute a merge ref and no checks ever ran — the gate was never actually tested against a live case.

## The fix

The workflow now resolves every bumped name against the tracked manifests instead of trusting the group name:

```yaml
ships=$(git ls-files -- 'package.json' '*/package.json' | while read -r f; do
  if [ "$(jq -r '.private // false' "$f")" = 'true' ]; then continue; fi
  jq -r '((.dependencies // {}) + (.optionalDependencies // {}) + (.peerDependencies // {})) | keys[]' "$f"
done | sort -u)
```

and the merge step gains `steps.gate.outputs.safe == 'true' &&`.

Three details worth reviewing:

- **Private workspaces are skipped.** They publish nothing, so their deps reach nobody. Flagging `apps/docs`'s React bump would train the reader to ignore the gate.
- **No dependency names reported ⇒ refuse.** Nothing verified is not the same as nothing to verify; that direction is where #423 failed open.
- **npm-specific by design.** A repo with no `package.json` (Swift, Python) finds nothing here and falls back to the group + semver gate, as before. Documented in the workflow comment rather than left to be discovered.

`doctor` gains the matching drift check, so a repo that took the #423 pair but not this one is told it still has the hole.

## Testing

The gate is shell, so **the test runs the shell** — extracts the `run:` body from the generated workflow and executes it under `bash` against a throwaway git repo. A string assertion would pass on a script that never sets `safe` at all.

Six cases: dev-only passes; a peer dep stands down; a runtime dep stands down; a private workspace's dep is ignored; a publishing workspace's dep stands down; empty names fails closed.

`vitest run` — 996 passed. The repo's own `action-pins` test caught `actions/checkout@v4` in the first draft and forced `@v7`, which is what the rest of the repo pins.

## Not done here

- **#455 itself is still stuck.** Rebasing it before this lands is what arms the trap. Once this is on `main`, `@dependabot rebase` is safe — the gate will see 13 peers and stand down.
- The `dev-minor` **grouping** is unchanged. It still collects peer deps; this makes that harmless rather than tidy. Narrowing the group in `dependabot.yml` would need a pattern Dependabot honours for peer deps, which is #458's option 1 and a separate question.
