### PR TITLE
test(biome): pin which config wins for the shipped preset's root: false

### DIFF
--- a/tests/cli/generators/linting.test.ts
+++ b/tests/cli/generators/linting.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra'
+import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
@@ -154,3 +155,104 @@ describe('generateLintingConfigs', () => {
 		expect(await fs.pathExists(join(dir, '.oxlintrc.json'))).toBe(false)
 	})
 })
+
+/**
+ * #486 — does the shipped preset's `"root": false` (#469) actually win where it
+ * lands? Every assertion here is a real `biome` run, because the failure mode is
+ * a config that resolves to nothing while the build stays green; no amount of
+ * reading JSON keys catches that.
+ *
+ * The probe is `any`, not `debugger`: `noExplicitAny` is on under Biome's
+ * built-in defaults and explicitly **off** in our preset, so its absence proves
+ * the preset was applied. A `debugger` is reported either way and would pass
+ * against a config that had silently evaporated.
+ *
+ * Two of the three tests are `it.fails` — they state the behaviour we want and
+ * assert it does not hold yet. Deleting the `.fails` is the whole fix-side edit
+ * once #486 is decided; the suite goes red the moment someone fixes it by
+ * accident, which is the point.
+ */
+describe.skipIf(!fs.existsSync(join(process.cwd(), 'node_modules', '.bin', 'biome')))(
+	'shipped biome preset: which config actually wins (#486)',
+	() => {
+		const newTmpDir = useTmpDir()
+		const biomeBin = join(process.cwd(), 'node_modules', '.bin', 'biome')
+		const PRESET = join(import.meta.dirname, '../../../tooling/biome/biome.json')
+		const PROBE = 'export const v: any = "x"\n'
+		/** A monorepo root that already owns a root config, on Biome's own defaults. */
+		const PARENT = {
+			$schema: 'https://biomejs.dev/schemas/latest/schema.json',
+			linter: { enabled: true, rules: { preset: 'recommended' } },
+		}
+
+		/** A tmp project with the preset installed the way a consumer would have it. */
+		async function project(): Promise<string> {
+			const dir = newTmpDir()
+			await fs.writeFile(join(dir, '.gitignore'), 'node_modules\n')
+			// The preset sets vcs.useIgnoreFile, which wants a real repo above it.
+			spawnSync('git', ['init', '--quiet'], { cwd: dir })
+
+			const pkg = join(dir, 'node_modules', '@rtorcato', 'repo-tooling')
+			await fs.ensureDir(join(pkg, 'tooling', 'biome'))
+			await fs.copy(PRESET, join(pkg, 'tooling', 'biome', 'biome.json'))
+			await fs.writeJson(join(pkg, 'package.json'), {
+				name: '@rtorcato/repo-tooling',
+				version: '0.0.0',
+				exports: { './biome': './tooling/biome/biome.json' },
+			})
+			return dir
+		}
+
+		function check(cwd: string, target = '.'): string {
+			const run = spawnSync(biomeBin, ['check', '--colors=off', target], {
+				cwd,
+				encoding: 'utf8',
+				timeout: 30_000,
+			})
+			return `${run.stdout}${run.stderr}`
+		}
+
+		// The case #486 was filed about, and the one `root: false` describes. It holds.
+		it('applies to a nested package, overriding the monorepo root config', async () => {
+			const root = await project()
+			await fs.writeJson(join(root, 'biome.json'), PARENT)
+			// `copy biome` drops the preset verbatim; the sibling has no config at all.
+			await fs.copy(PRESET, join(root, 'packages', 'nested', 'biome.json'))
+			await fs.outputFile(join(root, 'packages', 'nested', 'src', 'probe.ts'), PROBE)
+			await fs.outputFile(join(root, 'packages', 'sibling', 'src', 'probe.ts'), PROBE)
+
+			// A second root aborts the run outright, before any file is looked at.
+			expect(check(root)).not.toContain('nested root configuration')
+			// The nested preset won: it turns noExplicitAny off.
+			expect(check(root, 'packages/nested')).not.toContain('noExplicitAny')
+			// ...and the parent really was in force, so the silence above means something.
+			expect(check(root, 'packages/sibling')).toContain('noExplicitAny')
+		})
+
+		// `copy biome` writes the preset — `root: false` and all — as the consumer's
+		// own root config. Biome finds no root above it and silently falls back to
+		// its built-in defaults: no warning, no error, the preset simply gone.
+		it.fails('applies when copied in as the consumer’s own root config', async () => {
+			const dir = await project()
+			await fs.copy(PRESET, join(dir, 'biome.json'))
+			await fs.outputFile(join(dir, 'src', 'probe.ts'), PROBE)
+
+			expect(check(dir)).not.toContain('noExplicitAny')
+		})
+
+		// `root` is not inherited through `extends`, so the thin pointer
+		// `generateBiomeConfig` writes is still read as a root of its own. Loud
+		// rather than silent, but a scaffolded package inside someone else's
+		// monorepo cannot be checked from that monorepo's root at all.
+		it.fails('lets the scaffolded extends pointer sit inside a monorepo', async () => {
+			const root = await project()
+			await fs.writeJson(join(root, 'biome.json'), PARENT)
+			const scaffolded = join(root, 'packages', 'scaffolded')
+			await fs.ensureDir(scaffolded)
+			await generateBiomeConfig(scaffolded)
+			await fs.outputFile(join(scaffolded, 'src', 'probe.ts'), PROBE)
+
+			expect(check(root)).not.toContain('nested root configuration')
+		})
+	}
+)


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Refs #486. Leaving the issue open: the nested case it asked about holds, but testing it turned up two that do not, and the fix for those is a trade-off — see **For your decision**.

## What I ran

Everything below is `@biomejs/biome` **2.5.5**, run against throwaway fixtures outside the repo. No reasoning about how Biome "should" resolve configs — only observed output.

The probe file is `export const v: any = "x"`. That matters: `noExplicitAny` is **on** under Biome's built-in defaults and explicitly **off** in our preset, so its *absence* proves the preset was applied. `noDebugger` — the obvious probe — is recommended in both, so it is reported either way and would have passed against a config that had silently evaporated. My first pass used `noDebugger` and reached the wrong conclusion twice before I switched.

## 1. The case the issue asked about: it holds

Parent `biome.json` at a monorepo root (`recommended`), `packages/nested/biome.json` = the shipped preset verbatim, `packages/sibling` with no config at all.

| Run | Result |
|---|---|
| `biome check .` from the monorepo root | no config error; both packages checked |
| `biome check packages/nested` | `noExplicitAny` **not** reported → the nested preset won |
| `biome check packages/sibling` | `noExplicitAny` **reported** → the parent really was in force |
| From inside `packages/nested` | same as from the root; violations reported, exit 1 |

Formatting confirms it independently: the preset's `quoteStyle: single` is applied under `packages/nested` and not under the sibling. So the answer to all three questions in the issue is: the nested config applies, the violation is reported, and it does not differ by cwd.

## 2. `copy biome` into a standalone repo: the preset is silently ignored

`root: false` means "I am nested; my root is above me". When there is no root above, **Biome discards the config and falls back to its built-in defaults — with no warning, no error, and exit 0 on `--verbose`.**

`copy biome` writes `tooling/biome/biome.json` verbatim to the consumer's `biome.json`, at their repo root. So today, every repo scaffolded that way runs on stock Biome:

```
# preset copied in verbatim (has "root": false), no parent above
$ biome check src/probe.ts
src/probe.ts:1:17 lint/suspicious/noExplicitAny     <- preset turns this OFF
  × Formatter would have printed:  export const v: any = "x";   <- preset wants 'x' and no semicolon
```

Strip the `root` key from that same file and both diagnostics disappear. This is exactly the "resolves to nothing and looks like a green build" failure the issue predicted — just in the layout nobody was worried about.

I hit this in this repo too, while trialling a fix: adding `"root": false` to our own `biome.json` made `biome check --write` reformat 400+ lines to Biome defaults. Our root config has no `root` key, so **we are not affected** — but that is why the preset's `root: false` looked verified. It was never being read.

## 3. `root` does not inherit through `extends`

`generateBiomeConfig` writes a thin pointer, `{ "$schema": ..., "extends": ["@rtorcato/repo-tooling/biome"] }`, with no `root` key. The preset's `root: false` does **not** come through it, so Biome reads the pointer as a root config. Inside a larger monorepo:

```
$ biome lint .          # from the monorepo root
× Found a nested root configuration, but there's already a root configuration.
× Biome exited because the configuration resulted in errors.
```

Nothing is linted at all. Loud, not silent — but a scaffolded package inside someone else's monorepo cannot be checked from that monorepo's root. Adding `"root": false` to the pointer by hand fixes it (verified), which is also the proof that `extends` does not carry it.

This means the preset's `root: false` does nothing for `extends` consumers — the shape we actually scaffold — and actively breaks `copy biome` consumers. Its only working effect is letting *this* repo run `biome check .`, which was #469's goal.

## What I did not change

I tried to fix #3 by emitting `"root": false` on the pointer and reverted it: it fixes the nested case and silently disables linting for every standalone consumer, which is the larger and much worse population. Two dead ends also ruled out, both still hitting `Found a nested root configuration`:

- `files.includes: ["**", "!tooling/biome/**"]` on the root config — `includes` filters files, not config discovery.
- `files.experimentalScannerIgnores` — not a key Biome 2.5.5 accepts under `files`.

## This PR

Tests only, no shipped file touched. `tests/cli/generators/linting.test.ts` gains a `describe` that runs the real `biome` binary against all three fixtures. §1 is a passing test. §2 and §3 are `it.fails` — the body states the behaviour we want and pins that it does not hold yet, so the suite reports it the moment it changes. Deleting the `.fails` is the whole test-side edit once this is decided.

Verified: `biome lint .` exit 0 · `tsc --noEmit --project src/cli/tsconfig.json` exit 0 · `vitest run` — 1018 passed, 2 expected fail, 18 skipped, 61 files.

## For your decision

`root: false` is right for a nested config and wrong for a root one, and we ship one file into both positions. Three ways out, none free:

1. **Transform on copy** — strip `root` in `copyPreset` for `biome`. Smallest surface, but the #428 drift model in `src/cli/utils/copied-assets.ts` hashes the *source* and compares it to the target, so a transformed copy reads as permanently `modified`. Doing it properly means both `copyPreset` and `classifyCopiedAssets` hashing one shared "materialise" step. Existing `copy biome` consumers would then correctly show `stale` and be repaired by `fix copied-assets` — arguably the right migration signal.

2. **Rename the shipped preset** so Biome never auto-discovers it (`tooling/biome/preset.json`), and drop `root` entirely. Kills the collision at the source and removes the footgun from the published file. Invisible to `extends` consumers (they go through the `./biome` exports entry) and to `copy biome` (target name unchanged). Breaks anyone who hardcoded the raw `node_modules/.../tooling/biome/biome.json` path, and touches the exports map, the `files` list, `PRESETS.biome.source`, and doctor's path references.

3. **Revert #469** and put the lint scripts back to an explicit path list. Restores the footgun-free preset at the cost of the whole-repo `biome check .` that #469 bought, and re-opens #467.

Separately, whichever is chosen, #3 above (nested `extends` pointer) stays broken unless the pointer can learn when it is nested — a `--nested` flag on `fix biome`, or doctor detecting a parent `biome.json`. I did not want to guess at that.

I'd take **2**: it deletes the problem rather than working around it, and `root` stops being something a consumer can inherit by accident.
