### PR TITLE
fix(biome): rename the shipped preset so Biome never auto-discovers it

### DIFF
--- a/apps/docs/biome.json
+++ b/apps/docs/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/latest/schema.json",
   "root": false,
-  "extends": ["../../tooling/biome/biome.json"],
+  "extends": ["../../tooling/biome/preset.json"],
   "files": {
     "includes": ["!**/.docusaurus", "!**/build", "!**/node_modules", "!**/docs/changelog.md"]
   }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"tooling/docusaurus/docs-helpers.mjs",
 		"tooling/docusaurus/theme-tokens.css",
 		"tooling/docusaurus/theme.css",
-		"tooling/biome/biome.json",
+		"tooling/biome/preset.json",
 		"tooling/bun/bunfig.toml",
 		"tooling/nx/nx.json",
 		"tooling/changesets/config.json",
@@ -201,7 +201,7 @@
 			"types": "./tooling/docusaurus/index.d.mts",
 			"import": "./tooling/docusaurus/index.mjs"
 		},
-		"./biome": "./tooling/biome/biome.json",
+		"./biome": "./tooling/biome/preset.json",
 		"./nx": "./tooling/nx/nx.json",
 		"./changesets": "./tooling/changesets/config.json",
 		"./release-please": "./tooling/release-please/release-please-config.json",

--- a/scripts/copy-biome-config.sh
+++ b/scripts/copy-biome-config.sh
@@ -13,7 +13,7 @@ if [ ! -d "node_modules/@rtorcato/repo-tooling" ]; then
 fi
 
 # Copy the base configuration
-cp node_modules/@rtorcato/repo-tooling/tooling/biome/biome.json ./biome.json
+cp node_modules/@rtorcato/repo-tooling/tooling/biome/preset.json ./biome.json
 
 echo "✅ Biome configuration copied successfully!"
 echo ""

--- a/scripts/sync-biome-config.sh
+++ b/scripts/sync-biome-config.sh
@@ -4,11 +4,11 @@
 echo "🔄 Syncing Biome configurations..."
 
 # Copy the base config to root (removing comments for compatibility)
-jq '.' tooling/biome/biome.json > biome.json
+jq '.' tooling/biome/preset.json > biome.json
 
 # Add project-specific overrides
 jq '.files.includes += ["!**/.pnpm-store", "!**/tooling/typescript/**/*.json"]' biome.json > biome.temp.json
 mv biome.temp.json biome.json
 
-echo "✅ Biome config synced from tooling/biome/biome.json"
+echo "✅ Biome config synced from tooling/biome/preset.json"
 echo "📝 Added project-specific excludes"

--- a/src/cli/utils/copy-preset.ts
+++ b/src/cli/utils/copy-preset.ts
@@ -37,7 +37,9 @@ export interface PresetDefinition {
 
 export const PRESETS: Record<PresetName, PresetDefinition> = {
 	biome: {
-		source: 'tooling/biome/biome.json',
+		// Not named `biome.json`: Biome auto-discovers any file by that name, so
+		// shipping one inside this package made it a second root config here (#486).
+		source: 'tooling/biome/preset.json',
 		target: 'biome.json',
 		desc: 'Biome formatter and linter configuration',
 	},

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -108,7 +108,7 @@ function matchesBiomeConfig(contents: string): boolean {
 	if (BIOME_PRESET_REF.test(JSON.stringify(config.extends ?? ''))) return true
 
 	// The inlined preset: biome's own `$schema` plus the `linter.rules.preset`
-	// key the shipped `tooling/biome/biome.json` sets.
+	// key the shipped `tooling/biome/preset.json` sets.
 	const schema = config.$schema
 	return (
 		typeof schema === 'string' &&
@@ -1501,7 +1501,7 @@ function readSchemaUrl(contents: string): string | null {
  * of which version the config targets, so comparing it against the declared
  * dependency floor is exact — no heuristics, no false positives.
  *
- * This is the #330 defect precisely: `tooling/biome/biome.json` carries
+ * This is the #330 defect precisely: `tooling/biome/preset.json` carries
  * `$schema` 2.5.0 and uses `linter.rules.preset`, a 2.5 key, while
  * `peerDependencies` advertised `@biomejs/biome: ^2.0.0`. Consumers on 2.0–2.4
  * got `Found an unknown key \`preset\`` with nothing pointing at the range.

--- a/tests/cli/generators/linting.test.ts
+++ b/tests/cli/generators/linting.test.ts
@@ -118,7 +118,9 @@ describe('generateLintingConfigs', () => {
 	// #363: `useIgnoreFile` does nothing while `vcs.enabled` is false, so the
 	// preset linted build output — 1477 errors from .next/ on a Next.js app.
 	it('ships a preset whose .gitignore setting is actually switched on', async () => {
-		const preset = await fs.readJson(join(import.meta.dirname, '../../../tooling/biome/biome.json'))
+		const preset = await fs.readJson(
+			join(import.meta.dirname, '../../../tooling/biome/preset.json')
+		)
 		expect(preset.vcs).toMatchObject({ enabled: true, clientKind: 'git', useIgnoreFile: true })
 	})
 
@@ -144,7 +146,9 @@ describe('generateLintingConfigs', () => {
 	// The shipped preset is parsed by whichever Biome the consumer installed, so
 	// it must not pin either — it carried its own separate stale 2.5.0 (#468).
 	it('ships a preset whose $schema is unpinned too', async () => {
-		const preset = await fs.readJson(join(import.meta.dirname, '../../../tooling/biome/biome.json'))
+		const preset = await fs.readJson(
+			join(import.meta.dirname, '../../../tooling/biome/preset.json')
+		)
 		expect(preset.$schema).toBe('https://biomejs.dev/schemas/latest/schema.json')
 	})
 
@@ -157,27 +161,36 @@ describe('generateLintingConfigs', () => {
 })
 
 /**
- * #486 — does the shipped preset's `"root": false` (#469) actually win where it
- * lands? Every assertion here is a real `biome` run, because the failure mode is
- * a config that resolves to nothing while the build stays green; no amount of
- * reading JSON keys catches that.
+ * #486 — does the shipped preset actually win where it lands? Every assertion
+ * here is a real `biome` run, because the failure mode is a config that resolves
+ * to nothing while the build stays green; no amount of reading JSON keys catches
+ * that.
  *
  * The probe is `any`, not `debugger`: `noExplicitAny` is on under Biome's
  * built-in defaults and explicitly **off** in our preset, so its absence proves
  * the preset was applied. A `debugger` is reported either way and would pass
  * against a config that had silently evaporated.
  *
- * Two of the three tests are `it.fails` — they state the behaviour we want and
- * assert it does not hold yet. Deleting the `.fails` is the whole fix-side edit
- * once #486 is decided; the suite goes red the moment someone fixes it by
- * accident, which is the point.
+ * #486 renamed the shipped file to `preset.json` and dropped `"root": false`
+ * (#469). One file cannot be both a root and a non-root, so that traded one
+ * failure for another — and the trade is the point:
+ *
+ * - **Fixed:** a `copy biome` into a standalone repo used to be discarded in
+ *   silence, leaving the consumer on stock Biome with exit 0. It now applies.
+ * - **Traded:** that same verbatim copy, landed in a package under someone
+ *   else's monorepo root, is now a second root config and Biome aborts loudly.
+ *
+ * The trade is worth taking because it *converges* the residual: the copied
+ * config and the scaffolded `extends` pointer now fail the same way, for the
+ * same reason, and one fix — teaching the scaffold when it is nested — closes
+ * both. #486 left that open, so the last test stays `it.fails`.
  */
 describe.skipIf(!fs.existsSync(join(process.cwd(), 'node_modules', '.bin', 'biome')))(
 	'shipped biome preset: which config actually wins (#486)',
 	() => {
 		const newTmpDir = useTmpDir()
 		const biomeBin = join(process.cwd(), 'node_modules', '.bin', 'biome')
-		const PRESET = join(import.meta.dirname, '../../../tooling/biome/biome.json')
+		const PRESET = join(import.meta.dirname, '../../../tooling/biome/preset.json')
 		const PROBE = 'export const v: any = "x"\n'
 		/** A monorepo root that already owns a root config, on Biome's own defaults. */
 		const PARENT = {
@@ -194,11 +207,11 @@ describe.skipIf(!fs.existsSync(join(process.cwd(), 'node_modules', '.bin', 'biom
 
 			const pkg = join(dir, 'node_modules', '@rtorcato', 'repo-tooling')
 			await fs.ensureDir(join(pkg, 'tooling', 'biome'))
-			await fs.copy(PRESET, join(pkg, 'tooling', 'biome', 'biome.json'))
+			await fs.copy(PRESET, join(pkg, 'tooling', 'biome', 'preset.json'))
 			await fs.writeJson(join(pkg, 'package.json'), {
 				name: '@rtorcato/repo-tooling',
 				version: '0.0.0',
-				exports: { './biome': './tooling/biome/biome.json' },
+				exports: { './biome': './tooling/biome/preset.json' },
 			})
 			return dir
 		}
@@ -212,8 +225,11 @@ describe.skipIf(!fs.existsSync(join(process.cwd(), 'node_modules', '.bin', 'biom
 			return `${run.stdout}${run.stderr}`
 		}
 
-		// The case #486 was filed about, and the one `root: false` describes. It holds.
-		it('applies to a nested package, overriding the monorepo root config', async () => {
+		// The case #469's `root: false` bought, and what #486 gave back for it: a
+		// verbatim copy under a monorepo root is a second root, so the run aborts
+		// before any file is read. Loud — and it is the same defect the scaffolded
+		// pointer hits below, which is why one `--nested` fix would close both.
+		it('is a second root config when copied into a package under a monorepo root', async () => {
 			const root = await project()
 			await fs.writeJson(join(root, 'biome.json'), PARENT)
 			// `copy biome` drops the preset verbatim; the sibling has no config at all.
@@ -221,23 +237,41 @@ describe.skipIf(!fs.existsSync(join(process.cwd(), 'node_modules', '.bin', 'biom
 			await fs.outputFile(join(root, 'packages', 'nested', 'src', 'probe.ts'), PROBE)
 			await fs.outputFile(join(root, 'packages', 'sibling', 'src', 'probe.ts'), PROBE)
 
-			// A second root aborts the run outright, before any file is looked at.
-			expect(check(root)).not.toContain('nested root configuration')
-			// The nested preset won: it turns noExplicitAny off.
-			expect(check(root, 'packages/nested')).not.toContain('noExplicitAny')
-			// ...and the parent really was in force, so the silence above means something.
+			// It fails, but it says so — no silent fallback to stock Biome.
+			expect(check(root)).toContain('nested root configuration')
+			// ...and the parent really is in force, so that abort is the only thing
+			// standing between the monorepo root and a working check.
 			expect(check(root, 'packages/sibling')).toContain('noExplicitAny')
 		})
 
-		// `copy biome` writes the preset — `root: false` and all — as the consumer's
-		// own root config. Biome finds no root above it and silently falls back to
-		// its built-in defaults: no warning, no error, the preset simply gone.
-		it.fails('applies when copied in as the consumer’s own root config', async () => {
+		// The whole point of the rename: `copy biome` lands the preset as the
+		// consumer's own root config. With `root: false` still on it, Biome found no
+		// root above, silently fell back to built-in defaults and exited 0 — the
+		// preset simply gone. Dropping the key is what makes this hold.
+		it('applies when copied in as the consumer’s own root config', async () => {
 			const dir = await project()
 			await fs.copy(PRESET, join(dir, 'biome.json'))
 			await fs.outputFile(join(dir, 'src', 'probe.ts'), PROBE)
 
 			expect(check(dir)).not.toContain('noExplicitAny')
+		})
+
+		// The shape consumers actually use, and the one the rename could silently
+		// break: `extends` goes through the `./biome` exports entry, so if that entry
+		// and the file on disk drift apart the preset stops arriving. This repo's own
+		// `biome check .` proves nothing here — its node_modules symlinks back to the
+		// working tree, so it resolves whatever is checked out rather than what ships.
+		it('applies through the extends pointer, resolved via the exports map', async () => {
+			const dir = await project()
+			await generateBiomeConfig(dir)
+			await fs.outputFile(join(dir, 'src', 'probe.ts'), PROBE)
+
+			const out = check(dir)
+			// `Checked N files` only prints once config resolution succeeded — an
+			// exports entry pointing at nothing aborts the run instead, which would
+			// otherwise make the assertion below pass by printing nothing at all.
+			expect(out).toContain('Checked')
+			expect(out).not.toContain('noExplicitAny')
 		})
 
 		// `root` is not inherited through `extends`, so the thin pointer

--- a/tests/cli/utils/copy-preset.test.ts
+++ b/tests/cli/utils/copy-preset.test.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { PRESETS } from '../../../src/cli/utils/copy-preset.js'
+
+const repoRoot = join(import.meta.dirname, '../../..')
+const pkg = fs.readJsonSync(join(repoRoot, 'package.json'))
+
+/**
+ * #486 renamed `tooling/biome/biome.json` to `tooling/biome/preset.json`. Three
+ * places had to move together — `PRESETS.biome.source`, the `./biome` exports
+ * entry, and the `files` array — and nothing failed if one of them was missed:
+ * `files` is globs, so a stale exports target still resolves in the repo and
+ * only 404s once published. `npm pack --dry-run` answers what actually ships
+ * without reimplementing npm's glob semantics.
+ */
+describe('shipped preset paths', () => {
+	let published: Set<string>
+
+	beforeAll(() => {
+		// --ignore-scripts skips the build; nothing asserted here lives in dist.
+		const run = spawnSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+			cwd: repoRoot,
+			encoding: 'utf8',
+			timeout: 120_000,
+		})
+		// Without this, a failed pack surfaces as an opaque JSON.parse error.
+		if (run.status !== 0) throw new Error(`npm pack failed (${run.status}): ${run.stderr}`)
+		const files = JSON.parse(run.stdout)[0].files as { path: string }[]
+		published = new Set(files.map((f) => f.path))
+	})
+
+	it('publishes every file `copy <preset>` reads from', () => {
+		for (const [name, preset] of Object.entries(PRESETS)) {
+			expect(fs.existsSync(join(repoRoot, preset.source)), `${name}: missing on disk`).toBe(true)
+			expect(published.has(preset.source), `${name}: not in package.json files`).toBe(true)
+		}
+	})
+
+	it('publishes every file the exports map points at', () => {
+		// Object-valued entries resolve into dist, which --ignore-scripts skipped.
+		for (const [subpath, target] of Object.entries(pkg.exports)) {
+			if (typeof target !== 'string') continue
+			const rel = target.replace(/^\.\//, '')
+			expect(fs.existsSync(join(repoRoot, rel)), `${subpath}: missing on disk`).toBe(true)
+			expect(published.has(rel), `${subpath}: not in package.json files`).toBe(true)
+		}
+	})
+})

--- a/tooling/biome/README.md
+++ b/tooling/biome/README.md
@@ -16,13 +16,17 @@ npm install -D @rtorcato/repo-tooling @biomejs/biome
 npx @rtorcato/repo-tooling copy biome
 ```
 
-This will copy the base `biome.json` configuration to your project root.
+This will copy the base configuration to your project root as `biome.json`.
 
 ### Option 2: Manual Copy
 
 ```bash
-cp node_modules/@rtorcato/repo-tooling/tooling/biome/biome.json ./biome.json
+cp node_modules/@rtorcato/repo-tooling/tooling/biome/preset.json ./biome.json
 ```
+
+The shipped file is `preset.json`, not `biome.json`, so Biome's config discovery
+never picks it up out of `node_modules` as a config of its own (#486). The copy
+you land in your repo must still be named `biome.json`.
 
 ### Option 3: Reference in package.json
 

--- a/tooling/biome/preset.json
+++ b/tooling/biome/preset.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://biomejs.dev/schemas/latest/schema.json",
-  "root": false,
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
🤖 *Automated — implementer via `ai-issue-loop`.*

Implements **option 2** from the owner's decision on #486: rename `tooling/biome/biome.json` → `tooling/biome/preset.json` and drop `root` entirely.

Closes #486

## Why the rename does the work

`biome.json` is a name Biome's config discovery matches, so the file the package ships *was* a config wherever it sat. That is the only reason `"root": false` was ever on it (#469) — to stop the package's own copy colliding with this repo's root config. Renaming removes the collision at the source, so `root` has nothing left to do and stops being something a consumer inherits by accident.

The target name is unchanged: `copy biome` still writes the consumer's file as `biome.json`. Only the source moved.

## What changed

| Site | Change |
|---|---|
| `tooling/biome/biome.json` | → `tooling/biome/preset.json`, `"root": false` removed |
| `package.json` `files` | `tooling/biome/preset.json` |
| `package.json` `exports` | `"./biome"` → `./tooling/biome/preset.json` (**key unchanged**) |
| `src/cli/utils/copy-preset.ts` | `PRESETS.biome.source`, plus a comment saying why the name is not `biome.json` |
| `apps/docs/biome.json` | relative `extends` retargeted |
| `scripts/copy-biome-config.sh`, `scripts/sync-biome-config.sh` | paths |
| `tooling/biome/README.md` | manual-copy path, and a note that the copy must still land as `biome.json` |
| `src/languages/js/checks.ts` | two stale path references **in comments only** (kept minimal — `ai-484` is in flight on this file) |

Whole-repo grep for `tooling/biome/biome.json` is clean apart from one deliberate historical mention in a test docstring.

## Proof, not assumption

- **`extends: ["@rtorcato/repo-tooling/biome"]` still works** — new test `applies through the extends pointer, resolved via the exports map` runs a real `biome check` against a fixture package whose `exports` map is the shipped one. Mutation-checked: pointing the fixture's `./biome` at the old `biome.json` name makes it fail on `expected … to contain 'Checked'`.

  Worth flagging: **this repo's own `biome check .` proves nothing here.** `node_modules/@rtorcato/repo-tooling` symlinks back to the working tree, so it resolves whatever is checked out, not what ships. I initially took a green `biome check .` as the proof and it was not one — hence the fixture test.
- **`copy biome` still writes `biome.json`** — the existing `copy biome writes biome.json to target dir` e2e test passes against a real `pnpm build` + real CLI.
- **This repo's `biome check .` still works** — 229 files, zero errors, no nested-root abort. (#469's goal, now achieved by the rename rather than by `root: false`.)

## The `it.fails` tests from #491

| Test | Now |
|---|---|
| `applies to a nested package, overriding the monorepo root config` | **Rewritten** — see below |
| `applies when copied in as the consumer's own root config` | `.fails` **removed**, real assertion, passes |
| `lets the scaffolded extends pointer sit inside a monorepo` | `.fails` **kept** — still fails, out of scope |

### The trade this makes — please read

One file cannot be both a root and a non-root, so dropping `root` did not erase a failure, it **moved** one. The third test in that block was passing on `main` and would now fail:

- **Fixed:** `copy biome` into a standalone repo used to be discarded in silence — consumer left on stock Biome, exit 0, no warning. It now applies.
- **Traded:** that same verbatim copy landed in a package *under someone else's monorepo root* is now a second root config, and Biome aborts loudly with `Found a nested root configuration`.

I rewrote that test to assert the new behaviour rather than delete it, and documented the trade in the block's docstring. It still asserts the parent config is genuinely in force, so the result is not vacuous.

I think the trade is worth taking, because it **converges** the residual: the verbatim copy and the scaffolded `extends` pointer now fail the same way for the same reason. One fix — teaching the scaffold when it is nested — closes both, instead of two divergent behaviours needing two fixes.

## The residual is unchanged

Confirming as asked: **this does not fix finding 2.** The scaffolded `extends` pointer still reads as a root config inside someone else's monorepo, because `root` does not inherit through `extends`. That still needs a `--nested` flag or doctor detecting a parent config. Left open; the `it.fails` test still pins it.

## Bonus: a test for the `files`/`exports` gap

The brief asked whether `tooling/tests/exports-resolution` covers this. **It does not** — it cross-checks `src/` subfolders against the `exports` map and never looks at `tooling/` or at `files`.

So this rename had three places that had to move together (`PRESETS.biome.source`, the `./biome` export, the `files` entry) with **nothing failing if one was missed**: `files` is globs, so a stale exports target still resolves in-repo and only 404s once published.

New `tests/cli/utils/copy-preset.test.ts` closes that with `npm pack --dry-run --json --ignore-scripts` — the authoritative answer to "what actually ships", with no reimplementation of npm's glob semantics. Asserts every `PRESETS[*].source` and every string-valued `exports` target both exists on disk and is in the pack manifest. ~3.5s.

## For your decision

**Does this warrant `feat!:`?** I have left the commit as `fix(biome):` rather than decide alone, since the squash subject cuts the release.

The argument for `feat!:`: anyone hardcoding `node_modules/@rtorcato/repo-tooling/tooling/biome/biome.json` breaks. That path appeared in this repo's own `tooling/biome/README.md` as "Option 2: Manual Copy", so it is a documented path, not merely a theoretical one.

The argument for `fix:`: the supported entry points — `extends` via `./biome`, and `copy biome` — are both unchanged, and the user-visible effect is that a silently-ignored config now applies.

Also worth your call, and the reason I did not just pick: the **nested-copy regression** above is arguably the breaking part, more than the path rename is.

## Verification

- `biome check .` — 229 files, 0 errors
- `tsc --noEmit --project src/cli/tsconfig.json` — clean
- `vitest run` — 63 files, 1042 passed, 1 expected fail (the out-of-scope residual)

One caveat, reported rather than buried: I saw a single transient run with 6 failures and an anomalous skip count, immediately after `pnpm build` regenerated `dist/`. Four subsequent full runs were clean and I could not reproduce it; the detail was lost to output truncation. I checked the obvious suspect — the new test shelling out to `npm pack` — and ruled it out: there is no `prepack` script and `--ignore-scripts` is passed, so it cannot rebuild `dist` mid-suite. Flagging it in case CI shows the same thing.
