### PR TITLE
fix(setup): use inquirer's `select` type so the wizard can run at all

### DIFF
--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -192,7 +192,7 @@ async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
 	const detected = await detectLanguage(targetDir)
 	const { language } = await inquirer.prompt([
 		{
-			type: 'list',
+			type: 'select',
 			name: 'language',
 			message: '🗣️  What is the primary language of this repo?',
 			choices: Object.values(LANGUAGES).map((module) => ({
@@ -273,7 +273,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			validate: (input: string) => input.trim().length > 0 || 'Project name is required',
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'projectType',
 			message: '🏗️  What type of project are you building?',
 			choices: [
@@ -291,7 +291,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			default: true,
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'tsConfig',
 			message: '⚙️  Which TypeScript configuration?',
 			choices: (answers: any) => {
@@ -318,7 +318,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			when: (answers: any) => answers.useTypeScript,
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'lintingTool',
 			message: '🔍 Which linting/formatting tool?',
 			choices: [
@@ -330,7 +330,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			default: 'biome',
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'eslintConfig',
 			message: '🔧 Which ESLint configuration?',
 			choices: (answers: any) => {
@@ -350,7 +350,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			when: (answers: any) => answers.lintingTool !== 'none',
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'testingFramework',
 			message: '🧪 Which testing framework?',
 			choices: [
@@ -363,7 +363,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			default: 'vitest',
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'testEnvironment',
 			message: '🌍 Test environment?',
 			choices: [
@@ -388,7 +388,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			when: (answers: any) => answers.gitHooks,
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'releaseTool',
 			message: '🚀 Automated release tool?',
 			choices: [
@@ -433,7 +433,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			default: true,
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'orchestrator',
 			message: '🚀 Monorepo task orchestrator?',
 			choices: [
@@ -456,7 +456,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				answers.projectType === 'nextjs-app',
 		},
 		{
-			type: 'list',
+			type: 'select',
 			name: 'bundler',
 			message: '📦 Which bundler/build tool?',
 			choices: (answers: any) => {

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -498,4 +498,37 @@ describe('setup language prompt', () => {
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
 		expect(lock.config.language).toBe('js')
 	})
+
+	// #463: every test above spies on `inquirer.prompt`, which replaces the
+	// dispatcher wholesale — so they all passed against a wizard that could not
+	// ask a single question. inquirer v10 renamed `list` to `select`, v14 shipped
+	// in this repo, and `npx repo-tooling setup` died on its first prompt with
+	// `UnknownPromptTypeError` while this suite stayed green.
+	//
+	// The fix is to check the questions against the *installed* inquirer's own
+	// registry rather than a list written down here, so the next rename fails at
+	// the dependency bump instead of in a user's terminal.
+	it('only uses prompt types the installed inquirer registers', async () => {
+		const registered = new Set(Object.keys(inquirer.createPromptModule().prompts))
+		// Guard the oracle itself: an empty registry would pass everything.
+		expect(registered.has('select')).toBe(true)
+
+		const dir = newTmpDir()
+		const spy = mockPrompt({ language: 'js' }, JS_ANSWERS)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+		}
+
+		const asked = spy.mock.calls.flatMap(
+			([questions]) => questions as Array<{ type?: string; name?: string }>
+		)
+		// Without this the assertion below passes vacuously on zero questions.
+		expect(asked.length).toBeGreaterThan(5)
+		expect(
+			asked.filter((q) => q.type && !registered.has(q.type)).map((q) => `${q.name}: ${q.type}`)
+		).toEqual([])
+	})
 })


### PR DESCRIPTION
🤖 *Written by Claude (AI agent) and posted under the owner's account. There is no separate GitHub account for AI agents, so this appears under @rtorcato's avatar.*

Closes #463

## The fix

`type: 'list'` → `type: 'select'`. **10 sites**, not the 11 the issue estimated — all in `src/cli/commands/setup.ts`, and `grep -rn "type: 'list'" src/` now returns nothing.

The `{ name, value }` choice shape is identical between the two types, so nothing else moved.

**No other prompt type is affected.** The only inquirer types this codebase uses are `list`, `confirm` and `input`; v14 registers `confirm` and `input` unchanged. The other `type:` values that turn up in a grep (`boolean`, `string`, `object`, `json`, `module`, `autogenerated`) belong to config schemas, not inquirer.

## Why it shipped, and the part that stops it recurring

Every test in `tests/cli/commands/setup.test.ts` does this:

```ts
const spy = vi.spyOn(inquirer, 'prompt')
```

which replaces the dispatcher wholesale. No prompt type is ever resolved, so 33 tests passed against a wizard that could not ask a single question.

The new test checks the questions against the **installed inquirer's own registry** rather than a list written down in the test:

```ts
const registered = new Set(Object.keys(inquirer.createPromptModule().prompts))
```

so it tracks the dependency instead of drifting from it. Two guards against it passing for the wrong reason:

- `expect(registered.has('select')).toBe(true)` — an empty registry would otherwise wave everything through.
- `expect(asked.length).toBeGreaterThan(5)` — zero collected questions would otherwise satisfy the assertion vacuously.

## Confirmed it can actually fail

Reverted a site and ran it — twice, deliberately, in two different `inquirer.prompt` calls, since collecting only from the first call would still catch the language prompt while missing the nine questions in the JS array:

```
# reverted promptForLanguage (call 0)
AssertionError: expected [ 'language: list' ] to deeply equal []

# reverted projectType, inside the JS question array (call 1)
AssertionError: expected [ 'projectType: list' ] to deeply equal []
```

Both restored. The failure names the offending question, so the next person gets told which one rather than just that something is wrong.

## Scope

Deliberately untouched: `src/cli/commands/setup-presets.ts` and anything to do with TTY-awareness or a `minimal` preset. That is #461, which is held behind this PR precisely because routing people into the wizard is pointless while the wizard crashes.

One thing worth flagging about this repo's own hygiene rather than this diff: `pnpm lint` covers `src scripts` only, so `tests/` is not formatted by the pre-commit hook and ~20 test files are currently unformatted relative to `biome check`. Running `biome check --write tests` touches all of them. Not fixed here — it would bury a 43-line fix under a few hundred lines of reformatting — but it is a real gap, and the pre-commit hook will not catch a badly formatted test.

## Verification

`vitest run` — 996 passed, 18 skipped, 62 files. `biome lint --config-path=biome.json src scripts` clean. `tsc --noEmit --project src/cli/tsconfig.json` clean.
