### PR TITLE
feat(skills): guard the ai-issue-loop main checkout against a bare flip

### DIFF
--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -200,6 +200,44 @@ pass.** A session can be pinned to a worktree, so the orchestrator can find itse
 inside one it did not choose. `--git-common-dir` resolves to the main checkout's
 `.git` from anywhere, including a worktree, so `ROOT` is correct either way.
 
+**Check the main checkout is not bare before anything else uses `ROOT`.** It has gone
+`core.bare = true` on its own, repeatedly — four times in one session, some occurrences
+immediately after a `worktree remove` and some with nothing removed at all. The trigger
+is unidentified, so this is detection and repair only:
+
+```bash
+if [ "$(git -C "$ROOT" rev-parse --is-inside-work-tree 2>/dev/null)" != true ] && [ -d "$ROOT/.git" ]; then
+  echo "⚠ main checkout bare at $(date -u +%FT%TZ) — repairing"
+  git -C "$ROOT" config core.bare false || {
+    echo "⚠ repair FAILED — main checkout still bare"; exit 1; }
+fi
+```
+
+**It corrupts commits — this is not a cosmetic error message.** A bare main checkout
+wipes a worktree's index while every file sits untouched on disk, and the next commit
+faithfully records the whole repository as deleted. PR #500 died that way: a diff of
+`0 additions, 67703 deletions` across 359 files, not one of which had moved.
+
+**Test stdout, not the exit code.** `rev-parse --is-inside-work-tree` exits `0` either
+way and only *prints* the answer, so an exit-code probe is dead code. Verified on git
+2.55.0:
+
+| repo state | `--is-inside-work-tree` | `.git` |
+|---|---|---|
+| healthy checkout | `true`, exit 0 | directory |
+| **wrongly bare** | `false`, **exit 0** | directory |
+| genuinely bare | `false`, exit 0 | absent |
+| linked worktree | `true`, exit 0 | file |
+
+**`.git` must be a directory before repairing.** A genuinely bare repo prints `false`
+too, and nothing else separates the two — this skill ships to users' `~/.claude/skills/`,
+where "repairing" someone's real bare clone is the damage rather than the fix. The same
+check skips a linked worktree, whose `.git` is a file.
+
+**Fail loudly.** The repair writes `$ROOT/.git/config`, which a restrictive sandbox
+refuses with `error: could not lock config file .git/config: Operation not permitted` —
+observed. Aborting beats reporting a healthy repo while it stays broken.
+
 Never use a relative path like `ai-*`. From inside a worktree it matches nothing, and
 the failure is **silent**: Pass 2 concludes there is nothing to clean, every worktree
 survives, `ai-wip` is never cleared, and slots leak until the loop reports `idle`
@@ -472,6 +510,23 @@ and say in the comment that you re-queued it, that you deviated, and why. Re-add
 `ai-ready` is not optional: pickup cleared it, so clearing `ai-wip` alone drops the
 issue out of the queue silently, which is the worse failure. `ai-blocked` means *a
 human must look*; do not spend it on a claim you already understand.
+
+**Then re-check `core.bare`** — the same probe as Pass 0, against the same `ROOT`:
+
+```bash
+if [ "$(git -C "$ROOT" rev-parse --is-inside-work-tree 2>/dev/null)" != true ] && [ -d "$ROOT/.git" ]; then
+  echo "⚠ main checkout bare at $(date -u +%FT%TZ) — repairing"
+  git -C "$ROOT" config core.bare false || {
+    echo "⚠ repair FAILED — main checkout still bare"; exit 1; }
+fi
+```
+
+This is the last pass that *removes* worktrees, not the tick's last touch on the main
+checkout — Pass 4 still runs `git -C "$ROOT" worktree add` against it. That is exactly
+why the re-check belongs here: it catches a flip after this pass's removals and before
+Pass 4 branches every new worktree off a broken `ROOT`. Keep the timestamp in both log
+lines; which pass emitted one, and when, is the only instrumentation likely to pin the
+trigger down.
 
 ### Pass 3 — review
 


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Adds a `core.bare` detect-and-repair guard to Pass 0 and Pass 2 of
`skills/ai-issue-loop/SKILL.md`. Detection and repair only — **no cause claim**,
the trigger is still unidentified.

Closes #496

## Why it is worth having

It corrupts commits. A bare main checkout wipes a worktree's index while every
file sits untouched on disk, and the next commit faithfully records the whole
repository as deleted — which is how PR #500 ended up with a diff of
`0 additions, 67703 deletions` across 359 files. It is also frequent and
intermittent: four occurrences in one session, some immediately after a
`worktree remove` and some with nothing removed.

## It fired again during this PR

Immediately after `git push -u` on this branch, the main checkout went
`core.bare = true` again and this worktree's index was wiped — every tracked
file flipped to a staged deletion while sitting untouched on disk.

The commit itself is clean, verified before and after pushing:

```
1960d2f feat(skills): guard the ai-issue-loop main checkout against a bare flip
 skills/ai-issue-loop/SKILL.md | 55 +++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 55 insertions(+)
```

One file, 55 insertions, **zero deletions**. Nothing was committed after the
index was wiped.

The live repo matched the guard's fire condition exactly —
`is-inside-work-tree` printing `false` with `.git` still a directory — so the
probe in this diff is confirmed against the real failure, not only a scratch
repro.

**The main checkout is still `core.bare = true`.** The repair was declined by
the permission gate as a mutation of a shared checkout, which is correct — it
is not this agent's to make unattended. It needs, from the main checkout:

```bash
git -C /Volumes/RtorcatoSSD/WORK/repo-tooling config core.bare false
```

## Verified, not assumed

Scratch repos on git 2.55.0, one per state:

| repo state | `--is-inside-work-tree` | `.git` | probe |
|---|---|---|---|
| healthy checkout | `true`, exit 0 | directory | silent |
| **wrongly bare** | `false`, **exit 0** | directory | **fires** |
| genuinely bare | `false`, exit 0 | absent | silent |
| linked worktree | `true`, exit 0 | file | silent |

`git config core.bare true` on a normal checkout made the probe fire; `git init
--bare` did not. After the repair the wrongly-bare repo returned `true` and
`git status` went from exit 128 back to 0, while the genuine bare repo kept
`core.bare = true`.

This is why the diff does the three things the #500 reviews asked for:

1. **Tests stdout, not the exit code** — `--is-inside-work-tree` exits `0`
   either way, so an exit-code probe is dead code. That was #500's defect.
2. **Requires `.git` to be a directory** — a genuinely bare repo prints `false`
   too. This file ships to users' `~/.claude/skills/`, so "repairing" someone's
   real bare clone is not hypothetical. It also skips a linked worktree, whose
   `.git` is a file.
3. **Fails loudly** — the repair writes `$ROOT/.git/config`, which a restrictive
   sandbox refuses. Abort beats reporting healthy while the repo stays broken.

## The other open finding from #500

`code-reviewer` flagged that Pass 2 being "the last thing to touch the main
checkout in a tick" was unverifiable. **It is false** — Pass 4 runs `git -C
"$ROOT" worktree add` (line 838). Softened accordingly: Pass 2 is the last pass
that *removes* worktrees, and the re-check belongs there because it catches a
flip after those removals and before Pass 4 branches new worktrees off a broken
`ROOT`.

## Scope

`skills/ai-issue-loop/SKILL.md` only, Pass 0 and Pass 2. Pass 3 untouched — PR
#501 is editing it concurrently. `pnpm run check` exits 0 (62 pre-existing CSS
warnings) and 1034 tests pass.