### PR TITLE
fix(biome): stop pinning a version in the $schema URL

### DIFF
--- a/apps/docs/biome.json
+++ b/apps/docs/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "root": false,
   "extends": ["../../tooling/biome/biome.json"],
   "files": {

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -146,7 +146,7 @@ $ npx @rtorcato/repo-tooling fix biome --diff
     -  "rules": { "noConsole": "error" }
     -}
     +{
-    +  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+    +  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
     +  "extends": ["@rtorcato/repo-tooling/biome"],
     +  …
     +}

--- a/biome.json
+++ b/biome.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "extends": ["@rtorcato/repo-tooling/biome"]
 }

--- a/src/cli/generators/linting.ts
+++ b/src/cli/generators/linting.ts
@@ -44,61 +44,17 @@ export const BIOME_CONFIG = 'biome.json'
 export const BIOME_LEGACY_CONFIG = 'biome.jsonc'
 
 /**
- * Used when nothing in the target repo says which Biome will read the config —
- * a bare directory mid-`setup`, before `pnpm install` has run. Matches the
- * `$schema` the shipped preset carries.
- */
-const BIOME_SCHEMA_FALLBACK = '2.5.0'
-
-async function readJsonOrNull(filepath: string): Promise<Record<string, unknown> | null> {
-	try {
-		return (await fs.readJson(filepath)) as Record<string, unknown>
-	} catch {
-		return null
-	}
-}
-
-/**
- * The `@biomejs/biome` actually installed under `targetDir`, or null when
- * node_modules isn't populated. This is the binary that will parse the config
- * and emit the schema-mismatch warning, so it is the only version worth
- * comparing a written `$schema` against — a declared range like `^2.5.0` says
- * nothing about which 2.x resolved (#424).
- */
-export async function installedBiomeVersion(targetDir: string): Promise<string | null> {
-	const installed = await readJsonOrNull(
-		path.join(targetDir, 'node_modules', '@biomejs', 'biome', 'package.json')
-	)
-	const match =
-		typeof installed?.version === 'string' ? /(\d+\.\d+\.\d+)/.exec(installed.version) : null
-	return match?.[1] ?? null
-}
-
-/**
- * The Biome version the scaffolded `$schema` URL should name (#363).
+ * Unversioned on purpose (#468). A `$schema` naming an exact version is only
+ * ever right until the next `@biomejs/biome` bump, at which point Biome prints
+ * "The configuration schema version does not match the CLI version" on every
+ * invocation and doctor reports drift — so every Dependabot bump needed a hand
+ * edit before it could go green. Biome accepts `latest` and says nothing about
+ * it (verified against 2.5.5), which removes the failure class outright.
  *
- * A hardcoded version drifts the moment the consumer's Biome moves, and Biome
- * reports the mismatch on *every* invocation ("The configuration schema version
- * does not match the CLI version 2.5.7") — noise on a file the consumer never
- * wrote. The installed package wins because it is literally the binary that
- * will parse the file and emit that warning; the declared range is the next
- * best statement of intent when node_modules isn't populated yet.
+ * `latest` rather than dropping the key: editors still resolve a real schema
+ * for autocomplete and validation, which is the only reason the key is there.
  */
-export async function resolveBiomeSchemaVersion(targetDir: string): Promise<string> {
-	const installed = await installedBiomeVersion(targetDir)
-	if (installed) return installed
-
-	const pkg = await readJsonOrNull(path.join(targetDir, 'package.json'))
-	const deps = {
-		...((pkg?.dependencies as Record<string, string> | undefined) ?? {}),
-		...((pkg?.devDependencies as Record<string, string> | undefined) ?? {}),
-	}
-
-	// A range ("^2.5.0") carries the x.y.z we need just as an exact version does.
-	const declared = deps['@biomejs/biome']
-	const match = typeof declared === 'string' ? /(\d+\.\d+\.\d+)/.exec(declared) : null
-	return match?.[1] ?? BIOME_SCHEMA_FALLBACK
-}
+const BIOME_SCHEMA_URL = 'https://biomejs.dev/schemas/latest/schema.json'
 
 /**
  * The thin pointer config — the same shape this repo dogfoods. `fix biome` used
@@ -111,9 +67,8 @@ export async function generateBiomeConfig(targetDir: string): Promise<string> {
 	// file globs via `files.includes`; emitting the old 1.x `include`/`ignore`
 	// keys here forced consumers to run `biome migrate` before `biome check`
 	// would run at all.
-	const version = await resolveBiomeSchemaVersion(targetDir)
 	const biomeConfig = {
-		$schema: `https://biomejs.dev/schemas/${version}/schema.json`,
+		$schema: BIOME_SCHEMA_URL,
 		extends: ['@rtorcato/repo-tooling/biome'],
 	}
 

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -2,7 +2,6 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import type { BadgeAudience, FileCheck, GitHooksProfile } from '../../base/checks.js'
 import { checkFile, hookHasUncommented } from '../../base/checks.js'
-import { installedBiomeVersion } from '../../cli/generators/linting.js'
 import {
 	CLAUDE_SETTINGS_FILE,
 	readClaudeSettings,
@@ -197,24 +196,24 @@ export const BIOME_FILE_CHECK: FileCheck = {
 
 /**
  * The Biome check plus the one thing a contents-only matcher can't see: whether
- * the `$schema` URL still names the Biome that will read it (#424).
+ * the `$schema` URL still pins a version (#424, #468).
  *
- * `fix biome` writes the URL from the version resolved at scaffold time, and
- * nothing re-checked it afterwards — so once the repo's Biome moved on, every
- * single invocation (the pre-commit hook included) printed "The configuration
- * schema version does not match the CLI version", while doctor stayed clean.
+ * It began as a drift check — the URL named the Biome resolved at scaffold
+ * time, nothing re-checked it, and once the repo's Biome moved on every single
+ * invocation (the pre-commit hook included) printed "The configuration schema
+ * version does not match the CLI version" while doctor stayed clean.
  *
- * Compared against the *installed* package only, never the declared range: an
- * exact match is what Biome itself demands, and `^2.5.0` doesn't say which 2.x
- * resolved. With no node_modules there is nothing to be wrong about, so the
- * check says nothing rather than guessing.
+ * Chasing the installed version was treating the symptom: an exact pin is
+ * *only ever* correct until the next bump, so every `@biomejs/biome` update
+ * failed the build until someone hand-edited a URL. `fix biome` now writes the
+ * unpinned `latest`, and this reads as a migration signal instead — any
+ * surviving pin is a repo that predates the unpinning, whatever version it
+ * names. That makes it independent of node_modules, so it also fires on a
+ * fresh clone, and it goes quiet for good once the repo is migrated.
  */
 export async function checkBiome(dir: string): Promise<CheckResult> {
 	const result = await checkFile(dir, BIOME_FILE_CHECK)
 	if (result.status !== 'ok') return result
-
-	const installed = await installedBiomeVersion(dir)
-	if (!installed) return result
 
 	// The same candidate checkFile settled on — first one that exists wins.
 	for (const candidate of BIOME_FILE_CHECK.candidates) {
@@ -222,13 +221,13 @@ export async function checkBiome(dir: string): Promise<CheckResult> {
 		if (!(await fs.pathExists(filepath))) continue
 
 		const url = readSchemaUrl(await fs.readFile(filepath, 'utf8'))
-		const targeted = url?.includes('biomejs.dev') ? schemaUrlVersion(url)?.join('.') : null
-		if (targeted && targeted !== installed) {
+		const pinned = url?.includes('biomejs.dev') ? schemaUrlVersion(url)?.join('.') : null
+		if (pinned) {
 			return {
 				check: BIOME_FILE_CHECK.check,
 				status: 'drift',
-				detail: `${candidate} targets Biome ${targeted} but @biomejs/biome ${installed} is installed`,
-				hint: 'Run `npx @rtorcato/repo-tooling fix biome` to rewrite the $schema URL',
+				detail: `${candidate} pins Biome ${pinned} in $schema — the next @biomejs/biome bump past it breaks every Biome run`,
+				hint: 'Run `npx @rtorcato/repo-tooling fix biome` to drop the version from the $schema URL',
 			}
 		}
 		return result

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -268,14 +268,12 @@ describe('doctor', () => {
 		expect(results.find((r) => r.check === 'Biome')?.status).toBe('drift')
 	})
 
-	// #424: the config matched the preset, so doctor called it ok while every
-	// Biome run printed "The configuration schema version does not match the CLI
-	// version". The written `$schema` has to be re-checked against the installed
-	// binary, not just written once and trusted forever.
-	it('reports drift when the biome $schema names a different version than the installed CLI', async () => {
+	// #424/#468: a version in the `$schema` URL is only ever correct until the
+	// next @biomejs/biome bump, so any pin at all is drift — not just one that
+	// disagrees with what happens to be installed right now.
+	it('reports drift when the biome $schema still pins a version', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
-		await seedInstalledBiome(dir, '2.5.5')
 		await fs.writeJson(join(dir, 'biome.json'), {
 			$schema: 'https://biomejs.dev/schemas/2.4.16/schema.json',
 			extends: ['@rtorcato/repo-tooling/biome'],
@@ -284,15 +282,28 @@ describe('doctor', () => {
 		const biome = (await runDoctor(dir)).find((r) => r.check === 'Biome')
 		expect(biome?.status).toBe('drift')
 		expect(biome?.detail).toContain('2.4.16')
-		expect(biome?.detail).toContain('2.5.5')
 	})
 
-	it('reports ok when the biome $schema matches the installed CLI', async () => {
+	// The pin that matches today's CLI is the one that breaks tomorrow, so it
+	// has to be reported too — that is the whole point of #468.
+	it('reports drift for a pinned $schema even when it matches the installed CLI', async () => {
 		const dir = newTmpDir()
 		await seedPackageJson(dir)
 		await seedInstalledBiome(dir, '2.5.5')
 		await fs.writeJson(join(dir, 'biome.json'), {
 			$schema: 'https://biomejs.dev/schemas/2.5.5/schema.json',
+			extends: ['@rtorcato/repo-tooling/biome'],
+		})
+
+		expect((await runDoctor(dir)).find((r) => r.check === 'Biome')?.status).toBe('drift')
+	})
+
+	it('reports ok for the unpinned $schema `fix biome` writes', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await seedInstalledBiome(dir, '2.5.5')
+		await fs.writeJson(join(dir, 'biome.json'), {
+			$schema: 'https://biomejs.dev/schemas/latest/schema.json',
 			extends: ['@rtorcato/repo-tooling/biome'],
 		})
 

--- a/tests/cli/generators/linting.test.ts
+++ b/tests/cli/generators/linting.test.ts
@@ -7,7 +7,6 @@ import {
 	BIOME_CONFIG,
 	generateBiomeConfig,
 	generateLintingConfigs,
-	resolveBiomeSchemaVersion,
 } from '../../../src/cli/generators/linting.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -38,7 +37,7 @@ describe('generateLintingConfigs', () => {
 		expect(biome.extends).toEqual(['@rtorcato/repo-tooling/biome'])
 		// Biome 2.x schema + shape — no 1.x `files.include`/`ignore` that would
 		// force consumers to run `biome migrate` before `biome check` runs.
-		expect(biome.$schema).toContain('biomejs.dev/schemas/2.')
+		expect(biome.$schema).toBe('https://biomejs.dev/schemas/latest/schema.json')
 		expect(biome.files?.include).toBeUndefined()
 		expect(await fs.pathExists(join(dir, 'eslint.config.mjs'))).toBe(false)
 		expect(await fs.pathExists(join(dir, 'prettier.config.mjs'))).toBe(false)
@@ -122,9 +121,10 @@ describe('generateLintingConfigs', () => {
 		expect(preset.vcs).toMatchObject({ enabled: true, clientKind: 'git', useIgnoreFile: true })
 	})
 
-	// #363: a hardcoded 2.5.0 made Biome print a schema-version warning on every
-	// single run once the consumer's CLI moved past it.
-	it('derives $schema from the installed Biome, not a hardcoded version', async () => {
+	// #363/#468: any version in the URL — hardcoded, or derived from whatever is
+	// installed at scaffold time — makes Biome print a schema-version warning on
+	// every run the moment the consumer's CLI moves past it. `latest` never does.
+	it('writes an unpinned $schema, whatever Biome happens to be installed', async () => {
 		const dir = newTmpDir()
 		const biomePkg = join(dir, 'node_modules', '@biomejs', 'biome')
 		await fs.ensureDir(biomePkg)
@@ -137,19 +137,14 @@ describe('generateLintingConfigs', () => {
 		await generateBiomeConfig(dir)
 
 		const biome = await fs.readJson(join(dir, BIOME_CONFIG))
-		expect(biome.$schema).toBe('https://biomejs.dev/schemas/2.9.3/schema.json')
+		expect(biome.$schema).toBe('https://biomejs.dev/schemas/latest/schema.json')
 	})
 
-	it('falls back to the declared range, then to the preset version', async () => {
-		const withRange = newTmpDir()
-		await fs.writeJson(join(withRange, 'package.json'), {
-			name: 'demo',
-			devDependencies: { '@biomejs/biome': '^2.7.1' },
-		})
-		expect(await resolveBiomeSchemaVersion(withRange)).toBe('2.7.1')
-
-		// Bare directory mid-setup — nothing installed, nothing declared.
-		expect(await resolveBiomeSchemaVersion(newTmpDir())).toBe('2.5.0')
+	// The shipped preset is parsed by whichever Biome the consumer installed, so
+	// it must not pin either — it carried its own separate stale 2.5.0 (#468).
+	it('ships a preset whose $schema is unpinned too', async () => {
+		const preset = await fs.readJson(join(import.meta.dirname, '../../../tooling/biome/biome.json'))
+		expect(preset.$schema).toBe('https://biomejs.dev/schemas/latest/schema.json')
 	})
 
 	it('skips .oxlintrc.json when oxlint flag is unset', async () => {

--- a/tooling/biome/biome.json
+++ b/tooling/biome/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "root": false,
   "vcs": {
     "enabled": true,


### PR DESCRIPTION
🤖 *Automated — implementer via `ai-issue-loop`. Written by an AI agent and posted under the owner's account; not a human message. There is no separate GitHub account for AI agents, so this appears under @rtorcato's avatar.*

Closes #468.

Implements the owner's decision recorded on the issue (2026-08-21): **option 1, stop pinning a version in `$schema`**.

## Why `latest` and not dropping the key

Both work — verified against the installed 2.5.5:

| `$schema` | version notice | runs |
|---|---|---|
| pinned `2.5.0` | 2 lines | ✓ |
| `latest` | **none** | ✓ |
| omitted | none | ✓ |

`latest` wins because the key exists for exactly one reason: editors resolve it for autocomplete and validation of `biome.json`. Omitting it removes the failure class *and* that benefit; `latest` removes only the failure class. It costs nothing — Biome does not fetch the URL, it only parses a version out of it, and there is now nothing to parse.

## What moved

Both stale pins, as flagged on the issue:

- `biome.json` (root) — was 2.5.5
- `tooling/biome/biome.json` — the **shipped preset**, was 2.5.0
- `apps/docs/biome.json` — was 2.5.5
- `src/cli/generators/linting.ts` — the generator that emits `$schema` for scaffolded repos, now a constant
- `apps/docs/docs/guides/cli.md` — the `fix biome --diff` sample output

`fix biome` routes through `generateBiomeConfig`, so the fixer writes the unpinned URL with no separate change.

`resolveBiomeSchemaVersion` and `installedBiomeVersion` had no callers left once the emitted URL became a constant, so they were deleted along with `BIOME_SCHEMA_FALLBACK` and a now-unused JSON helper. Net **-40 lines**.

## For your decision

You asked whether #435's `$schema` drift check in `checkBiome` (`src/languages/js/checks.ts`) should be **removed** or **repurposed**, since the drift it looks for can no longer occur in a repo scaffolded by this version.

**I repurposed it, and I think that is right — but this is the part to overrule if you disagree.**

The check now flags **any surviving version pin**, whatever version it names, rather than comparing against the installed CLI:

```
biome.json pins Biome 2.4.16 in $schema — the next @biomejs/biome bump past it breaks every Biome run
→ Run `npx @rtorcato/repo-tooling fix biome` to drop the version from the $schema URL
```

Three reasons:

1. **Every existing consumer repo still has a pin.** They keep hitting this failure on every Biome bump until someone runs `fix biome`. Unpinning the generator fixes new repos and does nothing for them. This is the only thing that tells them.
2. **The old condition was too narrow anyway.** It only fired when the pin disagreed with the installed CLI — so a repo pinned to exactly what it has installed stayed green while sitting one Dependabot PR away from red. The pin that matches today is the one that breaks tomorrow. That is a widening, not just a re-aim, and it is why the old "matches the installed CLI" test now asserts `drift`.
3. **It costs almost nothing and gets simpler.** It no longer resolves `node_modules`, so it also works on a fresh clone before install, and it goes quiet permanently once a repo is migrated.

Case for **removing** it instead, so you have it: a check that only ever fires during a one-time migration is arguably a to-do disguised as a check, and it will sit in `doctor` forever after the last repo migrates. If you prefer that, deleting the loop in `checkBiome` and reverting it to a plain `checkFile` call is a small follow-up — the file-shape matching is untouched by this PR.

Note this changes doctor's verdict on repos that were previously green: any repo with a pinned `$schema` now reports Biome drift. That is the intent, and `fix biome` resolves it in one command.

**`checkConfigSchemaVersions` (#330) is deliberately untouched.** It degrades correctly on its own — `schemaUrlVersion` returns `null` for `latest`, so the config is skipped and it reports "no versioned config schemas to compare". It is generic over tools, so it keeps its value the moment a second entry lands in `SCHEMA_CONFIGS`.

## Commit type

`fix`, so this cuts a **patch**. It repairs a failure class rather than adding a capability, and the doctor change re-aims an existing check rather than introducing one. Flagging it explicitly because it edits a published file (`tooling/biome/biome.json`) and changes the output every scaffolded repo gets — if you read the new doctor verdict as significant enough to want a minor, say so and I will amend to `feat`.

## Verification

All run against the worktree's binaries, no repo-wide `--write` pass:

- `biome lint .` — clean (62 pre-existing warnings, all `apps/docs` CSS, unchanged by this PR)
- `tsc --noEmit --project src/cli/tsconfig.json` — clean
- `vitest run` — **1009 passed, 18 skipped, 0 failed** (61 files)

Confirmed independently that `latest` is accepted with no version notice, running the installed 2.5.5 against a scratch config.

Tests updated: `tests/cli/commands/doctor.test.ts` (pinned-URL drift, including the new matches-installed case, plus the unpinned-is-ok case) and `tests/cli/generators/linting.test.ts` (generator emits `latest`; shipped preset is unpinned — the second stale pin now has a test guarding it).

Also noted on the issue: #455 was hand-fixed to 2.5.8 to unblock it. That hand fix becomes unnecessary once this lands, though it is harmless to leave.
