### PR TITLE
feat(security): auto-merge github-actions patch and minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,11 @@ updates:
         update-types:
           - minor
           - patch
-      # The only tier that auto-merges on green — dev tooling never reaches a
-      # consumer of the published package.
+      # The tier that can auto-merge on green. "development" is Dependabot's
+      # classification, not a safety property: a package listed in both
+      # devDependencies and peerDependencies lands here, and peer deps are part
+      # of a published package's contract (#458). The auto-merge workflow
+      # re-checks every name against the manifests rather than trusting this.
       dev-minor:
         dependency-type: development
         update-types:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -58,10 +58,17 @@ jobs:
       # Belt and braces: the dev-minor group is already declared minor+patch in
       # dependabot.yml, but this workflow is the security gate and shouldn't
       # trust a config file a consumer repo can edit independently.
-      - name: Auto-merge dev-dependency patch and minor updates
+      #
+      # github-actions bumps are ungrouped, so they report an empty
+      # dependency-group and are matched by ecosystem instead (#452). They reach
+      # no consumer of the published package, and their squash subject is
+      # "ci(deps): …", which cuts no release. Majors still fall through to a
+      # human — the update-type clause below applies to them too.
+      - name: Auto-merge dev-dependency and CI action patch and minor updates
         if: |
           steps.gate.outputs.safe == 'true' &&
-          steps.metadata.outputs.dependency-group == 'dev-minor' &&
+          (steps.metadata.outputs.dependency-group == 'dev-minor' ||
+          steps.metadata.outputs.package-ecosystem == 'github-actions') &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"

--- a/apps/docs/docs/guides/dependabot-strategy.md
+++ b/apps/docs/docs/guides/dependabot-strategy.md
@@ -28,18 +28,20 @@ Dependabot opens roughly **3–4 PRs per cycle** instead of one per package:
 | `production-minor` | runtime `dependencies` | minor, patch | ❌ manual |
 | `dev-minor` | `devDependencies` | minor, patch | ✅ on green, if nothing in it ships |
 | `major-updates` | all packages | major | ❌ manual |
-| `github-actions` | workflow actions | all | ❌ manual |
+| `github-actions` | workflow actions | minor, patch | ✅ on green |
+| `github-actions` | workflow actions | major | ❌ manual |
 
-## 2. Auto-merge — dev dependencies only
+## 2. Auto-merge — dev dependencies and CI actions
 
-Patch and minor updates **of `devDependencies`** merge themselves once CI is
-green — no human in the loop. Implemented by
+Patch and minor updates **of `devDependencies`** and **of GitHub Actions** merge
+themselves once CI is green — no human in the loop. Implemented by
 `.github/workflows/dependabot-automerge.yml` using `dependabot/fetch-metadata` +
-`gh pr merge --auto --squash`, gated on **both** `dependency-group == 'dev-minor'`
-and `version-update:semver-patch` / `version-update:semver-minor`.
+`gh pr merge --auto --squash`, gated on the consumer-facing check below, **either**
+`dependency-group == 'dev-minor'` **or** `package-ecosystem == 'github-actions'`,
+**and** `version-update:semver-patch` / `version-update:semver-minor`.
 
-Everything else waits for a human, and the gate **fails closed**: a PR outside a
-group reports an empty `dependency-group` and so never matches.
+Everything else waits for a human, and the gate **fails closed**: an npm PR
+outside a group reports an empty `dependency-group` and so never matches.
 
 > **The group name is not the gate.** `dependency-type: development` is
 > Dependabot's classification, and it files a package listed in *both*
@@ -58,13 +60,30 @@ group reports an empty `dependency-group` and so never matches.
 > **Production bumps are deliberately excluded.** A minor bump to a runtime
 > dependency of a published package ships to every consumer on the next release.
 > Auto-merging those on green CI alone means the 7-day `cooldown` is the only
-> thing between a compromised upstream release and `main`. GitHub Actions bumps
-> are excluded for the same reason — a compromised action runs in CI holding
-> `GITHUB_TOKEN`.
+> thing between a compromised upstream release and `main`.
 >
 > The gate names the group that `dependabot.yml` declares, so the two files are
 > a paired unit: rename a group in one and auto-merge silently stops (which is
 > the safe direction, but still drift — `doctor` flags it).
+
+> **CI actions auto-merge; the counter-argument is real** (#452). Action bumps
+> are ungrouped, so they are matched on `package-ecosystem` rather than a group
+> name. They reach no consumer of the published package, and the scaffolded
+> `commit-message.prefix: ci` means the squash subject is `ci(deps): …`, which
+> cuts no release under semantic-release.
+>
+> Against that: a compromised action runs *in CI holding `GITHUB_TOKEN`*, which
+> is arguably a sharper surface than a dev dependency, not a softer one. The
+> mitigations relied on instead are the majors exclusion (an
+> `actions/checkout@v7 → v8` still waits for a human) and required status checks.
+> Note that `cooldown` is declared per `updates:` entry and the canonical
+> `github-actions` entry does not declare one, so it does **not** delay an action
+> bump the way it delays an npm bump.
+>
+> The alternative — leaving them to a human — was weighed and rejected: routine
+> `actions/checkout` bumps waiting on a human across every scaffolded repo is the
+> friction that ends in rubber-stamping, which weakens the gate for everything
+> else too.
 
 > **Requires branch protection.** `gh pr merge --auto` only gates correctly when
 > the repo has auto-merge enabled and `main` has required status checks
@@ -117,6 +136,10 @@ CI. Closing stale PRs is the normal, expected hygiene step — not a loss of wor
   **both** into new projects.
 - `repo-tooling doctor` flags drift from the canonical config; `repo-tooling fix`
   re-applies it. A strategy change propagates to every repo via `fix`.
+
+**Semver precedent** (#452): narrowing what auto-merges goes out as `fix` — the
+old behaviour was the bug, so removing it is a fix rather than a feature removal.
+That is how #447 shipped and how the next security narrowing should ship.
 
 ## 7. Repo-local `ignore:` rules
 

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -313,6 +313,12 @@ export async function checkDependabot(dir: string): Promise<CheckResult> {
 						'auto-merge workflow trusts the dev-minor group name (missing peerDependencies check)'
 					)
 				}
+				// #452: a repo that took the #423 pair has CI action bumps waiting on a
+				// human for no benefit — they reach no consumer. Drift in the
+				// convenience direction, not the safety one, but still drift.
+				if (!automerge.includes("package-ecosystem == 'github-actions'")) {
+					deltas.push('auto-merge workflow leaves CI action bumps to a human (#452)')
+				}
 			} else {
 				deltas.push('missing dependabot-automerge workflow')
 			}

--- a/src/cli/generators/security.ts
+++ b/src/cli/generators/security.ts
@@ -130,13 +130,20 @@ export function dependabotIgnoreRules(content: string): string[] {
 }
 
 /**
- * Auto-merges patch + minor Dependabot PRs **from the `dev-minor` group only**
- * once CI is green. Requires branch protection with required status checks on
- * the target branch — without it, \`gh pr merge --auto\` never fires.
+ * Auto-merges patch + minor Dependabot PRs from the \`dev-minor\` group **and the
+ * \`github-actions\` ecosystem** once CI is green. Requires branch protection with
+ * required status checks on the target branch — without it, \`gh pr merge --auto\`
+ * never fires.
  *
  * Everything else falls through to a human: production bumps ship to consumers
  * of a published package (#423), majors are breaking by definition, and an
- * ungrouped PR reports an empty \`dependency-group\`, so the gate fails closed.
+ * ungrouped npm PR reports an empty \`dependency-group\`, so the gate fails closed.
+ *
+ * CI action bumps are the one ungrouped case that is allowed through, matched on
+ * \`package-ecosystem\` (#452): they reach no consumer of the published package
+ * and land as \`ci(deps): …\`, which cuts no release. The counter-argument is real
+ * — a compromised action runs in CI holding \`GITHUB_TOKEN\` — so the majors
+ * exclusion and required status checks are doing the work here.
  *
  * The group name is the one \`dependabotConfig()\` writes — the two files are a
  * paired unit and have to move together.
@@ -208,10 +215,17 @@ jobs:
       # Belt and braces: the dev-minor group is already declared minor+patch in
       # dependabot.yml, but this workflow is the security gate and shouldn't
       # trust a config file a consumer repo can edit independently.
-      - name: Auto-merge dev-dependency patch and minor updates
+      #
+      # github-actions bumps are ungrouped, so they report an empty
+      # dependency-group and are matched by ecosystem instead (#452). They reach
+      # no consumer of the published package, and their squash subject is
+      # "ci(deps): …", which cuts no release. Majors still fall through to a
+      # human — the update-type clause below applies to them too.
+      - name: Auto-merge dev-dependency and CI action patch and minor updates
         if: |
           steps.gate.outputs.safe == 'true' &&
-          steps.metadata.outputs.dependency-group == 'dev-minor' &&
+          (steps.metadata.outputs.dependency-group == 'dev-minor' ||
+          steps.metadata.outputs.package-ecosystem == 'github-actions') &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --squash "$PR_URL"

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -958,7 +958,7 @@ describe('doctor security checks', () => {
 		await fs.writeFile(
 			workflow,
 			(await fs.readFile(workflow, 'utf8')).replace(
-				/\s*steps\.metadata\.outputs\.dependency-group == 'dev-minor' &&/,
+				/\s*\(steps\.metadata\.outputs\.dependency-group == 'dev-minor' \|\|/,
 				''
 			)
 		)
@@ -988,6 +988,27 @@ describe('doctor security checks', () => {
 		const dep = results.find((r) => r.check === 'Dependabot')
 		expect(dep?.status).toBe('drift')
 		expect(dep?.detail).toMatch(/peerDependencies/)
+		expect(dep?.hint).toMatch(/fix dependabot/)
+	})
+
+	// #452: a repo that took the #423/#458 pair has CI action bumps waiting on a
+	// human for no benefit. Drift in the convenience direction — still drift.
+	it('reports Dependabot drift when the auto-merge workflow lacks the github-actions arm', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await generateDependabotConfig(dir)
+		const workflow = join(dir, '.github', 'workflows', 'dependabot-automerge.yml')
+		await fs.writeFile(
+			workflow,
+			(await fs.readFile(workflow, 'utf8')).replace(
+				/\s*steps\.metadata\.outputs\.package-ecosystem == 'github-actions'\) &&/,
+				' &&'
+			)
+		)
+		const results = await runDoctor(dir)
+		const dep = results.find((r) => r.check === 'Dependabot')
+		expect(dep?.status).toBe('drift')
+		expect(dep?.detail).toMatch(/CI action bumps/)
 		expect(dep?.hint).toMatch(/fix dependabot/)
 	})
 

--- a/tests/cli/generators/security.test.ts
+++ b/tests/cli/generators/security.test.ts
@@ -56,19 +56,50 @@ describe('generateDependabotConfig', () => {
 		])
 	})
 
-	// #423: production bumps ship to consumers of a published package, so the
-	// auto-merge gate is the dev-minor group *and* the semver type.
-	it('gates auto-merge on the dev-minor group as well as the semver type', async () => {
+	// #423 + #452: production bumps ship to consumers of a published package, so
+	// the auto-merge gate is (dev-minor OR the github-actions ecosystem) *and*
+	// the semver type *and* the consumer-facing gate.
+	//
+	// Asserted whole rather than clause by clause: every exclusion this file
+	// exists to defend lives in this one expression, and a partial match would
+	// pass on an expression that dropped one of them.
+	it('gates auto-merge on the group or ecosystem, the semver type, and the ships-check', async () => {
 		const dir = newTmpDir()
 		await generateDependabotConfig(dir)
 		const content = await fs.readFile(
 			join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
 			'utf-8'
 		)
-		expect(content).toMatch(/steps\.metadata\.outputs\.dependency-group == 'dev-minor' &&/)
-		expect(content).toMatch(/update-type == 'version-update:semver-patch'/)
-		expect(content).toMatch(/update-type == 'version-update:semver-minor'/)
+		const expression = content.match(/^ {8}if: \|\n([\s\S]*?)\n {8}run:/m)?.[1]
+		expect(expression).toBeDefined()
+		expect(expression?.replace(/^ {10}/gm, '')).toBe(
+			[
+				"steps.gate.outputs.safe == 'true' &&",
+				"(steps.metadata.outputs.dependency-group == 'dev-minor' ||",
+				"steps.metadata.outputs.package-ecosystem == 'github-actions') &&",
+				"(steps.metadata.outputs.update-type == 'version-update:semver-patch' ||",
+				"steps.metadata.outputs.update-type == 'version-update:semver-minor')",
+			].join('\n')
+		)
 		expect(content).not.toMatch(/'production-minor'/)
+	})
+
+	// #452: the ecosystem arm is an alternative to the group, not to the semver
+	// clause — an `actions/checkout@v7 → v8` is still a human's call.
+	it('leaves major github-actions bumps to a human', async () => {
+		const dir = newTmpDir()
+		await generateDependabotConfig(dir)
+		const content = await fs.readFile(
+			join(dir, '.github', 'workflows', 'dependabot-automerge.yml'),
+			'utf-8'
+		)
+		const expression = content.match(/^ {8}if: \|\n([\s\S]*?)\n {8}run:/m)?.[1] ?? ''
+		// The ecosystem arm sits inside the parenthesised group alternation, so
+		// the semver clause that follows still applies to it.
+		expect(expression).toMatch(
+			/\(steps\.metadata\.outputs\.dependency-group == 'dev-minor' \|\|\s*steps\.metadata\.outputs\.package-ecosystem == 'github-actions'\) &&/
+		)
+		expect(expression).not.toMatch(/semver-major/)
 	})
 
 	// The gate names a group that the paired dependabot.yml has to declare —
@@ -154,6 +185,12 @@ describe('the auto-merge consumer-facing gate', () => {
 	// Dependabot files it under dev-minor. It still ships.
 	it('stands down when a bumped package is a peerDependency', async () => {
 		expect(await runGate(MANIFEST, 'knip,typescript')).toBe('false')
+	})
+
+	// #452: a CI action bump reports names like `actions/checkout`, which appear
+	// in no manifest — so the gate resolves safe and the ecosystem arm decides.
+	it('passes a CI action bump, whose names are in no manifest', async () => {
+		expect(await runGate(MANIFEST, 'actions/checkout,actions/setup-node')).toBe('true')
 	})
 
 	it('stands down on a runtime dependency', async () => {


### PR DESCRIPTION
🤖 *Written by Claude (AI agent) under @rtorcato's account, from the repo-tooling `ai-issue-loop` session. Not a human message — there is no separate GitHub account for AI agents.*

Implements the owner's decision recorded on #452 (option 1): restore auto-merge for `github-actions` Dependabot bumps.

## What changed

`DEPENDABOT_AUTOMERGE_WORKFLOW` now matches CI action bumps on `package-ecosystem` as an **alternative to the `dev-minor` group**, inside the same parenthesised alternation:

```yaml
if: |
  steps.gate.outputs.safe == 'true' &&
  (steps.metadata.outputs.dependency-group == 'dev-minor' ||
  steps.metadata.outputs.package-ecosystem == 'github-actions') &&
  (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
  steps.metadata.outputs.update-type == 'version-update:semver-minor')
```

Action bumps are ungrouped, so they report an empty `dependency-group` — matching on the ecosystem is what lets them through without loosening the group gate for anything else.

Every other exclusion survives:

- **Majors still wait for a human.** The `update-type` clause is a separate `&&` term, so it applies to the ecosystem arm too. `actions/checkout@v7 → v8` does not auto-merge.
- **#462's manifest gate still runs and composes correctly.** I ran it rather than assumed it: an action bump reports names like `actions/checkout`, which appear in no `package.json`, so `ships` never matches and it resolves `safe=true`. The empty-`NAMES` fail-closed branch is untouched and still refuses a PR that reports nothing.
- **`production-minor` still excluded** — asserted by `expect(content).not.toMatch(/'production-minor'/)`.

Also:

- **`doctor`** (`checkDependabot`) now asserts the `github-actions` arm as well, so a repo that took the #423/#458 pair is told it is behind. Both existing greps (`dependency-group == 'dev-minor'`, `steps.gate.outputs.safe == 'true'`) survive the change verbatim — re-read, not assumed.
- **Dogfooded.** `.github/workflows/dependabot-automerge.yml` was regenerated from the built generator (not hand-edited), so it is byte-identical to what `fix dependabot` emits. `pnpm dogfood` is clean: 60 checks, 6 accepted.
- **`.github/dependabot.yml`** also regenerated. It carried a stale pre-#458 comment ("the only tier that auto-merges on green") that this change makes doubly wrong; the diff there is comment-only, no config change.
- **Docs** — the auto-merge table, the "excluded for the same reason as production bumps" statement (now false), and the recorded counter-argument.

## Tests

`tests/cli/generators/security.test.ts` now asserts the merge condition **whole** rather than clause by clause — a partial match would pass on an expression that quietly dropped one exclusion. Plus a test that the ecosystem arm sits inside the group alternation (majors excluded), and a gate test that a CI action bump resolves `safe=true`.

Mutation-checked both required properties before pushing:

| Mutation | Result |
|---|---|
| Remove the `update-type` (majors) clause | 3 tests fail |
| Remove `steps.gate.outputs.safe == 'true' &&` | 3 tests fail |

`biome lint`, `tsc --noEmit`, `vitest run` (1017 tests) all green.

## Semver

Typed **`feat(security):`**, deliberately — a minor, not the `fix` that #447 used.

The owner's recorded reasoning for `fix` on #447 was that auto-merging production deps was the bug, so narrowing it is a fix. That argument does not transfer: this goes the other direction. It **widens** what merges unattended in every repo that runs `fix dependabot`, and a patch release is too quiet a signal for "more things now merge without a human". I recorded the symmetry in the guide: narrowing ships as `fix`, widening as `feat`.

## For your decision

Two things I did not decide silently:

1. **`feat` vs `fix` is genuinely arguable.** You could read this as fixing #447's overreach — the issue itself calls the actions exclusion "wider than the stated goal", i.e. a defect in the old behaviour, which is exactly the `fix` argument. If you prefer `fix(security):`, say so and I will amend before this merges; nothing else changes.

2. **`cooldown` does not actually cover CI actions.** The decision comment lists the 7-day `cooldown` as one of the three mitigations, but `cooldown` is declared **per `updates:` entry** and the canonical `github-actions` entry has none — only the npm entry does. So an action bump can open the day it is published, and the real mitigations are the majors exclusion and required status checks. I documented that gap honestly rather than repeating the claim, and left the config alone because adding `cooldown` to the `github-actions` entry is outside the agreed scope. It is a three-line change to `dependabotConfig()` if you want it; worth a follow-up issue either way.

Closes #452
