### PR TITLE
docs(site): refresh the homepage CLI transcripts against the real output

### DIFF
--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -183,9 +183,23 @@ type Example = {
 }
 
 // Hand-transcribed from the real CLI. When you change what these commands
-// print, update the matching entry here — the source of truth for each tab is
-// src/cli/commands/{setup,doctor,fix}.ts. Lines marked `…` are truncated on
+// print, update the matching entry here. Lines marked `…` are truncated on
 // purpose (a real run prints the full list); nothing else here is invented.
+//
+// Each command file renders the framing, but most of the per-item text does
+// not live there — to check a tab against the code, start at the command and
+// follow it out:
+//   setup  — src/cli/commands/setup.ts (file-count banner, feature
+//            checkboxes, phase lines); the file list itself is
+//            computeFileList() in src/cli/commands/setup-presets.ts.
+//   doctor — src/cli/commands/doctor.ts (heading, status lines, Summary,
+//            Next steps) also owns the Release token check; every other check
+//            name/detail/hint comes from src/base/checks.ts and
+//            src/languages/js/checks.ts.
+//   fix    — src/cli/commands/fix.ts (counts, wrote/skipped lines, Summary);
+//            the `check → target` arrows come from
+//            src/cli/commands/fix-targets.ts, and which checks have a fixer
+//            or are skipped unless named explicitly from src/base/fixers.ts.
 const EXAMPLES: Example[] = [
 	{
 		label: 'setup',

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -182,22 +182,44 @@ type Example = {
 	code: string
 }
 
+// Hand-transcribed from the real CLI. When you change what these commands
+// print, update the matching entry here — the source of truth for each tab is
+// src/cli/commands/{setup,doctor,fix}.ts. Lines marked `…` are truncated on
+// purpose (a real run prints the full list); nothing else here is invented.
 const EXAMPLES: Example[] = [
 	{
 		label: 'setup',
-		file: 'npx @rtorcato/repo-tooling setup',
+		file: 'npx @rtorcato/repo-tooling setup --preset library',
 		language: 'bash',
-		code: `$ npx @rtorcato/repo-tooling setup
+		code: `$ npx @rtorcato/repo-tooling setup --preset library
 
-🛠️  Welcome to repo-tooling setup!
-? Project type:    📚 Library/Package
-? TypeScript:      ✅ Yes
-? Linter:          ⚡ Biome
-? Test framework:  ⚡ Vitest
-? Git hooks:       ✅ Husky + lint-staged
-? Releases:        🚀 semantic-release
+📄 This preset writes 32 files:
 
-✅ Setup complete.`,
+   package.json
+   .repo-tooling.json
+   .editorconfig
+   .nvmrc
+   .gitignore
+   knip.json
+   .vscode/extensions.json
+   tsconfig.json
+   … and 24 more
+
+? 🧹 Uncheck anything you do not want:
+❯◉ Git hooks (Husky + lint-staged)
+ ◉ Conventional commit linting (commitlint)
+ ◉ Automated releases (semantic-release)
+ ◉ Security automation (Dependabot + CodeQL)
+ ◯ README status badges
+ ◯ AI agent rules (AGENTS.md, CLAUDE.md, Cursor, Copilot)
+
+🛠️  Scaffolding library in ~/my-lib
+
+📝 Generating configuration files...
+
+📦 Installing dependencies...
+
+✅ Setup completed successfully!`,
 	},
 	{
 		label: 'doctor',
@@ -205,14 +227,26 @@ const EXAMPLES: Example[] = [
 		language: 'bash',
 		code: `$ npx @rtorcato/repo-tooling doctor
 
-⚕️  Checking project health…
-✔ TypeScript      base config extends @rtorcato/repo-tooling
-✔ Biome           config present
-⚠ Vitest          coverage thresholds drifted
-⚠ Dependabot      not configured
-✖ CI workflow     missing typecheck job
+🩺 Diagnosing ~/my-lib against @rtorcato/repo-tooling presets...
 
-2 warnings, 1 missing → run \`fix\` to resolve.`,
+  ❌ TypeScript — missing
+     no tsconfig.json found
+  ⚠️  Release token — drift
+     release.yml runs semantic-release with bare GITHUB_TOKEN
+  ✅ EditorConfig — ok
+     .editorconfig found
+  ✅ GitHub Actions — ok
+     2 workflows in .github/workflows/
+  ➖ Dependabot — not configured
+     no Dependabot or Renovate config
+  … 47 more checks
+
+  Summary: 48 ok, 1 drift, 1 missing, 2 not configured
+
+  Next steps:
+    - Run \`npx @rtorcato/repo-tooling fix tsconfig\` to scaffold TypeScript
+    - Run \`npx @rtorcato/repo-tooling fix dependabot\` to scaffold Dependabot
+    - Run \`npx @rtorcato/repo-tooling fix\` to walk all findings interactively`,
 	},
 	{
 		label: 'fix',
@@ -220,12 +254,19 @@ const EXAMPLES: Example[] = [
 		language: 'bash',
 		code: `$ npx @rtorcato/repo-tooling fix --yes
 
-🔧 Applying fixes…
-✔ vitest          reset coverage thresholds
-✔ dependabot      scaffolded .github/dependabot.yml
-✔ ci              added typecheck job to ci.yml
+🔧 4 item(s) to address
 
-3 fixes applied. Re-run \`doctor\` to verify.`,
+  TypeScript (missing) → tsconfig
+  ✅ wrote tsconfig.json, package.json
+     ↻ .repo-tooling.json updated to reflect the new choice
+  — Release token: no fixer registered
+  Dependabot (optional-missing) → dependabot
+  ✅ wrote .github/dependabot.yml, .github/workflows/dependabot-automerge.yml
+     ↻ .repo-tooling.json updated to reflect the new choice
+  Claude skills (optional-missing) → claude-skills
+    skipped — run \`fix claude-skills\` explicitly
+
+  Summary: 2 applied, 1 skipped, 1 unsupported`,
 	},
 ]
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Closes #488

Took **option 1** (refresh by hand). Option 2 needs a non-interactive transcript mode the wizard does not have; option 3 throws away the first thing a prospective user sees. Option 1 is cheap and reversible.

## Which setup flow the demo shows

**`--preset library`, not the plain interactive wizard.**

The plain wizard is now **18 prompts** (`src/cli/commands/setup.ts:328-550`) — language, project name, type, TypeScript, tsconfig flavour, linter, oxlint, test framework, git hooks, commitlint, release tool, tree-shake, publint, badges, security, AI rules, bundler, bun. Compressing that to six lines is *exactly* what produced the stale mock: a shape that looks plausible and matches nothing.

The preset path is genuinely short, and it advertises the better story: one command, a **reviewable file list before a single file is written** (#470), and a checkbox to drop the opinionated extras. That is the thing worth putting on a homepage.

**Note for reviewers:** `--preset` sets `interactive = false` (`setup.ts:187`), so the `🛠️  Welcome to repo-tooling setup!` greeting does **not** appear on this path — its absence from the page is correct, not a regression of #481. The CLI greeting is still pinned by `tests/cli/commands/setup.test.ts:631`.

## `doctor` and `fix` had drifted too

Asked to check them — they were **not** fine. Neither matched the real output at all:

| | Homepage said | CLI actually prints |
|---|---|---|
| doctor header | `⚕️  Checking project health…` | `🩺 Diagnosing <dir> against @rtorcato/repo-tooling presets...` |
| doctor rows | `✔ TypeScript      base config extends …` | `✅ TypeScript — ok` + indented gray detail on the next line |
| doctor footer | `2 warnings, 1 missing → run \`fix\`` | `Summary: N ok, N drift, N missing, N not configured` + a `Next steps:` block |
| fix header | `🔧 Applying fixes…` | `🔧 N item(s) to address` |
| fix rows | `✔ vitest          reset coverage thresholds` | `Vitest (drift) → vitest` then `✅ wrote …` |
| fix footer | `3 fixes applied.` | `Summary: N applied, N skipped, N unsupported` |

Both are rewritten. Every check name, status word, detail string, fix target and verb is taken verbatim from `src/base/checks.ts`, `src/languages/js/checks.ts`, `src/cli/commands/fix-targets.ts` and `src/base/fixers.ts`. The three tabs now describe **one coherent repo**: doctor's four findings are the same four `fix --yes` walks, `Release token` correctly has no registered fixer, and `Claude skills` is correctly `explicitOnly` so `--yes` skips it.

Where a real run prints more than fits, the elision is marked (`… and 24 more`, `… 47 more checks`) rather than silently dropped — per the issue's "truncate visibly rather than invent a shorter flow".

## For your decision

The drift-reduction I did *not* build, in rough order of cost:

1. **What I did ship (free):** a comment above `EXAMPLES` naming the three source files each tab transcribes. Costs 4 lines; makes the next CLI-output change at least *findable* from the docs side, and vice versa.
2. **A cheap test (~20 lines, no new CLI code):** assert the transcripts contain strings the CLI genuinely exports — `PRESET_NAMES`, `REVIEWABLE_FEATURES[].label`, `FIX_TARGETS` values, the `STATUS_ICONS` labels. It would not catch layout drift, but it would have caught *every* drift actually present here, because all of it was in names and labels. This is the best value-per-line on the list.
3. **`setup --transcript` (option 2 proper):** a real non-interactive replay the docs build snapshots. Correct and self-maintaining, but it means teaching the wizard to render without a TTY — a much larger change than #488 justifies.

I'd take (2) as a follow-up if you want the guarantee; (1) alone leaves this drifting again at the next wizard change, which the issue already accepts.

## Verification

- `biome check apps/docs/src/pages/index.tsx` — clean
- `biome lint .` — 62 warnings, all pre-existing CSS `!important`/a11y warnings, none in the changed file
- `tsc --noEmit --project src/cli/tsconfig.json` — clean
- `vitest run` — 61 files passed, 1020 tests passed, 2 expected-fail, 18 skipped