### PR TITLE
fix(skills-install): quote the skill name in the README install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ MIT — see [LICENSE](LICENSE).
 Any agent that supports the [`skills`](https://www.npmjs.com/package/skills) CLI can install this repo's skills straight from GitHub — no clone, no package install:
 
 ```bash
-npx skills add https://github.com/rtorcato/repo-tooling --skill ai-issue-loop
-npx skills add https://github.com/rtorcato/repo-tooling --skill npm-publish
-npx skills add https://github.com/rtorcato/repo-tooling --skill repo-tooling
+npx skills add https://github.com/rtorcato/repo-tooling --skill 'ai-issue-loop'
+npx skills add https://github.com/rtorcato/repo-tooling --skill 'npm-publish'
+npx skills add https://github.com/rtorcato/repo-tooling --skill 'repo-tooling'
 ```
 <!-- js-tooling:skills:end -->

--- a/src/cli/generators/claude-skills.ts
+++ b/src/cli/generators/claude-skills.ts
@@ -10,6 +10,7 @@ import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
 import { getPackageRoot } from '../utils/copy-preset.js'
+import { shellQuote } from '../utils/shell.js'
 
 /** Skills this package owns the content of and keeps up to date. */
 export const SHIPPED_SKILL = 'ai-issue-loop'
@@ -200,16 +201,6 @@ export interface SkillInstallResult {
 	shippedFile: string
 	installedVersion: string | null
 	shippedVersion: string
-}
-
-/**
- * POSIX single-quote escaping — the only form correct for arbitrary bytes.
- * Inside single quotes every character is literal, so `'` is the sole one
- * needing care: end the quote, escape it, start a new one. Double quotes are
- * not a substitute; `$(...)`, backticks and `\` all still expand inside them.
- */
-function shellQuote(value: string): string {
-	return `'${value.replaceAll("'", "'\\''")}'`
 }
 
 /**

--- a/src/cli/generators/skills-install.ts
+++ b/src/cli/generators/skills-install.ts
@@ -4,6 +4,7 @@
 
 import path from 'node:path'
 import fs from 'fs-extra'
+import { shellQuote } from '../utils/shell.js'
 import { upsertBlock } from './agent-rules.js'
 import { parseRepository } from './badges.js'
 
@@ -26,11 +27,17 @@ export async function findSkills(targetDir: string): Promise<string[]> {
 /**
  * Build the README section body (inner content, no delimiters) listing one
  * `npx skills add` command per skill. Returns '' when there are no skills.
+ *
+ * The skill name is a directory basename — `findSkills` takes whatever is under
+ * `skills/`, and nothing constrains it — so it is quoted (#498). `owner`/`repo`
+ * are not: `parseRepository` already matches them against `[\w.-]+`. Unlike the
+ * doctor hint of #493 this line is committed to a README and rendered on GitHub
+ * and npm, where it gets pasted by people who did not create the directory.
  */
 export function buildSkillsInstallBody(owner: string, repo: string, skills: string[]): string {
 	if (skills.length === 0) return ''
 	const commands = skills
-		.map((s) => `npx skills add https://github.com/${owner}/${repo} --skill ${s}`)
+		.map((s) => `npx skills add https://github.com/${owner}/${repo} --skill ${shellQuote(s)}`)
 		.join('\n')
 	const plural = skills.length > 1 ? 's' : ''
 	return [
@@ -38,10 +45,21 @@ export function buildSkillsInstallBody(owner: string, repo: string, skills: stri
 		'',
 		`Any agent that supports the [\`skills\`](https://www.npmjs.com/package/skills) CLI can install this repo's skill${plural} straight from GitHub — no clone, no package install:`,
 		'',
-		'```bash',
+		`${fenceFor(commands)}bash`,
 		commands,
-		'```',
+		fenceFor(commands),
 	].join('\n')
+}
+
+/**
+ * A fence longer than any backtick run in the content, per CommonMark. Quoting
+ * cannot help here: a name may contain backticks *and* a newline, which puts
+ * arbitrary text at the start of a line inside the block and would otherwise
+ * close it early, mangling the rendered README.
+ */
+function fenceFor(content: string): string {
+	const longestRun = Math.max(0, ...[...content.matchAll(/`+/g)].map((m) => m[0].length))
+	return '`'.repeat(Math.max(3, longestRun + 1))
 }
 
 /**

--- a/src/cli/utils/shell.ts
+++ b/src/cli/utils/shell.ts
@@ -1,0 +1,13 @@
+/**
+ * POSIX single-quote escaping — the only form correct for arbitrary bytes.
+ * Inside single quotes every character is literal, so `'` is the sole one
+ * needing care: end the quote, escape it, start a new one. Double quotes are
+ * not a substitute; `$(...)`, backticks and `\` all still expand inside them.
+ *
+ * One escaper for every generator that emits a copy-pasteable command line
+ * (#498) — two independently-built ones drift, which is the argument #492 made
+ * for a single `skillDiffCommand`.
+ */
+export function shellQuote(value: string): string {
+	return `'${value.replaceAll("'", "'\\''")}'`
+}

--- a/tests/cli/generators/skills-install.test.ts
+++ b/tests/cli/generators/skills-install.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
@@ -14,19 +15,67 @@ async function scaffoldSkill(dir: string, name: string): Promise<void> {
 	await fs.writeFile(join(dir, 'skills', name, 'SKILL.md'), `---\nname: ${name}\n---\n`)
 }
 
+/**
+ * Run one emitted command line through a real shell with `npx` swapped for a
+ * printf that echoes its argv, and return what `npx` would have received. A
+ * name the shell splits, expands or executes fails to come back intact.
+ */
+function shellArgv(command: string): string[] {
+	const out = execFileSync('sh', ['-c', command.replace(/^npx /, "printf '%s\\n' ")], {
+		encoding: 'utf8',
+	})
+	return out.split('\n').slice(0, -1)
+}
+
+/** The command lines inside the ```bash fence. */
+function commandLines(body: string): string[] {
+	return body.split('\n').filter((line) => line.startsWith('npx skills add '))
+}
+
 describe('buildSkillsInstallBody', () => {
 	it('emits one npx skills add command per skill, singular vs plural heading', () => {
 		expect(buildSkillsInstallBody('rtorcato', 'browser-common', ['browser-common'])).toContain(
-			'npx skills add https://github.com/rtorcato/browser-common --skill browser-common'
+			"npx skills add https://github.com/rtorcato/browser-common --skill 'browser-common'"
 		)
 		const multi = buildSkillsInstallBody('rtorcato', 'js-tooling', ['js-tooling', 'npm-publish'])
 		expect(multi).toContain('## Install the skills')
-		expect(multi).toContain('--skill js-tooling')
-		expect(multi).toContain('--skill npm-publish')
+		expect(multi).toContain("--skill 'js-tooling'")
+		expect(multi).toContain("--skill 'npm-publish'")
 	})
 
 	it('returns empty for no skills', () => {
 		expect(buildSkillsInstallBody('rtorcato', 'x', [])).toBe('')
+	})
+
+	// #498: the skill name is an unconstrained directory basename, and this line
+	// is committed to a README that other people paste from.
+	it.each([
+		['a command separator', 'x; echo pwned'],
+		['a space', 'my skill'],
+		['a command substitution', '$(echo pwned)'],
+		['backticks and a variable', '`echo pwned`$HOME'],
+		['a double quote', 'we"rd'],
+		['a single quote', "it's"],
+	])('hands %s to npx as one literal argument', (_what, skill) => {
+		const [command, ...rest] = commandLines(buildSkillsInstallBody('rtorcato', 'x', [skill]))
+		expect(rest).toEqual([])
+		expect(shellArgv(command as string)).toEqual([
+			'skills',
+			'add',
+			'https://github.com/rtorcato/x',
+			'--skill',
+			skill,
+		])
+	})
+
+	// A name may carry backticks and a newline, putting arbitrary text at the
+	// start of a line inside the block. A 3-backtick fence would end there.
+	it('opens a fence the skill name cannot close', () => {
+		const lines = buildSkillsInstallBody('rtorcato', 'x', ['a\n```bash\nrm -rf /']).split('\n')
+		const open = lines.indexOf('````bash')
+		expect(open).toBeGreaterThan(-1)
+		expect(lines.at(-1)).toBe('````')
+		expect(lines.slice(open + 1, -1)).toContain('```bash')
 	})
 })
 
@@ -64,7 +113,7 @@ describe('installSkillsInstallDocs', () => {
 		expect(readme).toContain('# browser-common')
 		expect(readme).toContain('My notes.')
 		expect(readme).toContain(
-			'npx skills add https://github.com/rtorcato/browser-common --skill browser-common'
+			"npx skills add https://github.com/rtorcato/browser-common --skill 'browser-common'"
 		)
 		expect(readme.match(/<!-- js-tooling:skills:start -->/g)).toHaveLength(1)
 	})


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

`buildSkillsInstallBody` interpolated a `skills/<name>/` directory basename straight into `npx skills add … --skill ${s}`. Nothing constrains that basename — `findSkills` returns whatever is on disk — so a directory named `x; echo pwned` produced a README line that runs two commands when pasted. `owner`/`repo` are left alone: `parseRepository` already matches them against `[\w.-]+`.

The stakes are the destination, not the source. The directory is created by whoever runs the tooling, on their own repo, so no trust boundary is crossed — but the string is committed to a README and rendered on GitHub and npm, where it outlives the machine that generated it and gets pasted by people who did not create the directory.

## Where `shellQuote` lives

**Moved to `src/cli/utils/shell.ts`** rather than exported from `claude-skills.ts`. Both files are generators; importing one from the other would couple the README writer to the user-global `~/.claude` installer for a string utility that belongs to neither. `utils/` is where this package already keeps cross-generator helpers, and `claude-skills.ts` imports from it already (`utils/copy-preset.js`). One escaper, because two drift (#492).

## The fence, separately

Quoting alone does **not** fix the second effect the issue names. A backtick stays a literal backtick inside single quotes, and a basename may legally contain a newline *and* backticks — which puts arbitrary text at the start of a line inside the block and closes a 3-backtick fence early. Per CommonMark a fence is closed only by a run at least as long, so the opener is now `max(3, longest backtick run + 1)`. Ordinary repos are unaffected: the fence stays ```` ``` ````.

## Tests

Each emitted line is run through a real `sh` with `npx` swapped for a printf of its argv (#497's technique) and asserted to hand the name back as one byte-identical argument — `;`, spaces, `$(...)`, backticks, `"` and `'` — plus a fence case for a newline-and-backticks name.

**Verified they fail without the fix.** Reverting the interpolation and the fence to their previous form turned all 8 new/updated assertions red: `x; echo pwned` split into an extra argv entry, `$(echo pwned)` was substituted away, and the quote cases aborted `sh` with a parse error. Restored, all 1041 tests pass.

This repo's own generated README block is updated to match what the generator now emits, so the next `fix ai` is a no-op.

`biome check` (62 warnings, all pre-existing CSS, byte-identical to `origin/main`), `tsc --noEmit` and the full `vitest run` are clean.

Closes #498
