### PR TITLE
feat(skills): route agent follow-ups to ai-suggested issues

### DIFF
--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -60,6 +60,7 @@ drift with a second copy to maintain.
 |---|---|
 | Clean and ready | **None.** `ai-ok-code, ai-ok-sec` + assigned + no `ai-review` already says it. |
 | `ai-notes` | ≤10 lines; link the reviewer's `### Before merging`. |
+| Follow-up found | One line — `Follow-up: #<new>`. The issue carries the context. |
 | `ai-changes`, CI red, `ai-blocked` | ≤10 lines, action first, then the specific cause. |
 | Reviewer verdict | `### Before merging` plus ≤600 characters above it. |
 | Declining an issue | The one exception — a hard handoff needs its reasoning; see Pass 4. |
@@ -78,6 +79,7 @@ drift with a second copy to maintain.
 | `ai-ok-sec` | PR | `security-expert` passed. |
 | `ai-changes` | PR | A reviewer requested changes. Reviewers never apply it to a Dependabot PR. |
 | `ai-notes` | PR | Passed, but a reviewer left something to read before merging. |
+| `ai-suggested` | issue | Follow-up a reviewer filed. A triage queue, never auto-picked. |
 | `holding` | issue | A gate — closes on human judgement, never picked up. |
 
 **`ai-notes` is advisory and never blocks.** It rides *alongside* a pass label,
@@ -87,11 +89,18 @@ so `ai-notes` is the hold itself: it suppresses auto-merge and routes the PR to
 the human. It exists because a pass label currently means both "clean" and
 "I found something real but would not hold the PR over it", and those two are
 indistinguishable in the *Assigned to you* view where merges actually happen.
-The bar is a finding that **changes what a human would do**: a semver
-implication, a deliberate omission, a follow-up that must be filed. Not
+The bar is a finding that **changes what a human would do at merge time**: a
+semver implication, a deliberate omission, a question only they can answer. Not
 observations, not praise, not restating the diff. `ai-notes` on every PR is the
 failure mode — it trains the reader to ignore it, which is worse than not having
 it.
+
+**Follow-up work is an issue, not a note.** A finding that clears that bar *and*
+is work someone would plausibly do gets filed as its own issue labelled
+`ai-suggested`, by the reviewer that found it; the PR comment keeps one line and
+a link. It does **not** earn `ai-notes` — later work does not decide this merge.
+An observation is not a follow-up. Prose in a merged PR's comments is
+archaeology, which is how every follow-up left there so far has died on merge.
 
 First run in a repo, create any that are missing (`gh label create` is a no-op
 error if it exists — ignore that):
@@ -108,6 +117,7 @@ gh label create ai-ok-code -c '#0e8a16' -d 'code-reviewer passed'
 gh label create ai-ok-sec  -c '#0e8a16' -d 'security-expert passed'
 gh label create ai-changes -c '#d93f0b' -d 'Reviewer requested changes'
 gh label create ai-notes   -c '#fbca04' -d 'Passed, but a reviewer left something to read before merging'
+gh label create ai-suggested -c '#c2e0c6' -d 'Follow-up surfaced by an agent review — triage queue, never auto-picked'
 ```
 
 Bootstrap only. `gh label create` **cannot repair a label that already exists** —
@@ -539,10 +549,28 @@ Reviewer prompt template:
 > narrate only where the PR is **wrong** or **silent**. Never list what you
 > checked and found clean, and never confirm a claim the PR body already makes —
 > agreement is what the pass label is for, so a review that agrees is nearly
-> empty. The bar is a finding that **changes what a human would do**: a semver
-> implication, a deliberate omission, a follow-up that must be filed. Writing
-> `Nothing.` is a real verdict and the common one — say it plainly rather than
-> padding to look thorough.
+> empty. The bar is a finding that **changes what a human would do at merge
+> time**: a semver implication, a deliberate omission. Writing `Nothing.` is a
+> real verdict and the common one — say it plainly rather than padding to look
+> thorough.
+>
+> **Follow-up work is an issue, and you file it — it does not go in that
+> section.** When a finding clears that bar but is work someone would plausibly
+> do *later* rather than something that decides this merge:
+>
+> ```bash
+> gh issue create --label ai-suggested --title "<what to do>" --body "🤖 *Automated — \`<your agent type>\` via ai-issue-loop.*
+>
+> Surfaced reviewing #<N>. <What, and why it matters. A few lines.>"
+> ```
+>
+> Then put `Follow-up: #<new>` on one line in the body above `### Before
+> merging` and keep it out of that section, so it does not pull `ai-notes` in —
+> later work is not a merge gate. GitHub cross-links the two, so the trail
+> survives the merge in both directions; the comment prose does not. Filing is
+> the alternative to blocking, not a precondition for it. An observation is not
+> a follow-up — do not file one, and a trade-off that changes nothing a human
+> does is one line of body and nothing else.
 >
 > Then apply exactly one verdict label, **clearing your claim label in the same
 > command**:
@@ -655,6 +683,12 @@ package/from/to table survives because it sits at the top; classify from that.
 > unattended. A major, a package that ships to consumers, or a truncated body you
 > could not fully read **is** worth a note; restating the version table on a
 > routine dev-only patch bump is not.
+>
+> **Follow-up work is an issue here too** — same `gh issue create --label
+> ai-suggested` as the generic prompt, same `Follow-up: #<new>` one-liner in the
+> body, never in `### Before merging`. That separation matters more on this arm
+> than the other: a note here costs a human the merge, so routing "someone should
+> pin this transitive dep one day" to an issue is what keeps auto-merge usable.
 
 Be honest about what this buys: an agent reading a version table catches majors,
 production-dependency creep, and a renamed or newly-added package. It does **not**
@@ -727,6 +761,7 @@ gh api "repos/$OWNER_REPO/issues?labels=ai-ready&state=open" \
             | select([.labels[].name] | index("ai-wip") == null)
             | select([.labels[].name] | index("ai-blocked") == null)
             | select([.labels[].name] | index("holding") == null)
+            | select([.labels[].name] | index("ai-suggested") == null)
             | select(.author_association=="OWNER" or .author_association=="MEMBER" or .author_association=="COLLABORATOR")
             | {number, title}'
 ```
@@ -740,6 +775,10 @@ excluded here as belt-and-braces: such an issue should not carry `ai-ready` in
 the first place, but then mislabelling it costs nothing. Unlike `ai-blocked` (an
 agent tried and got stuck), `holding` says *no agent should ever start*, and it
 shows up in the issue list so a human triaging does not re-litigate it either.
+
+`ai-suggested` is excluded for a harder reason: it is an agent's own suggestion,
+so picking one up would let the loop feed itself work — promoting one is a human
+act, which is what makes that label a triage queue rather than a backlog.
 
 **Declining an issue is a visible act — comment, never just skip.** Whenever an
 agent decides an issue should *not* go to the pipeline — triaging which issues to

--- a/src/base/labels.ts
+++ b/src/base/labels.ts
@@ -50,11 +50,16 @@ export const LOOP_LABELS: readonly LabelSpec[] = [
 		color: 'fbca04',
 		description: 'Passed, but a reviewer left something to read before merging',
 	},
+	{
+		name: 'ai-suggested',
+		color: 'c2e0c6',
+		description: 'Follow-up surfaced by an agent review — triage queue, never auto-picked',
+	},
 ]
 
 /**
  * How many of the set have to exist before this repo counts as running the
- * loop. A repo with none has opted out, not drifted — creating eleven labels it
+ * loop. A repo with none has opted out, not drifted — creating twelve labels it
  * will never use is the nag this threshold exists to prevent. One alone is the
  * observed half-state (`cf-common` has only `ai-ready`, applied by hand), which
  * is likewise not evidence the pipeline runs there.
@@ -167,7 +172,7 @@ export async function checkLoopLabels(dir: string, exec?: GhExec): Promise<Check
  * Repairs colour and description with `gh label edit`, and creates the labels
  * the set is missing. Only on a repo already running the loop (the same
  * `IN_USE_THRESHOLD` gate the check uses) — otherwise a plain `fix --yes` would
- * push eleven labels into every repo it touches.
+ * push twelve labels into every repo it touches.
  *
  * Idempotent: an aligned repo is a no-op, and a label whose only difference is
  * the hex case is not touched at all.


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Closes #478

`ai-notes` listed "a follow-up that must be filed" among its examples and then never filed anything. Verified against the file before changing it: that sentence was at `SKILL.md:90` and in the reviewer prompt at `SKILL.md:543`, and nothing anywhere in the skill created an issue.

## The split

| Kind | Blocks? | Now goes to |
|---|---|---|
| Decides the merge | Effectively yes | PR comment + `ai-notes`, unchanged |
| Follow-up work | No | An `ai-suggested` issue the reviewer files; comment keeps `Follow-up: #N` |
| Context / trade-off | No | One line in the comment body |

`Follow-up: #N` goes in the comment body **above** `### Before merging`, deliberately not inside it. That section's contents are what trigger `ai-notes`, so putting a follow-up there would make later work suppress Dependabot auto-merge. Keeping it out means the existing `ai-notes` trigger, the merge conditions, and the auto-merge gate are all untouched.

## `ai-suggested` is a backlog, not a queue

Added to Pass 4's eligibility `--jq` alongside the `holding` exclusion, with a one-line why. An agent can never pick up another agent's suggestion; promoting one is a human act. Also added to the Labels table and the `gh label create` block, matching the description already on the repo (`#c2e0c6`).

The bar is what `ai-notes` has today **plus** "is work someone would plausibly do" — stated once in the label definition and once in the reviewer prompt, matching how the file already carries that sentence in both places.

## Scope deviation — `src/base/labels.ts`

I was asked to touch `SKILL.md` only. That is not achievable together with a green test run: `src/base/labels.ts` is the canonical label table, and `tests/base/labels.test.ts:180` asserts the skill's bootstrap block equals it element-for-element. Adding `ai-suggested` to only one side fails that test. So the diff is two files, and the second is seven lines: the label spec, plus two comments that said "eleven labels" and now say twelve.

## Size

**981 → 1020 lines (+39).** It grew, against #482's brevity pass. The new rule has four obligatory touch points (label definition, bootstrap block, both reviewer prompts) and one of them needs a `gh issue create` block a fresh agent can copy. I replaced the "must be filed" prose at both sites rather than adding beside it, and the Dependabot prompt points at the generic one instead of restating it, but I could not get this under the old line count without dropping a rule.

## Out of scope, as instructed

The implementer's `## For your decision` sections were left alone. For what it's worth: **yes, they should follow**, and I'd do it as a separate issue. The argument is the same one this PR makes and the mechanism is already built after this lands — but the implementer writes into a PR body rather than a review comment, so the "where does the one-liner go without tripping `ai-notes`" question has a different answer there and deserves its own review.

## Checks

`vitest run` — 1017 passed, 18 skipped, 61 files. Pre-commit (`biome check`, `typecheck`) passed via the husky hook.
