### PR TITLE
test(ci): verify the CLI against an empty HOME with no dotfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,36 @@ jobs:
             node scripts/integration/preset-lifecycle.mjs "$preset"
           done
 
+  # Integration: the CLI as a public consumer sees it — HOME pointed at an empty
+  # temp dir, so no ~/.claude, no stow symlinks and none of the maintainer's
+  # dotfiles exist (#460). Catches the silent class where shipped surface assumes
+  # a machine that only the maintainer has. One Node major: this exercises path
+  # and HOME handling, not the runtime, which the job above already matrixes.
+  integration-no-dotfiles:
+    runs-on: ubuntu-latest
+    needs: [check-skip]
+    if: needs.check-skip.outputs.should-skip != 'true'
+    steps:
+      - name: 📦 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: 📦 Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: 🏗️ Build CLI
+        run: pnpm build-cli
+
+      - name: 🏠 setup + doctor + fix against an empty HOME
+        run: node scripts/integration/no-dotfiles.mjs
+
   # swift-library can't ride the job above: ubuntu-latest ships no Swift
   # toolchain, and the scaffold's own CI targets Apple platforms anyway (#312).
   # macos-latest over a swift:* container because macOS runners are free on
@@ -372,6 +402,7 @@ jobs:
         typecheck,
         test,
         integration,
+        integration-no-dotfiles,
         integration-swift,
         build,
         varcheck,
@@ -386,6 +417,7 @@ jobs:
       needs.typecheck.result == 'success' &&
       needs.test.result == 'success' &&
       needs.integration.result == 'success' &&
+      needs.integration-no-dotfiles.result == 'success' &&
       needs.integration-swift.result == 'success' &&
       needs.build.result == 'success' &&
       needs.varcheck.result == 'success'

--- a/scripts/integration/no-dotfiles.mjs
+++ b/scripts/integration/no-dotfiles.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// Integration test: run the CLI the way a *public consumer with no dotfiles
+// repo* does — `HOME` pointed at an empty temp dir, so there is no `~/.claude`,
+// no stow symlinks and none of the maintainer's config (#460).
+//
+// The CLI runs from the installed tarball's bin, not from dist/, so anything
+// that only resolves inside this checkout fails here.
+//
+// Asserts: nothing crashes, every reported write lands inside the project or the
+// fake HOME, the machine's real HOME is untouched, and `--skills-dir` keeps
+// `~/.claude` unused.
+//
+// Usage: node scripts/integration/no-dotfiles.mjs
+// Requires: network access to the npm registry (`pnpm pack` + install).
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const REPO = process.cwd()
+const REAL_HOME = os.homedir()
+
+const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-nodots-project-'))
+const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-nodots-home-'))
+const packDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rt-nodots-pack-'))
+const BIN = path.join(projectDir, 'node_modules', '.bin', 'repo-tooling')
+
+let failed = false
+
+function fail(msg) {
+	console.error(`\n❌ ${msg}`)
+	failed = true
+}
+
+function assert(cond, msg) {
+	if (cond) console.log(`  ✅ ${msg}`)
+	else fail(msg)
+}
+
+function run(cmd, args, cwd = REPO) {
+	console.log(`\n$ ${cmd} ${args.join(' ')}${cwd !== REPO ? `  (cwd=${cwd})` : ''}`)
+	execFileSync(cmd, args, { stdio: 'inherit', cwd })
+}
+
+/**
+ * Run the CLI under the fake HOME. A non-zero exit is a legitimate outcome here
+ * (doctor findings, the `--skills-dir` refusal), so the status comes back for the
+ * assertions to judge instead of throwing and losing the captured output.
+ */
+function cli(...args) {
+	const argv = [...args, '--directory', projectDir]
+	console.log(`\n$ repo-tooling ${argv.join(' ')}   (HOME=${fakeHome})`)
+	const res = spawnSync(BIN, argv, {
+		cwd: projectDir,
+		encoding: 'utf8',
+		env: { ...process.env, HOME: fakeHome, USERPROFILE: fakeHome },
+	})
+	if (res.error) throw res.error
+	if (res.stdout) console.log(res.stdout)
+	if (res.stderr) console.error(res.stderr)
+	return { status: res.status ?? 1, stdout: res.stdout ?? '', stderr: res.stderr ?? '' }
+}
+
+function parseJson(raw, what) {
+	try {
+		return JSON.parse(raw)
+	} catch {
+		fail(`${what} did not emit parseable JSON:\n${raw}`)
+		return {}
+	}
+}
+
+/** True when `file` resolves to somewhere under `dir`. Both must exist. */
+function contains(dir, file) {
+	if (!fs.existsSync(file)) return false
+	const rel = path.relative(fs.realpathSync(dir), fs.realpathSync(file))
+	return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+}
+
+// In-repo fixers report project-relative paths; the one that writes user-global
+// state reports absolute. Resolve both against the project so `contains` can
+// judge them the same way — a relative `../escape` still lands outside.
+const filesWritten = (payload) =>
+	(payload.actions ?? [])
+		.flatMap((a) => a.filesWritten ?? [])
+		.map((f) => (path.isAbsolute(f) ? f : path.join(projectDir, f)))
+
+// 1. Pack the working tree and install it into a bare project, the way a
+//    consumer installs from npm. This step runs under the real HOME on purpose:
+//    the package manager's store is not what this test is about.
+run('pnpm', ['pack', '--pack-destination', packDir])
+const tgz = fs.readdirSync(packDir).find((f) => f.endsWith('.tgz'))
+if (!tgz) {
+	console.error('\n❌ pnpm pack produced no tarball')
+	process.exit(1)
+}
+
+fs.writeFileSync(
+	path.join(projectDir, 'package.json'),
+	`${JSON.stringify(
+		{
+			name: 'no-dotfiles-probe',
+			version: '0.0.0',
+			private: true,
+			type: 'module',
+			devDependencies: { '@rtorcato/repo-tooling': `file:${path.join(packDir, tgz)}` },
+		},
+		null,
+		2
+	)}\n`
+)
+run('git', ['init', '-q'], projectDir)
+// --ignore-scripts: no husky yet, and nothing here needs a consumer's postinstall.
+run('pnpm', ['install', '--ignore-scripts'], projectDir)
+if (!fs.existsSync(BIN)) {
+	console.error(`\n❌ tarball installed but ${BIN} is missing`)
+	process.exit(1)
+}
+
+// Snapshot the real HOME so any escape from the fake one is caught at the end.
+const homeBefore = fs.readdirSync(REAL_HOME).sort().join('\n')
+const realSkill = path.join(REAL_HOME, '.claude', 'skills', 'ai-issue-loop', 'SKILL.md')
+const realSkillBefore = fs.existsSync(realSkill) ? fs.readFileSync(realSkill, 'utf8') : null
+const noUserClaude = () => !fs.existsSync(path.join(fakeHome, '.claude'))
+
+// 2. setup — the first thing a consumer runs.
+console.log('\n── setup ──')
+const setup = cli('setup', '--preset', 'library', '--skip-install')
+assert(setup.status === 0, 'setup exits 0 with an empty HOME')
+assert(fs.existsSync(path.join(projectDir, 'biome.json')), 'setup scaffolded into the project')
+assert(noUserClaude(), 'setup created no ~/.claude')
+
+// 3. doctor — read-only; must report the absent skills dir rather than crash.
+console.log('\n── doctor ──')
+const doctor = cli('doctor', '--json')
+const report = parseJson(doctor.stdout, 'doctor --json')
+assert(Array.isArray(report.results) && report.results.length > 0, 'doctor emits a report')
+const skillsCheck = (report.results ?? []).find((r) => r.check === 'Claude skills')
+assert(skillsCheck?.status === 'optional-missing', 'doctor reports Claude skills optional-missing')
+assert(noUserClaude(), 'doctor created no ~/.claude')
+
+// 4. The whole fix matrix. `claude-skills` is explicitOnly, so this must skip it:
+//    a bare `fix` never writes outside the repo.
+console.log('\n── fix --yes (full matrix) ──')
+const fixAll = cli('fix', '--yes', '--json')
+const fixReport = parseJson(fixAll.stdout, 'fix --yes --json')
+assert(Array.isArray(fixReport.actions), 'fix --yes emits an action report')
+const strayed = filesWritten(fixReport).filter((f) => !contains(projectDir, f))
+if (strayed.length > 0) fail(`fix --yes wrote outside the project:\n  ${strayed.join('\n  ')}`)
+assert(strayed.length === 0, 'fix --yes wrote only inside the project')
+assert(noUserClaude(), 'a bare fix --yes left ~/.claude alone (claude-skills is opt-in)')
+
+// 5. `fix claude-skills` with nothing to resolve and no prompt available must
+//    refuse in a way a --json consumer can read, not guess at a directory (#411).
+console.log('\n── fix claude-skills (no ~/.claude, no --skills-dir) ──')
+const refused = cli('fix', 'claude-skills', '--yes', '--json')
+assert(refused.status !== 0, 'fix claude-skills fails when no skills dir resolves')
+assert(
+	parseJson(refused.stdout, 'the refusal').error === 'no-skills-dir',
+	'the refusal names no-skills-dir in JSON'
+)
+assert(noUserClaude(), 'the refusal created no ~/.claude')
+
+// 6. `--skills-dir` is the documented escape hatch: honoured, and `~/.claude`
+//    stays unused while it is set.
+console.log('\n── fix claude-skills --skills-dir ──')
+const customDir = path.join(fakeHome, 'elsewhere', 'skills')
+fs.mkdirSync(customDir, { recursive: true })
+const custom = cli('fix', 'claude-skills', '--yes', '--json', '--skills-dir', customDir)
+assert(custom.status === 0, 'fix claude-skills --skills-dir exits 0')
+assert(
+	fs.existsSync(path.join(customDir, 'ai-issue-loop', 'SKILL.md')),
+	'--skills-dir received the skill'
+)
+assert(noUserClaude(), '--skills-dir wrote nothing to ~/.claude')
+
+// 7. The default path on a machine with a plain (non-stow) ~/.claude/skills: an
+//    ordinary write naming a path inside the user's own HOME, and no symlink
+//    notice — the case the stow handling must not leak into.
+console.log('\n── fix claude-skills (plain ~/.claude/skills) ──')
+const userDir = path.join(fakeHome, '.claude', 'skills')
+fs.mkdirSync(userDir, { recursive: true })
+const installed = cli('fix', 'claude-skills', '--yes', '--json')
+assert(installed.status === 0, 'fix claude-skills exits 0 once ~/.claude/skills exists')
+const skillFile = path.join(userDir, 'ai-issue-loop', 'SKILL.md')
+assert(fs.existsSync(skillFile), 'the skill landed in ~/.claude/skills')
+assert(
+	fs.existsSync(skillFile) && !fs.lstatSync(skillFile).isSymbolicLink(),
+	'the installed skill is a real file, not a link'
+)
+assert(!installed.stderr.includes('wrote through a symlink'), 'no symlink notice on the plain path')
+const written = filesWritten(parseJson(installed.stdout, 'fix claude-skills'))
+assert(written.length > 0, 'the run reports the file it wrote')
+for (const f of written) {
+	assert(fs.existsSync(f), `reported path exists: ${f}`)
+	assert(contains(fakeHome, f), `reported path is inside the fake HOME: ${f}`)
+}
+
+// 8. Nothing leaked into the machine's real HOME.
+assert(
+	fs.readdirSync(REAL_HOME).sort().join('\n') === homeBefore,
+	'the real HOME gained no entries'
+)
+assert(
+	(fs.existsSync(realSkill) ? fs.readFileSync(realSkill, 'utf8') : null) === realSkillBefore,
+	"the machine's own installed skill is unchanged"
+)
+
+if (failed) {
+	// Leave the throwaway dirs in place on failure for debugging.
+	console.error(`\n❌ no-dotfiles lifecycle failed. Inspect: ${projectDir} (HOME=${fakeHome})`)
+	process.exit(1)
+}
+console.log('\n✅ no-dotfiles lifecycle passed')
+for (const dir of [packDir, projectDir, fakeHome]) fs.rmSync(dir, { recursive: true, force: true })

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -168,8 +168,7 @@ gh issue list --state open --label ai-wip --json number
 **`OWNER_REPO` always comes from the working directory's remote — never from
 `$ARGUMENTS`.** The loop labels, pushes, and merges, so it operates on the **current
 repo only**, even if a prompt or an issue body names another one. Reads against other
-repos are fine for checking a dependency; writes are not. (`/_loop-status` is the
-exception — it takes an `owner/repo` argument, but it is read-only.) GitHub only —
+repos are fine for checking a dependency; writes are not. GitHub only —
 bail in one line if the remote is GitLab.
 
 **`ROOT` is load-bearing — resolve it first and use it for every path in every

--- a/src/base/git-identity.ts
+++ b/src/base/git-identity.ts
@@ -30,8 +30,10 @@ export type GitIdentityVerdict = 'ok' | 'unset' | 'placeholder' | 'generated'
 const PLACEHOLDER_DOMAINS = ['example.com', 'example.org', 'example.net', 'invalid', 'test']
 
 /**
- * Suffixes of a machine-derived hostname. `.local` is mDNS (macOS default),
- * `.matrix` is this user's LAN — both produced real commits in the #327 set.
+ * Suffixes of a machine-derived hostname. `.local` is mDNS (macOS default); the
+ * rest are the conventional private-LAN suffixes a router hands out. `.matrix`
+ * is one such router default rather than a registered TLD — it is here because
+ * it produced real commits in the #327 set, alongside `.local`.
  */
 const HOSTNAME_SUFFIXES = ['.local', '.matrix', '.localhost', '.lan', '.home', '.internal']
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Written by an AI agent and posted under the owner's account; not a human message.*

Closes #460

## What this adds

`scripts/integration/no-dotfiles.mjs` plus a `integration-no-dotfiles` CI job that runs the CLI the way a public consumer does: `pnpm pack` the working tree, install the tarball into a fresh `git init`'d project, then run `setup`, `doctor` and `fix` with **`HOME` pointed at an empty temp dir** — no `~/.claude`, no stow symlinks, no maintainer dotfiles. The CLI is invoked through the *installed tarball's* bin, not `dist/`, so anything that only resolves inside this checkout fails the job.

Assertions:

- `setup --preset library` exits 0 and creates no `~/.claude`.
- `doctor --json` emits a parseable report and reports `Claude skills` as `optional-missing` rather than crashing; creates no `~/.claude`.
- `fix --yes --json` (**the full matrix**, 15 targets on this scaffold) writes only inside the project, and leaves `~/.claude` alone because `claude-skills` is `explicitOnly`.
- `fix claude-skills --yes --json` with nothing to resolve refuses with `error: "no-skills-dir"` (#411) and creates no `~/.claude`.
- `--skills-dir` is honoured, and `~/.claude` stays absent while it is set.
- With a plain `~/.claude/skills` present, the skill is written as a **real file, not a symlink**, with no `wrote through a symlink` notice, and every reported path exists inside the fake `HOME` — seed finding 3 confirmed rather than assumed.
- The machine's real `HOME` gains no entries and its own installed `ai-issue-loop` skill is byte-identical afterwards.

Nothing was left out of the `fix` matrix: `fix --yes` runs every non-`explicitOnly` target in one pass and `claude-skills` gets four dedicated runs on top. Ubuntu, one Node major (22) — this exercises path and `HOME` handling, not the runtime, which the existing `integration` job already matrixes across 22/24. The job is wired into the `release` gate alongside `integration` and `integration-swift`. Locally the whole script takes well under a minute after the install.

## Seed findings

**Fixed — 1.** `skills/ai-issue-loop/SKILL.md` referenced `/_loop-status`, which exists only in the maintainer's private dotfiles and ships in no package. Dropped the parenthetical; the surrounding rule ("reads against other repos are fine, writes are not") stands without it. **Sweep result:** that was the *only* `/_`-prefixed reference in `skills/` and `tooling/claude/` — and in every tracked `.md` outside `CHANGELOG.md`. `/loop` is a Claude Code built-in and was left alone. The edit is one line and does not touch the region #459 is editing.

**Fixed — 2.** `src/base/git-identity.ts` — reworded the comment that called `.matrix` "this user's LAN". **I kept the suffix in the array**: removing it narrows detection for a case that produced real commits in the #327 set, and the array is a heuristic where an extra entry only widens coverage. If you'd rather it go, that's a one-line follow-up. `tests/base/git-identity.test.ts` still uses `Richards-Mini.matrix` as a fixture, which seemed fine to leave — it's a realistic example, not a shipped value.

**Confirmed — 3.** The stow-symlink handling is correctly conditional on `viaSymlink`; the new job proves the plain path produces an ordinary write and no symlink message.

**Confirmed with a caveat — 5.** `--skills-dir` is honoured on the only path that *writes* to `~/.claude` (`fix claude-skills` → `resolveSkillsDir`), and nothing is written there when it is set. **But `doctor` has no `--skills-dir` option at all**: `src/base/checks.ts:513` calls `claudeSkillStatus()` with no argument, so the function's `explicit` parameter is dead and doctor always reports against `~/.claude/skills` regardless. Read-only, so it's a reporting asymmetry rather than a stray write — a consumer using `--skills-dir` gets a permanent `optional-missing` for a skill they have installed. Adding the flag to `doctor` is a CLI-surface change, so I left it for you.

## For your decision — not changed

`src/cli/generators/docs-site.ts:391` emits `uses: rtorcato/repo-tooling/.github/workflows/docs-deploy.yml@main` into the **consumer's** CI. That is a real, unpinned cross-repo dependency: any push to `main` here changes their build, and it's a supply-chain surface they don't control. Pinning to a tag or a SHA is the conventional answer, but it's a maintenance decision (a SHA needs Dependabot or manual bumps to stay current), so the code is untouched.

## Out of scope, per the issue

`@rtorcato/...` in the preset matchers (`src/languages/js/checks.ts`, `src/base/checks.ts`) is correct and was not touched.

## Verification

`biome check src scripts`, `tsc --noEmit`, `vitest run` (1006 tests, 62 files) all pass. `node scripts/integration/no-dotfiles.mjs` passes locally on macOS; CI will be its first Linux run.
