### PR TITLE
feat(doctor): honour --skills-dir when reporting the Claude skill

### DIFF
--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -521,11 +521,16 @@ export async function checkAiSetup(dir: string): Promise<CheckResult> {
  * is not a defect in this repo, and either of those statuses would fail its CI
  * over a file CI has never seen. `optional-missing` is the honest verdict — an
  * opt-in workflow tool that isn't configured — and it leaves the exit code alone.
+ *
+ * `skillsDir` is doctor's `--skills-dir`. Without it this reported against
+ * `~/.claude/skills` whatever directory the repo actually installs into, so a
+ * consumer who passes the flag to `fix` saw a permanent false `optional-missing`
+ * for a skill they have (#485).
  */
-export async function checkClaudeSkills(): Promise<CheckResult> {
+export async function checkClaudeSkills(skillsDir?: string): Promise<CheckResult> {
 	const check = 'Claude skills'
 	const hint = `Run \`npx @rtorcato/repo-tooling fix claude-skills\` to install the ${SHIPPED_SKILL} skill (writes outside the repo; opt-in, so \`fix\` alone skips it)`
-	const status = await claudeSkillStatus()
+	const status = await claudeSkillStatus(SHIPPED_SKILL, skillsDir)
 	if (!status.installed) {
 		return {
 			check,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -82,6 +82,8 @@ export { evaluateNodeVersion }
 export interface DoctorOptions {
 	directory?: string
 	json?: boolean
+	/** `--skills-dir`, mirroring `fix` — the read side of the same flag (#485). */
+	skillsDir?: string
 }
 
 const PACKAGE = '@rtorcato/repo-tooling'
@@ -222,6 +224,13 @@ interface BaseCheckOptions {
 	language: DetectedLanguage
 	/** The module's `codeqlLanguages`; empty means CodeQL can't analyse it (#289). */
 	codeqlLanguages: readonly string[]
+	/**
+	 * The run's `--skills-dir` — the one field here that isn't language-shaped.
+	 * It rides along because it is the only way the user-global skills check
+	 * hears about the flag, and threading it as a separate parameter reformats
+	 * every call site for no gain (#485).
+	 */
+	skillsDir?: string
 }
 
 // The language-agnostic checks (src/base): repo hygiene, git hooks, CI,
@@ -262,13 +271,13 @@ async function runBaseChecks(
 	results.push(await checkBrand(dir))
 	results.push(await checkAiSetup(dir))
 	// User-global, not repo state — see checkClaudeSkills on why it never returns drift.
-	results.push(await checkClaudeSkills())
+	results.push(await checkClaudeSkills(opts.skillsDir))
 	results.push(await checkReadmeBadges(dir, opts.badges.audience, opts.badges.fixTarget))
 	results.push(await checkCoverageUpload(dir))
 	return results
 }
 
-export async function runDoctor(dir: string): Promise<CheckResult[]> {
+export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckResult[]> {
 	const targetDir = path.resolve(dir)
 
 	const lock = await readLockfile(targetDir)
@@ -298,6 +307,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				presetWorkflow: null,
 				language,
 				codeqlLanguages: languageModule.codeqlLanguages,
+				skillsDir,
 			})),
 		]
 		return demoteDeclined(results, lock)
@@ -321,6 +331,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				presetWorkflow: renderSwiftWorkflow(await readSwiftPackage(targetDir)),
 				language,
 				codeqlLanguages: languageModule.codeqlLanguages,
+				skillsDir,
 			})),
 			...(await runSwiftChecks(targetDir)),
 		]
@@ -345,6 +356,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				presetWorkflow: renderPythonWorkflow(await readPyproject(targetDir)),
 				language,
 				codeqlLanguages: languageModule.codeqlLanguages,
+				skillsDir,
 			})),
 			...(await runPythonChecks(targetDir)),
 		]
@@ -371,6 +383,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 				presetWorkflow: renderPerlWorkflow(await readPerlProject(targetDir)),
 				language,
 				codeqlLanguages: languageModule.codeqlLanguages,
+				skillsDir,
 			})),
 			...(await runPerlChecks(targetDir)),
 		]
@@ -439,6 +452,7 @@ export async function runDoctor(dir: string): Promise<CheckResult[]> {
 			),
 			language,
 			codeqlLanguages: languageModule.codeqlLanguages,
+			skillsDir,
 		}))
 	)
 
@@ -509,7 +523,7 @@ export function summarize(results: CheckResult[]): {
 
 export async function doctorCommand(options: DoctorOptions = {}) {
 	const dir = options.directory ?? process.cwd()
-	const results = await runDoctor(dir)
+	const results = await runDoctor(dir, options.skillsDir)
 
 	if (options.json) {
 		console.log(JSON.stringify({ directory: path.resolve(dir), results }, null, 2))

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -447,7 +447,9 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 	const pkg = await readPackageJson(targetDir)
 	const lock = await readLockfile(targetDir)
 	const fixers = fixersForLanguage(await detectLanguage(targetDir))
-	const results = await runDoctor(targetDir)
+	// Same --skills-dir the claude-skills fixer writes to, so the diagnosis fix
+	// acts on and the install it performs agree on one directory (#485).
+	const results = await runDoctor(targetDir, options.skillsDir)
 	const actions: FixActionRecord[] = []
 
 	const noteLockConflict = (check: string): boolean => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -342,6 +342,12 @@ program
 	.description('🩺 Diagnose project alignment with @rtorcato/repo-tooling presets')
 	.option('-d, --directory <path>', 'Target directory to diagnose', process.cwd())
 	.option('--json', 'Emit machine-readable JSON output')
+	// The read side of `fix --skills-dir` (#485). No --yes/--json requirement
+	// here: doctor never writes, so an unresolved directory is just reported.
+	.option(
+		'--skills-dir <path>',
+		'Where `fix claude-skills` installs user-global agent skills (default: ~/.claude/skills). Pass the same path `fix` was given, or the skill reports as not installed'
+	)
 	.action(doctorCommand)
 
 program

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -8,6 +8,7 @@ import {
 	summarize,
 } from '../../../src/cli/commands/doctor.js'
 import { checkBuildApprovals, pnpmStoreDirToName } from '../../../src/languages/js/checks.js'
+import { installClaudeSkill } from '../../../src/cli/generators/claude-skills.js'
 import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
 import { copyPreset } from '../../../src/cli/utils/copy-preset.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -1750,6 +1751,35 @@ describe('checkBuildApprovals', () => {
 			expect(detail.match(/esbuild/g)).toHaveLength(1)
 			expect(detail).not.toContain('transitive')
 		})
+	})
+})
+
+// #485: `--skills-dir` used to be honoured only on the write path, so a repo
+// that installs anywhere but ~/.claude/skills got a permanent false
+// `optional-missing`. Both directions are asserted, so reverting the threading
+// fails one of them whichever way the real ~/.claude/skills happens to look.
+describe('doctor --skills-dir', () => {
+	const claudeSkills = async (dir: string, skillsDir: string) =>
+		(await runDoctor(dir, skillsDir)).find((r) => r.check === 'Claude skills')
+
+	it('reports the skill as installed from a custom skills dir', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const skillsDir = join(dir, 'custom-skills')
+		await installClaudeSkill(skillsDir)
+
+		const result = await claudeSkills(dir, skillsDir)
+		expect(result?.status).toBe('ok')
+		expect(result?.detail).toContain('installed')
+	})
+
+	it('reports it missing when the custom skills dir has not got it', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+
+		const result = await claudeSkills(dir, join(dir, 'empty-skills'))
+		expect(result?.status).toBe('optional-missing')
+		expect(result?.detail).toContain('not installed')
 	})
 })
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

`--skills-dir` was defined on `fix` only, so `doctor` always resolved the skill against `~/.claude/skills`. `claudeSkillStatus(name, explicit?)` already took the override; `checks.ts` called it bare, so a repo installed anywhere else got a permanent false `optional-missing` for a skill it has.

## What changed

- `--skills-dir <path>` on `doctor`, threaded action → `runDoctor` → base suite → `checkClaudeSkills`. No module-level state.
- No `--yes`/`--json` guard, unlike `fix`: doctor never writes, so an unresolved directory is just reported as not installed rather than being an error.
- `fix` now passes its own `--skills-dir` to the `runDoctor` call it makes, so the diagnosis it acts on and the install it performs agree on one directory.

## The other half: is anything else honoured on write and ignored on read?

No — and there is a structural reason, not just an empty grep.

- **Every other CLI option that affects a write has no read-side counterpart.** `--force-skills` is overwrite policy (doctor reports a fork as `ok` with a hint; there is nothing to honour). `--preset`, `--config`, `--skip-install` are `setup`-only inputs that leave no state outside the repo. `-d/--directory` is already honoured on both sides.
- **`--skills-dir` was the only candidate by construction**: `checkClaudeSkills` is, as its own doc comment says, the only check that reports on state *outside* the repo being audited. Every other check derives everything it reads from `dir`, so there is no second path where a flag could go missing.
- The other optional overrides in the check modules (`exec?: GhExec` in `labels.ts`, `milestones.ts`, `github-settings.ts`; `exec?: GitExec` in `git-identity.ts`) are test seams with no CLI flag behind them. Being called bare is what they are for.

## Tests

`tests/cli/commands/doctor.test.ts` — `doctor` reports the skill `ok` when `--skills-dir` points at a directory containing it, and `optional-missing` when it does not. The pair is revert-sensitive on any machine: whichever way the real `~/.claude/skills` happens to look, dropping the threading fails one of the two.

Verified: `biome lint .` (62 warnings, identical to `origin/main`), `tsc --noEmit -p src/cli/tsconfig.json`, `vitest run` (1019 passed).

`feat` rather than `fix`: it closes a bug report, but what ships is a new flag on a public command.

Closes #485
