### PR TITLE
feat(skills): tell a stale installed skill from a deliberate local fork

### DIFF
--- a/apps/docs/docs/guides/ai-issue-loop.md
+++ b/apps/docs/docs/guides/ai-issue-loop.md
@@ -23,7 +23,7 @@ the machine — which is why it is **opt-in**: a bare `fix` or `fix --yes` skips
 it and says so, and `doctor` reports it as *not configured* rather than as a
 finding against your repo.
 
-Three things follow from that:
+Four things follow from that:
 
 - **`--skills-dir <path>`** overrides the destination. It is required alongside
   `--yes` / `--json` when `~/.claude/skills` does not exist, since a prompt
@@ -37,6 +37,16 @@ Three things follow from that:
   `repo-tooling-version` stamp in its frontmatter. A repo pinned to an older
   release reports and skips rather than overwriting a newer skill — otherwise
   two repos on different versions would fight over it on every `fix`.
+- **The install refuses to overwrite a local fork.** Alongside the version, each
+  copy carries a `repo-tooling-hash` of the content we wrote. If the installed
+  file no longer matches that hash — or predates it, so nothing can be proven —
+  the install prints what diverged and stops, the same rule
+  [`fix copied-assets`](./cli.md) follows for copied presets. This is the case
+  the version stamp alone cannot see: a fork that is merely *older* than the
+  package looks exactly like a stale copy. Diff it against the shipped file the
+  message names, then pass **`--force-skills`** to take the shipped version.
+  `--yes` deliberately does *not* imply it: unattended runs pass `--yes`, and
+  this is the one overwrite that destroys work living outside the repo.
 
 Any agent that reads the [`skills`](https://www.npmjs.com/package/skills) CLI
 format can also take it straight from GitHub:

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -544,6 +544,21 @@ export async function checkClaudeSkills(): Promise<CheckResult> {
 			hint,
 		}
 	}
+	// A local fork is `ok` for the same reason a modified copied asset is (#448):
+	// it is somebody's deliberate work, so it is named once and never nagged as
+	// fixable — pointing at a `fix` that would refuse is worse than saying nothing.
+	if (status.contentState && status.contentState !== 'pristine') {
+		const why =
+			status.contentState === 'modified'
+				? `has local changes since ${status.installedVersion}`
+				: 'carries no content record, so a fork cannot be told from a stale copy'
+		return {
+			check,
+			status: 'ok',
+			detail: `${SHIPPED_SKILL} skill at ${status.file} ${why}; this package ships ${status.shippedVersion} and will not overwrite it`,
+			hint: `Diff it against the shipped copy, then run \`npx @rtorcato/repo-tooling fix claude-skills --force-skills\` to take the shipped version`,
+		}
+	}
 	return {
 		check,
 		status: 'ok',

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -20,6 +20,7 @@ import {
 	installClaudeSkill,
 	resolveSkillsDir,
 	SHIPPED_SKILL,
+	type SkillInstallResult,
 } from '../cli/generators/claude-skills.js'
 import { generateBrand } from '../cli/generators/brand.js'
 import { generateCommunityHealth } from '../cli/generators/community-health.js'
@@ -53,6 +54,8 @@ interface FixerContext {
 	lock: Lockfile | null
 	/** `--skills-dir`, for the one fixer that writes user-global state (#404). */
 	skillsDir?: string
+	/** `--force-skills`: overwrite a locally forked skill anyway (#480). */
+	forceSkills?: boolean
 	/** True under `--yes` / `--json`, so a fixer knows a prompt is not available. */
 	assumeYes: boolean
 }
@@ -139,6 +142,25 @@ async function resolveInstallDir(explicit: string | undefined, assumeYes: boolea
 	])
 	const trimmed = typeof answer === 'string' ? answer.trim() : ''
 	return trimmed ? path.resolve(trimmed) : null
+}
+
+/**
+ * Why the install refused, and what to do about it. A bare "skipped" would be
+ * its own failure mode: the user still wants the update, and nothing on screen
+ * would say how to get it or what they would be giving up (#480).
+ */
+function describeSkillFork(result: SkillInstallResult): string[] {
+	const target = result.viaSymlink ? `${result.file} → ${result.realFile}` : result.realFile
+	const why =
+		result.contentState === 'modified'
+			? `its content has diverged from the ${result.installedVersion} release it was installed from`
+			: 'it carries no content record, so a local fork and a stale copy are indistinguishable'
+	return [
+		`skipped — ${SHIPPED_SKILL} was not overwritten with ${result.shippedVersion}: ${why}`,
+		`  ${target}`,
+		`  compare:  diff "${result.realFile}" "${result.shippedFile}"`,
+		'  overwrite anyway:  fix claude-skills --force-skills',
+	]
 }
 
 export const BASE_FIXERS: Fixer[] = [
@@ -402,16 +424,22 @@ export const BASE_FIXERS: Fixer[] = [
 		riskLevel: 'safe-add',
 		explicitOnly: true,
 		canFixDrift: true,
-		async run({ skillsDir, assumeYes }) {
+		async run({ skillsDir, forceSkills, assumeYes }) {
 			const dir = await resolveInstallDir(skillsDir, assumeYes)
 			if (!dir) return { filesWritten: [] }
-			const result = await installClaudeSkill(dir)
+			const result = await installClaudeSkill(dir, SHIPPED_SKILL, { force: forceSkills })
 			if (result.status === 'declined-downgrade') {
 				console.error(
 					chalk.yellow(
 						`   skipped — ${result.file} is at ${result.installedVersion}, newer than the ${result.shippedVersion} this package ships`
 					)
 				)
+				return { filesWritten: [] }
+			}
+			if (result.status === 'declined-fork') {
+				// Name `realFile`: through a stow symlink the overwrite would land in a
+				// *second* repo's working tree, and that is the path to look at (#480).
+				for (const line of describeSkillFork(result)) console.error(chalk.yellow(`   ${line}`))
 				return { filesWritten: [] }
 			}
 			if (result.status === 'up-to-date') return { filesWritten: [] }

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -64,6 +64,8 @@ export interface FixOptions {
 	diff?: boolean
 	/** Destination for the user-global agent skills `fix claude-skills` writes. */
 	skillsDir?: string
+	/** Overwrite a locally forked skill instead of refusing (#480). */
+	forceSkills?: boolean
 }
 
 export type FixActionStatus = 'applied' | 'dry-run' | 'skipped' | 'already-ok' | 'unsupported'
@@ -275,7 +277,7 @@ async function applyFixer(
 	lock: Lockfile | null,
 	dryRun: boolean,
 	silent: boolean,
-	opts: { skillsDir?: string; assumeYes: boolean }
+	opts: { skillsDir?: string; forceSkills?: boolean; assumeYes: boolean }
 ): Promise<{ filesWritten: string[]; dryRun: boolean }> {
 	if (dryRun) {
 		if (!silent) {
@@ -543,6 +545,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 		// branch and records a skip, since one refusal must not abandon the rest.
 		const outcome = await applyFixer(fixer, effectiveResult, targetDir, pkg, lock, dryRun, silent, {
 			skillsDir: options.skillsDir,
+			forceSkills: options.forceSkills,
 			assumeYes,
 		}).catch((err: unknown) => {
 			if (!(err instanceof FixerAbort)) throw err
@@ -630,6 +633,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 		try {
 			outcome = await applyFixer(fixer, result, targetDir, pkg, lock, dryRun, silent, {
 				skillsDir: options.skillsDir,
+				forceSkills: options.forceSkills,
 				assumeYes,
 			})
 		} catch (err) {

--- a/src/cli/generators/claude-skills.ts
+++ b/src/cli/generators/claude-skills.ts
@@ -5,6 +5,7 @@
  * version stamp, the symlink handling, and the fixer's opt-in `explicitOnly`.
  */
 
+import { createHash } from 'node:crypto'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
@@ -20,6 +21,21 @@ export const SHIPPED_SKILL = 'ai-issue-loop'
  * is wrong to do so.
  */
 export const VERSION_KEY = 'repo-tooling-version'
+
+/**
+ * The pristine sha256 of the content we wrote, stamped beside the version — the
+ * skills half of #448. The version alone cannot tell a stale copy from a
+ * deliberate local fork: a fork that is merely older than the package looks
+ * exactly like a copy waiting for an update, and gets overwritten (#480).
+ * With the hash, "installed content still matches what some release of this
+ * package shipped" is a fact rather than an inference.
+ *
+ * It lives in the file instead of `.repo-tooling.json` because skills are
+ * user-global — no one repo owns the record.
+ */
+export const HASH_KEY = 'repo-tooling-hash'
+
+const STAMP_KEYS = [VERSION_KEY, HASH_KEY]
 
 const FRONTMATTER = /^---\n([\s\S]*?)\n---\n/
 
@@ -50,25 +66,81 @@ export async function resolveSkillsDir(
 	return { dir: null, source: 'none' }
 }
 
+function readStamp(content: string, key: string): string | null {
+	return content.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]?.trim() ?? null
+}
+
 /** The version recorded in an installed copy, or null if it predates the stamp. */
 export function readSkillVersion(content: string): string | null {
-	return content.match(new RegExp(`^${VERSION_KEY}:\\s*(.+)$`, 'm'))?.[1]?.trim() ?? null
+	return readStamp(content, VERSION_KEY)
+}
+
+/** The pristine hash recorded in an installed copy, or null if it predates it. */
+export function readSkillHash(content: string): string | null {
+	return readStamp(content, HASH_KEY)
 }
 
 /**
- * Replace (or add) the version line in the frontmatter. Appending it last is
+ * Replace (or add) the stamp lines in the frontmatter. Appending them last is
  * safe even after a multi-line `description: |` block: an unindented key ends
- * the block scalar, which is exactly what this line is.
+ * the block scalar, which is exactly what these lines are.
+ *
+ * With no stamps this is the exact inverse of stamping, so a file we wrote
+ * strips back to the bytes we were given — which is what makes the hash
+ * comparable.
+ */
+function setStamps(content: string, stamps: string[]): string {
+	const match = content.match(FRONTMATTER)
+	if (!match) return stamps.length === 0 ? content : `---\n${stamps.join('\n')}\n---\n\n${content}`
+	const kept = (match[1] ?? '')
+		.split('\n')
+		.filter((line) => !STAMP_KEYS.some((key) => line.startsWith(`${key}:`)))
+	return `---\n${[...kept, ...stamps].join('\n')}\n---\n${content.slice(match[0].length)}`
+}
+
+/** An installed copy with this package's own bookkeeping lines removed. */
+export function stripSkillStamps(content: string): string {
+	return setStamps(content, [])
+}
+
+/**
+ * The version stamp on its own — the shape releases before #480 wrote, and what
+ * `classifySkillContent` sees as `unknown`. Not the write path; `stampSkill` is.
  */
 export function stampSkillVersion(content: string, version: string): string {
-	const stamp = `${VERSION_KEY}: ${version}`
-	const match = content.match(FRONTMATTER)
-	if (!match) return `---\n${stamp}\n---\n\n${content}`
-	const fields = (match[1] ?? '')
-		.split('\n')
-		.filter((line) => !line.startsWith(`${VERSION_KEY}:`))
-		.join('\n')
-	return `---\n${fields}\n${stamp}\n---\n${content.slice(match[0].length)}`
+	return setStamps(content, [`${VERSION_KEY}: ${version}`])
+}
+
+/** sha256 of the content this package shipped, ignoring the stamps it adds. */
+export function hashSkillContent(content: string): string {
+	return createHash('sha256').update(stripSkillStamps(content)).digest('hex')
+}
+
+/** The version + hash stamps, as written to disk. */
+export function stampSkill(content: string, version: string): string {
+	return setStamps(content, [
+		`${VERSION_KEY}: ${version}`,
+		`${HASH_KEY}: ${hashSkillContent(content)}`,
+	])
+}
+
+/**
+ * How an installed copy relates to the releases this package has shipped —
+ * #448's vocabulary, applied to skills.
+ *
+ * - `pristine` — content still matches the hash the install recorded (or is
+ *   verbatim what we ship right now), so re-writing it loses nothing.
+ * - `modified` — content has diverged from that record. Somebody's fork.
+ * - `unknown` — no record at all (installed before this stamp existed). A fork
+ *   and a stale copy are indistinguishable, so it is not safe to overwrite.
+ */
+export type SkillContentState = 'pristine' | 'modified' | 'unknown'
+
+export function classifySkillContent(installed: string, shipped: string): SkillContentState {
+	if (stripSkillStamps(installed) === stripSkillStamps(shipped)) return 'pristine'
+	const recorded = readSkillHash(installed)
+	if (!recorded) return 'unknown'
+	return recorded === hashSkillContent(installed) ? 'pristine' : 'modified'
 }
 
 function versionParts(version: string): number[] {
@@ -88,21 +160,32 @@ export function isNewerVersion(a: string, b: string): boolean {
 export interface ShippedSkill {
 	content: string
 	version: string
+	/** Where that content lives on disk, inside this package. */
+	file: string
 }
 
 /** The skill source and the package version that will be stamped into it. */
 export async function readShippedSkill(name: string = SHIPPED_SKILL): Promise<ShippedSkill> {
 	const root = getPackageRoot()
-	const content = await fs.readFile(path.join(root, 'skills', name, 'SKILL.md'), 'utf8')
+	const file = path.join(root, 'skills', name, 'SKILL.md')
+	const content = await fs.readFile(file, 'utf8')
 	const pkg = await fs.readJson(path.join(root, 'package.json'))
-	return { content, version: String(pkg.version) }
+	return { content, version: String(pkg.version), file }
 }
 
-export type SkillInstallStatus = 'installed' | 'updated' | 'up-to-date' | 'declined-downgrade'
+export type SkillInstallStatus =
+	| 'installed'
+	| 'updated'
+	| 'up-to-date'
+	| 'declined-downgrade'
+	/** Content this package never shipped — a local fork, or unprovable either way. */
+	| 'declined-fork'
 
 export interface SkillInstallResult {
 	name: string
 	status: SkillInstallStatus
+	/** Null when nothing is installed yet. */
+	contentState: SkillContentState | null
 	/** The nominal path — `<skillsDir>/<name>/SKILL.md`. */
 	file: string
 	/**
@@ -113,6 +196,8 @@ export interface SkillInstallResult {
 	realFile: string
 	/** True when `file` is a symlink — a stow-managed copy living in dotfiles. */
 	viaSymlink: boolean
+	/** The shipped source inside this package, so a refusal can name a real `diff`. */
+	shippedFile: string
 	installedVersion: string | null
 	shippedVersion: string
 }
@@ -139,7 +224,8 @@ async function isSymlink(file: string): Promise<boolean> {
  */
 export async function installClaudeSkill(
 	skillsDir: string,
-	name: string = SHIPPED_SKILL
+	name: string = SHIPPED_SKILL,
+	{ force = false }: { force?: boolean } = {}
 ): Promise<SkillInstallResult> {
 	const shipped = await readShippedSkill(name)
 	const file = path.join(skillsDir, name, 'SKILL.md')
@@ -148,8 +234,10 @@ export async function installClaudeSkill(
 	const viaSymlink = await isSymlink(file)
 	const base = {
 		name,
+		contentState: existing === null ? null : classifySkillContent(existing, shipped.content),
 		file,
 		viaSymlink,
+		shippedFile: shipped.file,
 		realFile: viaSymlink ? await fs.realpath(file) : file,
 		installedVersion,
 		shippedVersion: shipped.version,
@@ -159,7 +247,14 @@ export async function installClaudeSkill(
 		return { ...base, status: 'declined-downgrade' }
 	}
 
-	const next = stampSkillVersion(shipped.content, shipped.version)
+	// Only `pristine` content is provably ours to replace. Anything else is a
+	// fork (or unprovable, which for a destructive write is the same thing) and
+	// stays a human decision — the same rule `fix copied-assets` follows (#448).
+	if (!force && base.contentState !== null && base.contentState !== 'pristine') {
+		return { ...base, status: 'declined-fork' }
+	}
+
+	const next = stampSkill(shipped.content, shipped.version)
 	if (existing === next) return { ...base, status: 'up-to-date' }
 
 	await fs.ensureDir(path.dirname(file))
@@ -174,7 +269,13 @@ export interface SkillStatus {
 	/** Null when installed but unstamped — a copy that predates this feature. */
 	installedVersion: string | null
 	shippedVersion: string
-	/** True when nothing is installed, or what is installed predates what we ship. */
+	/** Null when nothing is installed. */
+	contentState: SkillContentState | null
+	/**
+	 * True when nothing is installed, or what is installed predates what we ship
+	 * *and* `fix` would actually replace it. A fork is never "needs install":
+	 * pointing at a fix that will refuse is worse than saying nothing.
+	 */
 	needsInstall: boolean
 }
 
@@ -183,23 +284,28 @@ export async function claudeSkillStatus(
 	name: string = SHIPPED_SKILL,
 	explicit?: string
 ): Promise<SkillStatus> {
-	const { version } = await readShippedSkill(name)
+	const shipped = await readShippedSkill(name)
 	const { dir } = await resolveSkillsDir(explicit)
 	const absent = {
 		installed: false,
 		installedVersion: null,
-		shippedVersion: version,
+		shippedVersion: shipped.version,
+		contentState: null,
 		needsInstall: true,
 	}
 	if (!dir) return { file: null, ...absent }
 	const file = path.join(dir, name, 'SKILL.md')
 	if (!(await fs.pathExists(file))) return { file, ...absent }
-	const installedVersion = readSkillVersion(await fs.readFile(file, 'utf8'))
+	const content = await fs.readFile(file, 'utf8')
+	const installedVersion = readSkillVersion(content)
+	const contentState = classifySkillContent(content, shipped.content)
+	const behind = installedVersion === null || isNewerVersion(shipped.version, installedVersion)
 	return {
 		file,
 		installed: true,
 		installedVersion,
-		shippedVersion: version,
-		needsInstall: installedVersion === null || isNewerVersion(version, installedVersion),
+		shippedVersion: shipped.version,
+		contentState,
+		needsInstall: behind && contentState === 'pristine',
 	}
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -358,6 +358,12 @@ program
 		'--skills-dir <path>',
 		'Where `fix claude-skills` installs user-global agent skills (default: ~/.claude/skills). Required with --yes/--json when that directory does not exist'
 	)
+	// Deliberately not folded into --yes: unattended runs pass --yes, and this is
+	// the one overwrite that destroys work living outside the repo (#480).
+	.option(
+		'--force-skills',
+		'Let `fix claude-skills` overwrite a locally modified skill instead of refusing'
+	)
 	.action((target: string | undefined, options) =>
 		fixCommand(target, {
 			directory: options.directory,
@@ -368,6 +374,7 @@ program
 			resync: options.resync,
 			diff: options.diff,
 			skillsDir: options.skillsDir,
+			forceSkills: options.forceSkills,
 		})
 	)
 

--- a/tests/cli/generators/claude-skills.test.ts
+++ b/tests/cli/generators/claude-skills.test.ts
@@ -3,12 +3,16 @@ import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import {
 	claudeSkillStatus,
+	HASH_KEY,
 	installClaudeSkill,
 	isNewerVersion,
+	readShippedSkill,
 	readSkillVersion,
 	resolveSkillsDir,
 	SHIPPED_SKILL,
+	stampSkill,
 	stampSkillVersion,
+	stripSkillStamps,
 	VERSION_KEY,
 } from '../../../src/cli/generators/claude-skills.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -17,6 +21,17 @@ const newTmpDir = useTmpDir()
 
 function skillFile(skillsDir: string): string {
 	return join(skillsDir, SHIPPED_SKILL, 'SKILL.md')
+}
+
+/**
+ * What an older release left behind: its own content, stamped with its own
+ * version and its own pristine hash. The `stale but unmodified` case.
+ */
+async function installedByOlderRelease(skillsDir: string, body: string): Promise<void> {
+	await fs.outputFile(
+		skillFile(skillsDir),
+		stampSkill(`---\nname: ai-issue-loop\n---\n\n${body}\n`, '0.0.1')
+	)
 }
 
 describe('resolveSkillsDir', () => {
@@ -101,12 +116,78 @@ describe('installClaudeSkill', () => {
 		expect(await fs.readFile(skillFile(skillsDir), 'utf8')).toContain('from the future')
 	})
 
-	it('adopts an unstamped copy', async () => {
+	it('updates a stale copy that is still verbatim what an older release shipped', async () => {
+		const skillsDir = newTmpDir()
+		await installedByOlderRelease(skillsDir, 'the 0.0.1 body')
+
+		const result = await installClaudeSkill(skillsDir)
+
+		expect(result.status).toBe('updated')
+		expect(result.contentState).toBe('pristine')
+		expect(result.installedVersion).toBe('0.0.1')
+		expect(await fs.readFile(skillFile(skillsDir), 'utf8')).toContain('# ai-issue-loop')
+	})
+
+	// #480: the version stamp alone cannot see this. The fork was *older* than
+	// what we ship, so the downgrade guard waves it through and 121 lines of
+	// somebody's work vanish with no warning.
+	it('refuses to overwrite a copy whose content has diverged since it was installed', async () => {
+		const skillsDir = newTmpDir()
+		await installedByOlderRelease(skillsDir, 'the 0.0.1 body')
+		const forked = `${await fs.readFile(skillFile(skillsDir), 'utf8')}\n## a section only the fork has\n`
+		await fs.outputFile(skillFile(skillsDir), forked)
+
+		const result = await installClaudeSkill(skillsDir)
+
+		expect(result.status).toBe('declined-fork')
+		expect(result.contentState).toBe('modified')
+		expect(await fs.readFile(skillFile(skillsDir), 'utf8')).toBe(forked)
+		// Actionable: the refusal can name the shipped file to diff against.
+		expect(result.shippedFile).toBe((await readShippedSkill()).file)
+	})
+
+	it('refuses an unstamped copy rather than guessing it is merely stale', async () => {
 		const skillsDir = newTmpDir()
 		await fs.outputFile(skillFile(skillsDir), '---\nname: ai-issue-loop\n---\n\nold\n')
+
 		const result = await installClaudeSkill(skillsDir)
-		expect(result.status).toBe('updated')
+
+		expect(result.status).toBe('declined-fork')
+		expect(result.contentState).toBe('unknown')
 		expect(result.installedVersion).toBeNull()
+		expect(await fs.readFile(skillFile(skillsDir), 'utf8')).toContain('old')
+	})
+
+	it('overwrites a fork when explicitly forced', async () => {
+		const skillsDir = newTmpDir()
+		await fs.outputFile(skillFile(skillsDir), '---\nname: ai-issue-loop\n---\n\nold\n')
+
+		const result = await installClaudeSkill(skillsDir, SHIPPED_SKILL, { force: true })
+
+		expect(result.status).toBe('updated')
+		expect(await fs.readFile(skillFile(skillsDir), 'utf8')).toContain('# ai-issue-loop')
+	})
+
+	// An unstamped copy of exactly what we ship is not a fork — it just predates
+	// the hash. Refusing it would make `--force-skills` a routine step.
+	it('stamps an unstamped copy that already matches the shipped content', async () => {
+		const skillsDir = newTmpDir()
+		const { content } = await readShippedSkill()
+		await fs.outputFile(skillFile(skillsDir), content)
+
+		const result = await installClaudeSkill(skillsDir)
+
+		expect(result.status).toBe('updated')
+		expect(result.contentState).toBe('pristine')
+	})
+
+	it('records a hash that survives a round trip through the stamps', async () => {
+		const skillsDir = newTmpDir()
+		await installClaudeSkill(skillsDir)
+		const written = await fs.readFile(skillFile(skillsDir), 'utf8')
+
+		expect(written).toContain(`${HASH_KEY}: `)
+		expect(stripSkillStamps(written)).toBe((await readShippedSkill()).content)
 	})
 
 	// The failure mode the feature exists to prevent: stow symlinks at file level,
@@ -115,7 +196,7 @@ describe('installClaudeSkill', () => {
 	it('writes through a symlink instead of replacing it', async () => {
 		const skillsDir = newTmpDir()
 		const dotfiles = join(newTmpDir(), 'SKILL.md')
-		await fs.outputFile(dotfiles, '---\nname: ai-issue-loop\n---\n\nold\n')
+		await fs.outputFile(dotfiles, stampSkill('---\nname: ai-issue-loop\n---\n\nold\n', '0.0.1'))
 		await fs.ensureDir(join(skillsDir, SHIPPED_SKILL))
 		await fs.symlink(dotfiles, skillFile(skillsDir))
 
@@ -142,6 +223,25 @@ describe('claudeSkillStatus', () => {
 		const status = await claudeSkillStatus(SHIPPED_SKILL, skillsDir)
 		expect(status.installed).toBe(true)
 		expect(status.needsInstall).toBe(false)
+		expect(status.contentState).toBe('pristine')
 		expect(status.installedVersion).toBe(status.shippedVersion)
+	})
+
+	it('flags an out-of-date but unmodified copy as needing an install', async () => {
+		const skillsDir = newTmpDir()
+		await installedByOlderRelease(skillsDir, 'the 0.0.1 body')
+		const status = await claudeSkillStatus(SHIPPED_SKILL, skillsDir)
+		expect(status.contentState).toBe('pristine')
+		expect(status.needsInstall).toBe(true)
+	})
+
+	// Never "needs install": the fix would refuse, so nagging about it is noise.
+	it('does not ask for an install it knows will be declined', async () => {
+		const skillsDir = newTmpDir()
+		await installedByOlderRelease(skillsDir, 'the 0.0.1 body')
+		await fs.appendFile(skillFile(skillsDir), '\nlocal edit\n')
+		const status = await claudeSkillStatus(SHIPPED_SKILL, skillsDir)
+		expect(status.contentState).toBe('modified')
+		expect(status.needsInstall).toBe(false)
 	})
 })


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Closes #480

Option 1 only — detect the fork and refuse. Reconciling the two divergent copies of `SKILL.md` is a human decision and stays out of this PR; `skills/ai-issue-loop/SKILL.md` is untouched.

## What changed

`installClaudeSkill` guarded on the version stamp alone, so a fork that was merely *older* than the package was indistinguishable from a stale copy — the write proceeded and the local content was gone. Through a stow symlink that overwrite lands in a second repo's working tree.

This applies #448's mechanism rather than inventing a second one. Every install now stamps `repo-tooling-hash` — the sha256 of the pristine content — beside `repo-tooling-version`. The record lives in the file, not `.repo-tooling.json`, because skills are user-global and no one repo owns them.

| Installed content | `SkillContentState` | `fix claude-skills` |
|---|---|---|
| matches the recorded hash, or is verbatim what we ship now | `pristine` | updates |
| differs from the recorded hash | `modified` | `declined-fork` |
| no record at all (installed before this) | `unknown` | `declined-fork` |

The refusal is actionable — it names what diverged, the real path (`file → realFile` when it is a symlink, so the message points at the dotfiles checkout the write would have hit), a ready-to-run `diff` against the shipped file, and `--force-skills`.

`--yes` deliberately does **not** imply `--force-skills`. Unattended runs pass `--yes`, and this is the one overwrite that destroys work living outside the repo.

`doctor` reports a fork as `ok` and never as `needsInstall`, matching how #448 treats a modified copied asset: named once, never nagged as fixable. Pointing at a fix that would refuse is worse than saying nothing.

## Verification

1016 tests pass; `biome lint .` at the same 62 pre-existing warnings as `main`; `biome format .` and `tsc --noEmit` clean.

New tests cover: fork declines and the file is byte-identical afterwards; an unstamped copy declines; a stale-but-pristine copy still updates cleanly; `--force` overwrites; identical content is `up-to-date`; the hash survives a round trip through the stamps; and `needsInstall` stays false for a fork.

## For your decision

- **`unknown` refuses, and that changes the first run after upgrade.** Every copy installed before this has no hash, so the first `fix claude-skills` on an out-of-date skill will now refuse and ask for `--force-skills` once. I chose safety over convenience because your machine is exactly this case — a legacy stamp at `3.9.2` with 121 lines the shipped copy lacks. The alternative (treat "no record" as safe to overwrite, per #448's `unknown` → never drift) would leave the reported bug unfixed on precisely the install that reported it. It converges after one run.
- **The old `adopts an unstamped copy` test asserted the behaviour this issue calls the defect**, so it is replaced rather than kept.
- **Ordering:** a fork stamped *newer* than the package reports `declined-downgrade`, not `declined-fork`. Both refuse, so nothing is lost, but the message names the version rather than the divergence.
