### PR TITLE
feat(setup): review --preset in a terminal and add a minimal preset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Every command supports `--json` and a non-interactive mode. Combine with `--yes`
 
 | Command | Non-interactive | JSON output | Use case |
 |---|---|---|---|
-| `setup --preset <name>` | ✅ | `--dry-run` only | Scaffold a new project. Presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`. |
+| `setup --preset <name>` | ✅ (non-TTY, or with `--yes`) | `--dry-run` only | Scaffold a new project. Presets: `minimal`, `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`. In an interactive terminal it first prints the file list and lets you deselect; pass `--yes` for the one-shot behaviour. |
 | `setup --config <path>` | ✅ | `--dry-run` only | Scaffold with a full `ProjectConfig` JSON file. See `setup --config-schema`. |
 | `setup --config-schema` | ✅ | ✅ (JSON Schema) | Print the JSON Schema for `ProjectConfig`. Use to validate configs before scaffolding. |
 | `setup --dry-run` | ✅ | ✅ | Print resolved config + file list without writing. Pair with `--preset` or `--config`. |

--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ npx @rtorcato/repo-tooling setup
 Non-interactive — scaffold from a named preset in one shot (CI-friendly):
 
 ```bash
-npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
-# presets: library | web-app | node-api | nextjs-app | react-app | swift-library
+npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install --yes
+# presets: minimal | library | web-app | node-api | nextjs-app | react-app | swift-library
 ```
+
+Run without `--yes` in a terminal and the preset first prints every file it would
+write and lets you uncheck the parts you don't want (git hooks, commitlint,
+releases, Dependabot/CodeQL, badges, AI agent rules). Piped or redirected — CI —
+it writes everything in one shot, exactly as before. `minimal` is tsconfig +
+Biome + Vitest and nothing else.
 
 `swift-library` scaffolds a SwiftPM package (manifest, sources, tests, SwiftLint,
 Periphery, macOS CI) instead of an npm one — see the

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -13,10 +13,16 @@ npx @rtorcato/repo-tooling setup -d ./my-app  # specific directory
 npx @rtorcato/repo-tooling setup --skip-install  # skip npm/pnpm install
 ```
 
-Add `--preset <name>` to skip the prompts entirely: `library`, `web-app`,
-`node-api`, `nextjs-app`, `react-app`, or `swift-library`. The Swift preset
-scaffolds a SwiftPM package rather than an npm one — see the
-[Swift guide](./swift.md).
+Add `--preset <name>` to skip the wizard: `minimal`, `library`, `web-app`,
+`node-api`, `nextjs-app`, `react-app`, or `swift-library`. `minimal` is tsconfig
++ Biome + Vitest and nothing else. The Swift preset scaffolds a SwiftPM package
+rather than an npm one — see the [Swift guide](./swift.md).
+
+In a terminal, `--preset` prints the file list it resolved and lets you uncheck
+the extras (git hooks, commitlint, releases, Dependabot/CodeQL, badges, AI agent
+rules) before anything is written. Pass `--yes` to write it all in one shot. When
+stdin or stdout is piped or redirected — CI — the review is skipped
+automatically.
 
 ## copy \<name\>
 

--- a/apps/docs/docs/guides/for-ai-agents.md
+++ b/apps/docs/docs/guides/for-ai-agents.md
@@ -14,10 +14,10 @@ All commands take `-d <path>` for the target directory (defaults to `process.cwd
 ### `setup` — scaffold a new project
 
 ```bash
-# Sane defaults per project type (no prompts)
-npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
-npx @rtorcato/repo-tooling setup --preset react-app -d ./my-app --skip-install
-npx @rtorcato/repo-tooling setup --preset nextjs-app -d ./my-site --skip-install
+# Sane defaults per project type. --yes guarantees no prompts even from a terminal.
+npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install --yes
+npx @rtorcato/repo-tooling setup --preset react-app -d ./my-app --skip-install --yes
+npx @rtorcato/repo-tooling setup --preset nextjs-app -d ./my-site --skip-install --yes
 
 # Full control via a JSON config file
 npx @rtorcato/repo-tooling setup --config ./project.json --skip-install
@@ -29,7 +29,12 @@ npx @rtorcato/repo-tooling setup --config-schema > project-config.schema.json
 npx @rtorcato/repo-tooling setup --preset library --dry-run
 ```
 
-Available presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`.
+Available presets: `minimal`, `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`.
+
+`minimal` is tsconfig + Biome + Vitest and nothing else. Pass `--yes` whenever a
+human might be at the terminal: without it, `--preset` prints its file list and
+opens a deselection prompt. A piped or redirected stream is treated as CI and
+never prompts.
 
 `swift-library` scaffolds a SwiftPM package — no `package.json`, no install step, and the file list is entirely different. See the [Swift guide](./swift.md).
 
@@ -150,13 +155,13 @@ Use this to discover what's available and to map between named tools and the `fi
 
 ```bash
 # 1. Decide the project type (or read from existing pkg deps)
-PRESET=library  # or web-app, node-api, nextjs-app, react-app, swift-library
+PRESET=library  # or minimal, web-app, node-api, nextjs-app, react-app, swift-library
 
 # 2. Preview
 npx @rtorcato/repo-tooling setup --preset $PRESET --dry-run
 
 # 3. Scaffold
-npx @rtorcato/repo-tooling setup --preset $PRESET -d . --skip-install
+npx @rtorcato/repo-tooling setup --preset $PRESET -d . --skip-install --yes
 
 # 4. Install deps yourself (the CLI skips install when --skip-install is set)
 pnpm install

--- a/apps/docs/docs/guides/getting-started.mdx
+++ b/apps/docs/docs/guides/getting-started.mdx
@@ -96,10 +96,14 @@ Python and Perl write nothing and point you at `doctor`. For **Python** that's n
 Skip the prompts entirely by scaffolding from a named preset:
 
 ```bash
-npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
+npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install --yes
 ```
 
-Presets: `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`.
+Presets: `minimal`, `library`, `web-app`, `node-api`, `nextjs-app`, `react-app`, `swift-library`.
+
+`minimal` is tsconfig + Biome + Vitest and nothing else — no git hooks, no commitlint, no release pipeline, no Dependabot/CodeQL, no AI agent files.
+
+When stdin and stdout are both a terminal, `--preset` first prints every file it would write and lets you uncheck the parts you don't want. Piped or redirected — CI — it writes everything in one shot. `--yes` forces the one-shot path in a terminal too.
 
 `swift-library` scaffolds a SwiftPM package instead of an npm one — no `package.json`, no install step. See the [Swift guide](./swift.md) for the full file list.
 

--- a/skills/repo-tooling/SKILL.md
+++ b/skills/repo-tooling/SKILL.md
@@ -47,8 +47,9 @@ npx @rtorcato/repo-tooling fix <target> --diff           # unified diff before c
 ## Scaffolding a new project
 
 ```bash
-# Quick: from a named preset (library | web-app | node-api | nextjs-app | react-app | swift-library)
-npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
+# Quick: from a named preset (minimal | library | web-app | node-api | nextjs-app | react-app | swift-library)
+# --yes skips the interactive file-list review; without it, a terminal lets you deselect.
+npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install --yes
 
 # Full control: validate a config against the schema, preview, then write
 npx @rtorcato/repo-tooling setup --config-schema > project-config.schema.json

--- a/src/cli/commands/setup-presets.ts
+++ b/src/cli/commands/setup-presets.ts
@@ -3,6 +3,7 @@ import { BIOME_CONFIG } from '../generators/linting.js'
 import type { ProjectConfig } from './setup.js'
 
 export type PresetName =
+	| 'minimal'
 	| 'library'
 	| 'web-app'
 	| 'node-api'
@@ -11,6 +12,7 @@ export type PresetName =
 	| 'swift-library'
 
 export const PRESET_NAMES: readonly PresetName[] = [
+	'minimal',
 	'library',
 	'web-app',
 	'node-api',
@@ -34,6 +36,33 @@ const BASE: Omit<ProjectConfig, 'projectName' | 'projectType' | 'typescript' | '
 
 export function buildPresetConfig(name: PresetName, projectName: string): ProjectConfig {
 	switch (name) {
+		// tsconfig + biome + vitest, nothing else (#461). Deliberately not spread
+		// from BASE: BASE hardcodes git hooks, commitlint, security automation,
+		// badges and the AI agent files, and every other case only ever adds to
+		// it — so no preset built on BASE can produce a small repo.
+		//
+		// `node-api` is the only projectType that adds nothing of its own:
+		// `library` would pull in publint, attw, a size-limit budget and a
+		// dist/-rooted exports map that `bundler: 'none'` never builds, and the
+		// three app types each seed a framework. It says "plain Node package",
+		// which is what this preset scaffolds.
+		case 'minimal':
+			return {
+				projectName,
+				language: 'js',
+				projectType: 'node-api',
+				typescript: { enabled: true, config: 'base' },
+				linting: { tool: 'biome' },
+				formatting: { tool: 'biome' },
+				testing: { framework: 'vitest', environment: 'node' },
+				gitHooks: false,
+				commitLint: false,
+				semanticRelease: false,
+				securityAutomation: false,
+				bundler: 'none',
+				badges: false,
+				aiSetup: false,
+			}
 		case 'library':
 			return {
 				...BASE,
@@ -227,7 +256,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 	if (config.language === 'swift') return swiftFileList(config)
 
 	const files: string[] = ['package.json', '.repo-tooling.json']
-	files.push('.editorconfig', '.nvmrc', 'knip.json', '.vscode/extensions.json')
+	files.push('.editorconfig', '.nvmrc', '.gitignore', 'knip.json', '.vscode/extensions.json')
 	if (config.typescript.enabled) {
 		files.push('tsconfig.json', 'reset.d.ts')
 	}
@@ -261,7 +290,7 @@ export function computeFileList(config: ProjectConfig): string[] {
 		)
 	}
 	if (config.gitHooks) {
-		files.push('.husky/pre-commit', '.gitignore')
+		files.push('.husky/pre-commit')
 	}
 	if (config.commitLint) {
 		files.push('.husky/commit-msg', 'commitlint.config.mjs')

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -79,6 +79,65 @@ export interface SetupOptions {
 	preset?: string
 	dryRun?: boolean
 	configSchema?: boolean
+	/** Accept a `--preset` as-is instead of reviewing it in an interactive terminal. */
+	yes?: boolean
+}
+
+/**
+ * The opinionated extras a preset turns on, in the order they're offered for
+ * review. Each one writes files (or a README block) the user never asked for by
+ * name, which is the complaint in #461.
+ */
+const REVIEWABLE_FEATURES = [
+	{ key: 'gitHooks', label: 'Git hooks (Husky + lint-staged)' },
+	{ key: 'commitLint', label: 'Conventional commit linting (commitlint)' },
+	{ key: 'semanticRelease', label: 'Automated releases (semantic-release)' },
+	{ key: 'securityAutomation', label: 'Security automation (Dependabot + CodeQL)' },
+	{ key: 'badges', label: 'README status badges' },
+	{ key: 'aiSetup', label: 'AI agent rules (AGENTS.md, CLAUDE.md, Cursor, Copilot)' },
+] as const satisfies ReadonlyArray<{ key: keyof ProjectConfig; label: string }>
+
+/**
+ * A preset run may only ask questions when a human is on both ends of the pipe.
+ * Redirect either direction and this is CI — the case `--preset` exists for —
+ * where the one-shot behaviour has to stay exactly as it was.
+ */
+function isInteractiveTerminal(): boolean {
+	return process.stdin.isTTY === true && process.stdout.isTTY === true
+}
+
+/**
+ * Show what the preset resolved to and let the user drop parts of it before a
+ * single file is written (#461).
+ */
+async function reviewPresetConfig(config: ProjectConfig): Promise<ProjectConfig> {
+	const files = computeFileList(config)
+	console.log(chalk.cyan(`\n📄 This preset writes ${files.length} files:\n`))
+	for (const file of files) console.log(chalk.gray(`   ${file}`))
+	console.log()
+
+	const enabled = REVIEWABLE_FEATURES.filter((feature) => config[feature.key] === true)
+	if (enabled.length === 0) return config
+
+	const { features } = await inquirer.prompt([
+		{
+			type: 'checkbox',
+			name: 'features',
+			message: '🧹 Uncheck anything you do not want:',
+			choices: enabled.map((feature) => ({
+				name: feature.label,
+				value: feature.key,
+				checked: true,
+			})),
+		},
+	])
+
+	const kept = new Set(features as string[])
+	const reviewed = { ...config }
+	for (const feature of enabled) {
+		if (!kept.has(feature.key)) reviewed[feature.key] = false
+	}
+	return reviewed
 }
 
 /** `null` means the run was declined, not that it failed — see promptForConfig. */
@@ -111,7 +170,9 @@ async function resolveConfig(options: SetupOptions): Promise<ProjectConfig | nul
 			throw new Error(`Unknown preset: ${options.preset}. Available: ${PRESET_NAMES.join(', ')}`)
 		}
 		const projectName = path.basename(path.resolve(options.directory))
-		return buildPresetConfig(options.preset as PresetName, projectName)
+		const config = buildPresetConfig(options.preset as PresetName, projectName)
+		if (options.dryRun || options.yes || !isInteractiveTerminal()) return config
+		return reviewPresetConfig(config)
 	}
 	return promptForConfig(path.resolve(options.directory))
 }

--- a/src/cli/generators/index.ts
+++ b/src/cli/generators/index.ts
@@ -69,10 +69,11 @@ export async function generateConfigs(config: ProjectConfig, targetDir: string) 
 		await generateTestingConfigs(config, targetDir)
 	}
 
-	// Generate git configurations
-	if (config.gitHooks || config.commitLint) {
-		await generateGitConfigs(config, targetDir)
-	}
+	// Unconditional: generateGitConfigs already gates husky and commitlint on
+	// their own flags, and the .gitignore it also writes has nothing to do with
+	// either. Gating the whole call meant any scaffold that declined git hooks —
+	// which is every `minimal` run (#461) — got no .gitignore at all.
+	await generateGitConfigs(config, targetDir)
 
 	// Generate GitHub Actions workflow
 	await generateGitHubActions(config, targetDir)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -34,6 +34,10 @@ program
 	.option('--skip-install', 'Skip installing dependencies')
 	.option('--preset <name>', 'Skip prompts; use defaults for a project type')
 	.option(
+		'-y, --yes',
+		'With --preset in a terminal, skip the file-list review and write everything'
+	)
+	.option(
 		'--config <path>',
 		'Skip prompts; read a ProjectConfig or .repo-tooling.json lockfile from <path>'
 	)

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -294,6 +294,230 @@ describe('setup --preset', () => {
 	})
 })
 
+// #461: BASE hardcoded git hooks, commitlint, security automation, badges and
+// the AI agent files, and every preset only ever added to it — so no preset
+// could produce a small repo. `minimal` is built without spreading BASE.
+describe('setup --preset minimal', () => {
+	it('turns off every opinionated extra', () => {
+		const config = buildPresetConfig('minimal', 'demo')
+		expect(config.gitHooks).toBe(false)
+		expect(config.commitLint).toBe(false)
+		expect(config.semanticRelease).toBe(false)
+		expect(config.securityAutomation).toBe(false)
+		expect(config.badges).toBe(false)
+		expect(config.aiSetup).toBe(false)
+		expect(config.bundler).toBe('none')
+		expect(validateProjectConfig(config).valid).toBe(true)
+	})
+
+	it('lists tsconfig + biome + vitest and nothing else', () => {
+		const files = computeFileList(buildPresetConfig('minimal', 'demo'))
+		expect(files).toContain('tsconfig.json')
+		expect(files).toContain('biome.json')
+		expect(files).toContain('vitest.config.ts')
+		for (const unwanted of [
+			'.husky/pre-commit',
+			'.husky/commit-msg',
+			'commitlint.config.mjs',
+			'release.config.mjs',
+			'.github/dependabot.yml',
+			'.github/workflows/codeql.yml',
+			'AGENTS.md',
+			'CLAUDE.md',
+			'tsup.config.ts',
+			'.size-limit.json',
+		]) {
+			expect(files, unwanted).not.toContain(unwanted)
+		}
+	})
+
+	it('scaffolds only those files', async () => {
+		const dir = newTmpDir()
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'minimal', skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+		}
+		expect(await fs.pathExists(join(dir, 'tsconfig.json'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'biome.json'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'vitest.config.ts'))).toBe(true)
+		// A scaffold with no .gitignore commits node_modules on the first push.
+		expect(await fs.pathExists(join(dir, '.gitignore'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.husky'))).toBe(false)
+		expect(await fs.pathExists(join(dir, 'AGENTS.md'))).toBe(false)
+		expect(await fs.pathExists(join(dir, '.github', 'dependabot.yml'))).toBe(false)
+
+		// The library shape would add publint/attw/size-limit scripts plus a
+		// dist/-rooted exports map that `bundler: 'none'` never builds.
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(Object.keys(pkg.scripts)).not.toContain('publint')
+		expect(Object.keys(pkg.scripts)).not.toContain('attw')
+		expect(Object.keys(pkg.scripts)).not.toContain('size-limit')
+		expect(Object.keys(pkg.scripts)).not.toContain('release')
+		expect(Object.keys(pkg.scripts)).not.toContain('prepare')
+		expect(pkg.exports).toBeUndefined()
+		for (const dep of [
+			'husky',
+			'lint-staged',
+			'@commitlint/cli',
+			'semantic-release',
+			'size-limit',
+			'@arethetypeswrong/cli',
+		]) {
+			expect(Object.keys(pkg.devDependencies ?? {}), dep).not.toContain(dep)
+		}
+	})
+})
+
+// #461: in a terminal a preset now shows its file list and lets the user
+// deselect. Non-TTY is CI — the case --preset was added for — and must keep the
+// exact one-shot behaviour.
+describe('setup --preset review prompt', () => {
+	/** Pretend both ends of the pipe are a terminal; returns the undo. */
+	function fakeTTY(): () => void {
+		const saved = [process.stdin, process.stdout].map(
+			(stream) => [stream, Object.getOwnPropertyDescriptor(stream, 'isTTY')] as const
+		)
+		for (const [stream] of saved) {
+			Object.defineProperty(stream, 'isTTY', { value: true, configurable: true })
+		}
+		return () => {
+			for (const [stream, descriptor] of saved) {
+				if (descriptor) Object.defineProperty(stream, 'isTTY', descriptor)
+				else delete (stream as unknown as { isTTY?: boolean }).isTTY
+			}
+		}
+	}
+
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	it('does not prompt when stdin/stdout are not a terminal', async () => {
+		const dir = newTmpDir()
+		const spy = vi.spyOn(inquirer, 'prompt')
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'library', skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+		}
+		expect(spy).not.toHaveBeenCalled()
+		// The one-shot scaffold is unchanged: everything BASE turns on still lands.
+		expect(await fs.pathExists(join(dir, '.husky', 'pre-commit'))).toBe(true)
+		expect(await fs.pathExists(join(dir, 'AGENTS.md'))).toBe(true)
+		expect(await fs.pathExists(join(dir, '.github', 'dependabot.yml'))).toBe(true)
+	})
+
+	it('offers a checkbox of the preset extras, all pre-checked', async () => {
+		const dir = newTmpDir()
+		const restoreTTY = fakeTTY()
+		const spy = vi
+			.spyOn(inquirer, 'prompt')
+			.mockImplementation((async () => ({ features: [] })) as never)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'library', skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+			restoreTTY()
+		}
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const [questions] = spy.mock.calls[0] as [Array<Record<string, unknown>>]
+		expect(questions).toHaveLength(1)
+		const question = questions[0]
+		// inquirer v14 has no `list`; a multi-select is `checkbox` (#463).
+		expect(Object.keys(inquirer.createPromptModule().prompts)).toContain(question.type)
+		expect(question.type).toBe('checkbox')
+		const choices = question.choices as Array<{ value: string; checked: boolean }>
+		expect(choices.map((c) => c.value)).toEqual([
+			'gitHooks',
+			'commitLint',
+			'semanticRelease',
+			'securityAutomation',
+			'badges',
+			'aiSetup',
+		])
+		expect(choices.every((c) => c.checked)).toBe(true)
+	})
+
+	it('writes nothing for the features the user unchecks', async () => {
+		const dir = newTmpDir()
+		const restoreTTY = fakeTTY()
+		vi.spyOn(inquirer, 'prompt').mockImplementation((async () => ({
+			features: ['semanticRelease', 'badges'],
+		})) as never)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'library', skipInstall: true })
+		} finally {
+			logSpy.mockRestore()
+			restoreTTY()
+		}
+		expect(await fs.pathExists(join(dir, '.husky'))).toBe(false)
+		expect(await fs.pathExists(join(dir, 'commitlint.config.mjs'))).toBe(false)
+		expect(await fs.pathExists(join(dir, 'AGENTS.md'))).toBe(false)
+		expect(await fs.pathExists(join(dir, '.github', 'dependabot.yml'))).toBe(false)
+		// Kept, so still written.
+		expect(await fs.pathExists(join(dir, 'release.config.mjs'))).toBe(true)
+
+		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(lock.config.gitHooks).toBe(false)
+		expect(lock.config.aiSetup).toBe(false)
+		expect(lock.config.semanticRelease).toBe(true)
+	})
+
+	it('prints the resolved file list before asking', async () => {
+		const dir = newTmpDir()
+		const restoreTTY = fakeTTY()
+		vi.spyOn(inquirer, 'prompt').mockImplementation((async () => ({ features: [] })) as never)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		let output = ''
+		try {
+			await setupProject({ directory: dir, preset: 'library', skipInstall: true })
+			output = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+		} finally {
+			logSpy.mockRestore()
+			restoreTTY()
+		}
+		for (const file of computeFileList(buildPresetConfig('library', 'demo'))) {
+			expect(output, file).toContain(file)
+		}
+	})
+
+	it('skips the review with --yes even in a terminal', async () => {
+		const dir = newTmpDir()
+		const restoreTTY = fakeTTY()
+		const spy = vi.spyOn(inquirer, 'prompt')
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'library', skipInstall: true, yes: true })
+		} finally {
+			logSpy.mockRestore()
+			restoreTTY()
+		}
+		expect(spy).not.toHaveBeenCalled()
+		expect(await fs.pathExists(join(dir, 'AGENTS.md'))).toBe(true)
+	})
+
+	it('skips the review with --dry-run even in a terminal', async () => {
+		const dir = newTmpDir()
+		const restoreTTY = fakeTTY()
+		const spy = vi.spyOn(inquirer, 'prompt')
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, preset: 'library', skipInstall: true, dryRun: true })
+		} finally {
+			logSpy.mockRestore()
+			restoreTTY()
+		}
+		expect(spy).not.toHaveBeenCalled()
+		expect(await fs.readdir(dir)).toEqual([])
+	})
+})
+
 describe('setup --config', () => {
 	it('reads a JSON ProjectConfig and uses it instead of prompts', async () => {
 		const dir = newTmpDir()

--- a/tooling/claude/repo-tooling.md
+++ b/tooling/claude/repo-tooling.md
@@ -51,8 +51,9 @@ npx @rtorcato/repo-tooling fix <target> --diff           # unified diff before c
 ## Scaffolding a new project
 
 ```bash
-# Quick: from a named preset (library | web-app | node-api | nextjs-app | react-app | swift-library)
-npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install
+# Quick: from a named preset (minimal | library | web-app | node-api | nextjs-app | react-app | swift-library)
+# --yes skips the interactive file-list review; without it, a terminal lets you deselect.
+npx @rtorcato/repo-tooling setup --preset library -d ./my-lib --skip-install --yes
 
 # Full control: validate a config against the schema, preview, then write
 npx @rtorcato/repo-tooling setup --config-schema > project-config.schema.json


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop. Written by an AI agent and posted under the owner's account; not a human message.*

Closes #461

## What changed

**1. TTY-aware `--preset`.** When `process.stdin.isTTY` and `process.stdout.isTTY` are both true and `--yes` is absent, `setup --preset` now prints the file list `computeFileList` resolved and opens a `checkbox` prompt (a type in the installed inquirer v14 registry — not `list`, per #463) letting the user drop git hooks, commitlint, semantic-release, Dependabot/CodeQL, badges and the AI agent files before anything is written.

Piped or redirected either direction is treated as CI and keeps today's exact one-shot behaviour. `--dry-run` and the new `-y, --yes` also bypass the review.

**2. A `minimal` preset.** tsconfig + Biome + Vitest, nothing else — built without spreading `BASE`, the way `swift-library` already is.

It uses `projectType: 'node-api'` rather than `'library'`. `library` is the only project type that adds surface of its own: `publint` / `attw` / `size-limit` scripts, the `@arethetypeswrong/cli` + `size-limit` deps, `.size-limit.json`, and a `dist/`-rooted `exports` map that `bundler: 'none'` never builds. `node-api` adds nothing, so it is the honest "plain Node package" shape. Flagging the naming in case you would rather I add a neutral project type instead.

**3. One root-cause fix picked up on the way.** `generateConfigs` only called `generateGitConfigs` when `gitHooks || commitLint`, but that function also writes `.gitignore`, which has nothing to do with either. So *every* `minimal` run — and every deselection of git hooks in the new prompt — would have scaffolded a repo with no `.gitignore`. The call is now unconditional (it already gates husky and commitlint internally). This also fixes the pre-existing case where the wizard's "no to hooks, no to commitlint" answers produced the same hole. `.gitignore` moved to the unconditional baseline in `computeFileList` to match.

## For your decision

**Is proposal 1 a breaking change — `feat:` or `feat!:`?**

I committed it as `feat:` and did not decide this. The argument either way:

- **Not breaking:** the non-TTY path is byte-identical, and non-TTY is the documented reason `--preset` exists. Every scripted/CI invocation is unaffected.
- **Breaking:** an interactive `--preset` run without a flag now stops and asks, where before it wrote and exited. That is a behaviour change to a documented path, and anyone running `--preset` by hand in a terminal (or from a tool that keeps a TTY attached) will now block on a prompt.

Retitle to `feat!:` before merging if you read it the second way. Note this decides whether a release goes out.

## Tests

`tests/cli/commands/setup.test.ts`, +224 lines:

- `minimal` flags, its file list, and its scaffold on disk — including that `package.json` has no `publint`/`attw`/`size-limit`/`release`/`prepare` scripts, no `exports`, and none of husky / lint-staged / commitlint / semantic-release / size-limit / attw in `devDependencies`.
- Non-TTY `--preset` calls `inquirer.prompt` **zero** times and still writes `.husky/pre-commit`, `AGENTS.md` and `.github/dependabot.yml` — this fails if the non-TTY path ever starts prompting.
- The TTY path asserts on the *questions handed to inquirer*: exactly one question, `type: 'checkbox'`, the type is present in the installed `inquirer.createPromptModule().prompts` registry, and the six choices are all there and pre-checked.
- Unchecking features writes none of their files and records the `false` in `.repo-tooling.json`.
- The file list is printed before the prompt.
- `--yes` and `--dry-run` each skip the review in a faked TTY.

TTY is faked by `Object.defineProperty` on the real `process.stdin`/`process.stdout`, restored in `finally`, so the tests exercise the real detection rather than a seam.

## Verification

- `biome lint --config-path=biome.json src scripts` — clean
- `biome check` on every file touched — clean (`check --write` was **not** run on `tests/`; that is #467)
- `tsc --noEmit --project src/cli/tsconfig.json` — clean
- `vitest run` — 1005 passed, 18 skipped, 61 files

## Left alone deliberately

- The scaffold's own output failing `biome check` — #467.
- The `biome.json` `$schema` version pin vs the installed Biome — #468.
- `minimal` is **not** wired into `scripts/integration/preset-lifecycle.mjs`, so the CI preset loop does not run a real install/build/verify against it. Its config is a strict subset of presets that are covered, and the unit tests assert the emitted `package.json` and file set, but say the word and I will add it.
