### PR TITLE
fix(doctor): shell-quote both paths in the skill-fork diff hint

### DIFF
--- a/src/cli/generators/claude-skills.ts
+++ b/src/cli/generators/claude-skills.ts
@@ -203,14 +203,31 @@ export interface SkillInstallResult {
 }
 
 /**
+ * POSIX single-quote escaping — the only form correct for arbitrary bytes.
+ * Inside single quotes every character is literal, so `'` is the sole one
+ * needing care: end the quote, escape it, start a new one. Double quotes are
+ * not a substitute; `$(...)`, backticks and `\` all still expand inside them.
+ */
+function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+/**
  * The command a human runs to see what their fork changed, before deciding
  * whether to take the shipped copy. One builder, because `doctor` and `fix`
  * both print it and two independently-built strings drift (#484). Always
  * `realFile`: through a stow symlink the nominal path is the link, and the
  * bytes worth reading are in the dotfiles checkout it points at.
+ *
+ * Both paths are user-influenced — `--skills-dir` is an argument (#490) and
+ * `realFile` is wherever a symlink happens to point — and this line exists to
+ * be pasted into a shell, so it is quoted rather than merely interpolated
+ * (#493). Quoting beats refusing to emit a command: single quotes make an odd
+ * path *more* visible, not less, and keep the hint usable in the odd case
+ * instead of only the ordinary one.
  */
 export function skillDiffCommand(paths: { realFile: string; shippedFile: string }): string {
-	return `diff "${paths.realFile}" "${paths.shippedFile}"`
+	return `diff ${shellQuote(paths.realFile)} ${shellQuote(paths.shippedFile)}`
 }
 
 /** Whether `file` is itself a symlink, as opposed to merely resolving through one. */

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1800,7 +1800,9 @@ describe('doctor: a forked Claude skill', () => {
 
 		const result = await claudeSkills(dir, skillsDir)
 		expect(result?.status).toBe('ok')
-		expect(result?.hint).toContain(`diff "${skillFile(skillsDir)}" "${shippedFile}"`)
+		// Single-quoted: the paths are user-influenced and the line is meant to be
+		// pasted into a shell (#493). skillDiffCommand's own tests cover the escaping.
+		expect(result?.hint).toContain(`diff '${skillFile(skillsDir)}' '${shippedFile}'`)
 	})
 
 	// stow symlinks at file level, so the installed path is routinely a link into

--- a/tests/cli/generators/claude-skills.test.ts
+++ b/tests/cli/generators/claude-skills.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
@@ -10,6 +11,7 @@ import {
 	readSkillVersion,
 	resolveSkillsDir,
 	SHIPPED_SKILL,
+	skillDiffCommand,
 	stampSkill,
 	stampSkillVersion,
 	stripSkillStamps,
@@ -207,6 +209,59 @@ describe('installClaudeSkill', () => {
 		expect((await fs.lstat(skillFile(skillsDir))).isSymbolicLink()).toBe(true)
 		expect(await fs.realpath(result.realFile)).toBe(await fs.realpath(dotfiles))
 		expect(await fs.readFile(dotfiles, 'utf8')).toContain('# ai-issue-loop')
+	})
+})
+
+// #493: the hint is built to be pasted into a shell, and both paths are
+// user-influenced — `--skills-dir` is an argument (#490) and `realFile` is
+// wherever a symlink points. Unquoted, a path carrying `"` or `$(...)` yields a
+// line that does something other than a diff.
+describe('skillDiffCommand', () => {
+	const SHIPPED = '/pkg/skills/ai-issue-loop/SKILL.md'
+
+	/**
+	 * Run the emitted command through a real shell with `diff` swapped for a
+	 * printf that echoes its argv, and return what `diff` would have received.
+	 * A path the shell splits, expands or executes fails to come back intact.
+	 */
+	function shellArgv(command: string): string[] {
+		const out = execFileSync('sh', ['-c', command.replace(/^diff /, "printf '%s\\n' ")], {
+			encoding: 'utf8',
+		})
+		return out.split('\n').slice(0, -1)
+	}
+
+	it('is a pasteable diff for ordinary paths', () => {
+		const realFile = '/home/me/.claude/skills/ai-issue-loop/SKILL.md'
+		expect(skillDiffCommand({ realFile, shippedFile: SHIPPED })).toBe(
+			`diff '${realFile}' '${SHIPPED}'`
+		)
+		expect(shellArgv(skillDiffCommand({ realFile, shippedFile: SHIPPED }))).toEqual([
+			realFile,
+			SHIPPED,
+		])
+	})
+
+	it.each([
+		['a space', '/tmp/my skills/ai-issue-loop/SKILL.md'],
+		['a double quote', '/tmp/we"rd/SKILL.md'],
+		['a single quote', "/tmp/it's/SKILL.md"],
+		['a command substitution', '/tmp/$(echo pwned)/SKILL.md'],
+		['backticks and a variable', '/tmp/`echo pwned`$HOME/SKILL.md'],
+		['a command separator', '/tmp/x; echo pwned/SKILL.md'],
+	])('hands %s to diff untouched', (_what, realFile) => {
+		expect(shellArgv(skillDiffCommand({ realFile, shippedFile: SHIPPED }))).toEqual([
+			realFile,
+			SHIPPED,
+		])
+	})
+
+	it('escapes the shipped path too', () => {
+		const shippedFile = "/pkg/o'dd/SKILL.md"
+		expect(shellArgv(skillDiffCommand({ realFile: '/tmp/a/SKILL.md', shippedFile }))).toEqual([
+			'/tmp/a/SKILL.md',
+			shippedFile,
+		])
 	})
 })
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

`skillDiffCommand` interpolated both paths into a double-quoted `diff` line for a human to paste. Both are user-influenced — `--skills-dir` is an argument (#490), `realFile` is wherever a symlink resolves — so a path carrying `"`, `$(...)` or a backtick yielded a line that fails to parse or runs something other than a diff. Nothing in this package executes the string (confirmed: no `child_process`/`execa` on either path); the hazard is the human who pastes it.

**Chose escaping over refusing to emit a command.** POSIX single-quoting is the only form correct for arbitrary bytes, and it makes a strange path *more* visible rather than less — `diff '/tmp/$(echo x)/SKILL.md' …` shows the oddity and still runs. Refusing would need a metacharacter predicate (its own bug surface, and getting it wrong is a silent miss) plus a second output shape at both call sites, reintroducing exactly the drift #492 removed. One builder, one shape, still pasteable in the ordinary case.

Tests run the emitted command through a real `sh` with `diff` swapped for a printf of its argv, and assert the two paths come back byte-identical — so a path the shell splits, expands or executes fails. Verified the three hazardous cases (`"`, `$(...)`, backtick) do fail against the old double-quoted builder.

**Swept for the same shape elsewhere:** nothing else in `src/` builds a copy-paste shell command from a filesystem path — every other interpolated command uses a module constant or a hardcoded fixer target. One adjacent case worth its own issue, not fixed here: `src/cli/generators/skills-install.ts:33` interpolates `skills/<name>` directory basenames and the `repository` owner/repo into `npx skills add …` lines written into a consuming repo's README.

`biome lint` (62 warnings, byte-identical to `origin/main`, all pre-existing CSS), `tsc --noEmit`, and the full `vitest run` (1034 passed) are clean.

Closes #493