### PR TITLE
fix(doctor): name both paths in the skill-fork diff hint

### DIFF
--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -2,7 +2,11 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { BLOCK_START, hasStaleAgentBlock } from '../cli/generators/agent-rules.js'
 import { BADGE_START, hasPublicOnlyBadges } from '../cli/generators/badges.js'
-import { claudeSkillStatus, SHIPPED_SKILL } from '../cli/generators/claude-skills.js'
+import {
+	claudeSkillStatus,
+	SHIPPED_SKILL,
+	skillDiffCommand,
+} from '../cli/generators/claude-skills.js'
 import { DEPENDABOT_CONFIG_PATHS, dependabotIgnoreRules } from '../cli/generators/security.js'
 import { type DetectedLanguage, detectNestedLanguages } from '../cli/utils/detect-language.js'
 import type { CheckResult } from './types.js'
@@ -552,7 +556,9 @@ export async function checkClaudeSkills(skillsDir?: string): Promise<CheckResult
 	// A local fork is `ok` for the same reason a modified copied asset is (#448):
 	// it is somebody's deliberate work, so it is named once and never nagged as
 	// fixable — pointing at a `fix` that would refuse is worse than saying nothing.
-	if (status.contentState && status.contentState !== 'pristine') {
+	// `realFile` is set whenever `contentState` is — both mean something is
+	// installed. The extra test is TypeScript's, not a real condition.
+	if (status.realFile && status.contentState && status.contentState !== 'pristine') {
 		const why =
 			status.contentState === 'modified'
 				? `has local changes since ${status.installedVersion}`
@@ -561,7 +567,9 @@ export async function checkClaudeSkills(skillsDir?: string): Promise<CheckResult
 			check,
 			status: 'ok',
 			detail: `${SHIPPED_SKILL} skill at ${status.file} ${why}; this package ships ${status.shippedVersion} and will not overwrite it`,
-			hint: `Diff it against the shipped copy, then run \`npx @rtorcato/repo-tooling fix claude-skills --force-skills\` to take the shipped version`,
+			// Name both paths: "diff it against the shipped copy" left the reader
+			// with nothing to diff, in the one case they most want to look (#484).
+			hint: `Diff it against the shipped copy — \`${skillDiffCommand({ realFile: status.realFile, shippedFile: status.shippedFile })}\` — then run \`npx @rtorcato/repo-tooling fix claude-skills --force-skills\` to take the shipped version`,
 		}
 	}
 	return {

--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -20,6 +20,7 @@ import {
 	installClaudeSkill,
 	resolveSkillsDir,
 	SHIPPED_SKILL,
+	skillDiffCommand,
 	type SkillInstallResult,
 } from '../cli/generators/claude-skills.js'
 import { generateBrand } from '../cli/generators/brand.js'
@@ -158,7 +159,7 @@ function describeSkillFork(result: SkillInstallResult): string[] {
 	return [
 		`skipped — ${SHIPPED_SKILL} was not overwritten with ${result.shippedVersion}: ${why}`,
 		`  ${target}`,
-		`  compare:  diff "${result.realFile}" "${result.shippedFile}"`,
+		`  compare:  ${skillDiffCommand(result)}`,
 		'  overwrite anyway:  fix claude-skills --force-skills',
 	]
 }

--- a/src/cli/generators/claude-skills.ts
+++ b/src/cli/generators/claude-skills.ts
@@ -202,6 +202,17 @@ export interface SkillInstallResult {
 	shippedVersion: string
 }
 
+/**
+ * The command a human runs to see what their fork changed, before deciding
+ * whether to take the shipped copy. One builder, because `doctor` and `fix`
+ * both print it and two independently-built strings drift (#484). Always
+ * `realFile`: through a stow symlink the nominal path is the link, and the
+ * bytes worth reading are in the dotfiles checkout it points at.
+ */
+export function skillDiffCommand(paths: { realFile: string; shippedFile: string }): string {
+	return `diff "${paths.realFile}" "${paths.shippedFile}"`
+}
+
 /** Whether `file` is itself a symlink, as opposed to merely resolving through one. */
 async function isSymlink(file: string): Promise<boolean> {
 	return await fs
@@ -265,6 +276,14 @@ export async function installClaudeSkill(
 export interface SkillStatus {
 	/** Null when no skills directory could be resolved at all. */
 	file: string | null
+	/**
+	 * Where the bytes actually live — `file` resolved when it is a symlink into a
+	 * dotfiles checkout. Null when nothing is installed, so there is nothing to
+	 * resolve. See `SkillInstallResult.realFile`.
+	 */
+	realFile: string | null
+	/** The shipped source inside this package, so doctor can name a real `diff`. */
+	shippedFile: string
 	installed: boolean
 	/** Null when installed but unstamped — a copy that predates this feature. */
 	installedVersion: string | null
@@ -287,6 +306,8 @@ export async function claudeSkillStatus(
 	const shipped = await readShippedSkill(name)
 	const { dir } = await resolveSkillsDir(explicit)
 	const absent = {
+		realFile: null,
+		shippedFile: shipped.file,
 		installed: false,
 		installedVersion: null,
 		shippedVersion: shipped.version,
@@ -302,6 +323,8 @@ export async function claudeSkillStatus(
 	const behind = installedVersion === null || isNewerVersion(shipped.version, installedVersion)
 	return {
 		file,
+		realFile: (await isSymlink(file)) ? await fs.realpath(file) : file,
+		shippedFile: shipped.file,
 		installed: true,
 		installedVersion,
 		shippedVersion: shipped.version,

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -8,7 +8,7 @@ import {
 	summarize,
 } from '../../../src/cli/commands/doctor.js'
 import { checkBuildApprovals, pnpmStoreDirToName } from '../../../src/languages/js/checks.js'
-import { installClaudeSkill } from '../../../src/cli/generators/claude-skills.js'
+import { installClaudeSkill, SHIPPED_SKILL } from '../../../src/cli/generators/claude-skills.js'
 import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
 import { copyPreset } from '../../../src/cli/utils/copy-preset.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
@@ -1780,6 +1780,43 @@ describe('doctor --skills-dir', () => {
 		const result = await claudeSkills(dir, join(dir, 'empty-skills'))
 		expect(result?.status).toBe('optional-missing')
 		expect(result?.detail).toContain('not installed')
+	})
+})
+
+// #484: the fork hint said "diff it against the shipped copy" and named neither
+// file, in the one case the reader most wants to look before deciding whether to
+// --force-skills. Both paths are asserted, so dropping either fails a test.
+describe('doctor: a forked Claude skill', () => {
+	const skillFile = (skillsDir: string) => join(skillsDir, SHIPPED_SKILL, 'SKILL.md')
+	const claudeSkills = async (dir: string, skillsDir: string) =>
+		(await runDoctor(dir, skillsDir)).find((r) => r.check === 'Claude skills')
+
+	it('names the installed and the shipped file in a runnable diff', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const skillsDir = join(dir, 'custom-skills')
+		const { shippedFile } = await installClaudeSkill(skillsDir)
+		await fs.appendFile(skillFile(skillsDir), '\nlocal edit\n')
+
+		const result = await claudeSkills(dir, skillsDir)
+		expect(result?.status).toBe('ok')
+		expect(result?.hint).toContain(`diff "${skillFile(skillsDir)}" "${shippedFile}"`)
+	})
+
+	// stow symlinks at file level, so the installed path is routinely a link into
+	// a dotfiles checkout. Diffing the link's own path sends the reader nowhere.
+	it('names the symlink target rather than the link', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		const skillsDir = join(dir, 'custom-skills')
+		const dotfiles = join(dir, 'dotfiles', 'SKILL.md')
+		await fs.outputFile(dotfiles, `---\nname: ${SHIPPED_SKILL}\n---\n\nmy fork\n`)
+		await fs.ensureDir(join(skillsDir, SHIPPED_SKILL))
+		await fs.symlink(dotfiles, skillFile(skillsDir))
+
+		const result = await claudeSkills(dir, skillsDir)
+		expect(result?.hint).toContain(await fs.realpath(dotfiles))
+		expect(result?.hint).not.toContain(skillFile(skillsDir))
 	})
 })
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

`doctor`'s fork hint said *"Diff it against the shipped copy"* and named neither file, so anyone acting on `doctor` output alone had nothing to diff.

- `claudeSkillStatus` now carries `realFile` and `shippedFile`.
- One `skillDiffCommand` helper builds the command for both `doctor` and `fix claude-skills`, so the two can never name different files (the #475 two-copies problem).
- `realFile` is the resolved target, so a stow symlink into a dotfiles checkout sends the reader to the bytes rather than the link.
- `--skills-dir` (#490) needs nothing extra: `realFile` derives from whatever directory `resolveSkillsDir` returns.

Tests assert the exact `diff "<installed>" "<shipped>"` string in the hint, plus the symlink case (target named, link not).

`biome lint`, `tsc --noEmit`, and `vitest run` (1022 passed) are clean.

Closes #484