### PR TITLE
fix(setup): greet with the current product name, not "JS Tooling"

### DIFF
--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -189,7 +189,7 @@ const EXAMPLES: Example[] = [
 		language: 'bash',
 		code: `$ npx @rtorcato/repo-tooling setup
 
-🛠️  Welcome to JS Tooling Setup!
+🛠️  Welcome to repo-tooling setup!
 ? Project type:    📚 Library/Package
 ? TypeScript:      ✅ Yes
 ? Linter:          ⚡ Biome

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -188,7 +188,7 @@ export async function setupProject(options: SetupOptions) {
 	const dryRun = options.dryRun === true
 
 	if (interactive && !dryRun) {
-		console.log(chalk.cyan('\n🛠️  Welcome to JS Tooling Setup!\n'))
+		console.log(chalk.cyan('\n🛠️  Welcome to repo-tooling setup!\n'))
 		console.log(chalk.gray(`Setting up tooling in: ${targetDir}\n`))
 	}
 

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -626,6 +626,22 @@ describe('setup language prompt', () => {
 		vi.restoreAllMocks()
 	})
 
+	// #475: the greeting was still "JS Tooling Setup" months after the rename
+	// because nothing pinned it. It is the first thing a user ever sees.
+	it('greets with the current product name, not the pre-rename one', async () => {
+		const dir = newTmpDir()
+		mockPrompt({ language: 'js' }, JS_ANSWERS)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true })
+			const greeting = logSpy.mock.calls.map((c) => String(c[0])).join('\n')
+			expect(greeting).toContain('Welcome to repo-tooling setup!')
+			expect(greeting).not.toMatch(/JS Tooling/i)
+		} finally {
+			logSpy.mockRestore()
+		}
+	})
+
 	it('defaults to the language detected in the target directory', async () => {
 		const dir = newTmpDir()
 		await fs.writeFile(join(dir, 'Package.swift'), '// swift-tools-version:6.0\n')


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Tier 1 of #475 only: the setup wizard still greeted users with `🛠️  Welcome to JS Tooling Setup!` — wrong on two counts, since the package is `@rtorcato/repo-tooling` and the tool is no longer JS-only.

- `src/cli/commands/setup.ts:191` — the real CLI greeting
- `apps/docs/src/pages/index.tsx:192` — an independently hardcoded copy in the docs homepage demo

Now both read `🛠️  Welcome to repo-tooling setup!`, matching the bin name and the docs site title. Added a test in `tests/cli/commands/setup.test.ts` asserting the greeting — nothing pinned it before, which is how it drifted for months.

A repo-wide grep found no other stale user-facing branding; the remaining `js-tooling` hits are legacy handling and are correct as-is.

`Refs #475`, not `Closes` — tier 2 (the `js-tooling:` upsert markers in `agent-rules.ts` / `badges.ts` / `skills-install.ts`) is untouched and still needs a maintainer decision. Renaming those naively breaks upsert idempotency: the next `fix` cannot find its own block and appends a duplicate into every pre-existing consumer's `AGENTS.md`/`README.md`. Close #475 by hand if you decide tier 2 isn't worth doing.

## Also noted, not fixed

The docs terminal demo is a hand-written duplicate of CLI output, not generated — which is why both copies drifted together and neither caught the other. It is **already stale in a second way**: #470 changed the wizard so interactive `--preset` shows a reviewable file list, and the mock still shows the old flow. Fixing that flow was out of scope here, but it should not be lost.

## For your decision

Cheapest way to stop the mock drifting again, roughly in order of effort:

1. **A doctor check on this repo's own docs** — `src/base/checks.ts` already has a check that flags stale `js-tooling` references. A sibling check could assert that each `EXAMPLES[].code` block's first line matches the corresponding command's real greeting constant. Catches wording drift, not flow drift.
2. **Export the greeting as a constant and import it into `index.tsx`** — the docs app builds from the same repo, so `code` could interpolate it. One shared string, zero drift on that line. Doesn't help the prompt list below it.
3. **Generate the mock from a `--dry-run` snapshot** — most faithful, most work, and needs the wizard to have a non-interactive transcript mode.

(2) is probably the honest cost/benefit sweet spot for the greeting; the prompt-flow drift from #470 really needs (3) or a manual refresh.
