### PR TITLE
feat(fix): scaffold the release environment gate

### DIFF
--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -38,7 +38,12 @@ import { copyPreset } from '../cli/utils/copy-preset.js'
 import { detectLanguage } from '../cli/utils/detect-language.js'
 import type { Lockfile } from '../cli/utils/lockfile.js'
 import { resolveLanguageModule } from '../languages/registry.js'
-import { applyGithubSettings } from './github-settings.js'
+import {
+	applyGithubSettings,
+	applyReleaseEnvironment,
+	RELEASE_ENV_CHECK,
+	RELEASE_GATE_CHECK,
+} from './github-settings.js'
 import { applyLoopLabels } from './labels.js'
 import { closeCompletedMilestones } from './milestones.js'
 import type { CheckResult } from './types.js'
@@ -287,6 +292,27 @@ export const BASE_FIXERS: Fixer[] = [
 		canFixDrift: true,
 		async run({ targetDir }) {
 			return { filesWritten: await applyGithubSettings(targetDir) }
+		},
+	},
+	{
+		target: 'release-environment',
+		description:
+			'Create the `release` environment (authenticated user as required reviewer) and wire `environment: release` into the publishing job — the gate between merging and publishing (#429)',
+		appliesTo: [RELEASE_GATE_CHECK, RELEASE_ENV_CHECK],
+		outputs: [
+			'GitHub `release` environment (remote, via gh api)',
+			'.github/workflows/<the publishing workflow>',
+		],
+		// safe-add for the same shadow-run reason as github-settings, and
+		// explicitOnly because arming the gate changes what a merge *does*: the
+		// next release run sits `waiting` for an approval instead of publishing.
+		// That is the point, but it must be a chosen rollout per repo, not a side
+		// effect of a bare `fix`.
+		riskLevel: 'safe-add',
+		explicitOnly: true,
+		canFixDrift: true,
+		async run({ targetDir }) {
+			return { filesWritten: await applyReleaseEnvironment(targetDir) }
 		},
 	},
 	{

--- a/src/base/github-settings.ts
+++ b/src/base/github-settings.ts
@@ -76,8 +76,8 @@ export const GITHUB_STANDARD = {
 } as const
 
 const CODE_SCANNING_CHECK = 'Code-scanning gate'
-const RELEASE_GATE_CHECK = 'Release gate'
-const RELEASE_ENV_CHECK = 'Release environment'
+export const RELEASE_GATE_CHECK = 'Release gate'
+export const RELEASE_ENV_CHECK = 'Release environment'
 const CHECK_NAMES = [
 	'Branch protection',
 	'Merge settings',
@@ -489,7 +489,7 @@ const RELEASE_ENVIRONMENT = 'release'
 const PUBLISH_COMMAND = /semantic-release|changesets\/action|(?:npm|pnpm|yarn)\s+publish/
 
 const GATE_HINT =
-	'Create a `release` environment with required reviewers (Settings → Environments) and add `environment: release` to the publishing job — a merge to the default branch then leaves the run `waiting` instead of publishing'
+	'Run `npx @rtorcato/repo-tooling fix release-environment` to create the `release` environment with required reviewers (you) and add `environment: release` to the publishing job — a merge to the default branch then leaves the run `waiting` instead of publishing'
 
 const ENV_HINT =
 	'Add `environment: release` to the publishing job, or delete the environment — whichever was meant. An environment nothing references still lists under Settings → Environments as though it gates something'
@@ -668,9 +668,9 @@ async function readEnvironments(gh: GhExec, nwo: string): Promise<Environments |
  * environment" is the gate check's; "no `environment:` but a `release`
  * environment exists" is the environment check's, and the gate check defers.
  *
- * A repo that publishes nothing is `ok` — not applicable, not drift. There is
- * no fixer: creating the environment needs a `required_reviewers` list only a
- * human can supply, so both hints describe the manual step.
+ * A repo that publishes nothing is `ok` — not applicable, not drift. The fixer
+ * is `fix release-environment` (`applyReleaseEnvironment` below), which uses
+ * the authenticated user as the required reviewer.
  */
 async function checkReleaseGate(
 	gh: GhExec,
@@ -932,6 +932,150 @@ export async function applyGithubSettings(dir: string, exec?: GhExec): Promise<s
 					`   ${GIT_PLUGIN_REMEDY}.`
 			)
 		)
+	}
+
+	if (applied.length === 0) console.error(chalk.gray('   already configured — nothing to apply'))
+	return applied
+}
+
+// --- Release environment scaffolding (#429) --------------------------------
+
+/**
+ * Insert `environment: <env>` as the first key of job `jobId`. Line-based, same
+ * reasoning as `workflowJobs`: this package ships no YAML dependency, and jobs
+ * sit one indent level under `jobs:` with their keys one level below. Returns
+ * null when the job cannot be found. The caller only reaches this when
+ * `jobEnvironment()` was null, so it never doubles an existing key.
+ */
+export function addJobEnvironment(yaml: string, jobId: string, env: string): string | null {
+	const lines = yaml.split('\n')
+	const start = lines.findIndex((l) => /^jobs:\s*$/.test(l))
+	if (start === -1) return null
+	const indentOf = (l: string) => l.length - l.trimStart().length
+
+	// The job headers' indent — from the first real line after `jobs:`, exactly
+	// as workflowJobs derives it, so the two agree on what counts as a header.
+	let jobIndent = -1
+	for (let i = start + 1; i < lines.length; i++) {
+		const line = lines[i] ?? ''
+		if (line.trim() === '' || line.trimStart().startsWith('#')) continue
+		if (indentOf(line) === 0) return null
+		jobIndent = indentOf(line)
+		break
+	}
+	if (jobIndent === -1) return null
+
+	for (let i = start + 1; i < lines.length; i++) {
+		const line = lines[i] ?? ''
+		if (line.trim() === '' || line.trimStart().startsWith('#')) continue
+		if (indentOf(line) === 0) return null // left the jobs block
+		if (indentOf(line) !== jobIndent || !line.trim().startsWith(`${jobId}:`)) continue
+		// Key indent = the job's first real line, so the insert matches whatever
+		// indentation the file already uses.
+		for (let j = i + 1; j < lines.length; j++) {
+			const next = lines[j] ?? ''
+			if (next.trim() === '' || next.trimStart().startsWith('#')) continue
+			lines.splice(j, 0, `${' '.repeat(indentOf(next))}environment: ${env}`)
+			return lines.join('\n')
+		}
+		return null
+	}
+	return null
+}
+
+/**
+ * Scaffold the release environment gate — the fixer half of #429 (the checks
+ * shipped with #449). Two writes, each skipped when already in place:
+ *
+ * 1. `PUT /repos/{nwo}/environments/release` with the **authenticated user** as
+ *    the required reviewer. On a solo-maintained repo they are the only human
+ *    there is; add or swap reviewers afterwards under Settings → Environments.
+ *    An environment that already carries a `required_reviewers` rule is never
+ *    touched — whoever set it up made a richer decision than this default.
+ * 2. `environment: release` on the publishing job, so the merge leaves the run
+ *    `waiting` instead of publishing.
+ *
+ * A job already behind some *other* environment is a warning, not a rename —
+ * this fixer scaffolds the standard, it does not migrate a custom setup.
+ */
+export async function applyReleaseEnvironment(dir: string, exec?: GhExec): Promise<string[]> {
+	if (!(await fs.pathExists(path.join(dir, '.git')))) {
+		console.error(chalk.gray('   skipped — not a git repository'))
+		return []
+	}
+	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin, dir))
+	const probe = await probeRepo(gh)
+	if ('skip' in probe) {
+		console.error(chalk.gray(`   skipped — ${probe.skip}`))
+		return []
+	}
+	const nwo = probe.info.nwo
+
+	const publish = (await isPrivatePackage(dir)) ? null : await findPublishJob(dir)
+	if (publish === 'skip') {
+		console.error(chalk.yellow('   skipped — could not read .github/workflows'))
+		return []
+	}
+	if (!publish) {
+		console.error(chalk.gray('   skipped — no workflow job publishes to a registry'))
+		return []
+	}
+	if (publish.environment !== null && publish.environment !== RELEASE_ENVIRONMENT) {
+		console.error(
+			chalk.yellow(
+				`   skipped — ${publish.file} \`${publish.job}\` already runs behind \`${publish.environment}\`; not renaming it`
+			)
+		)
+		return []
+	}
+
+	const envs = await readEnvironments(gh, nwo)
+	if (envs === 'skip') {
+		console.error(chalk.yellow('   skipped — could not read environments'))
+		return []
+	}
+
+	const applied: string[] = []
+	if (envs.get(RELEASE_ENVIRONMENT) !== true) {
+		const user = await gh(['api', 'user', '--jq', '.id'])
+		const id = user.ok ? Number.parseInt(user.stdout.trim(), 10) : Number.NaN
+		if (Number.isNaN(id)) {
+			console.error(
+				chalk.yellow(
+					`   could not resolve the authenticated user for required_reviewers: ${user.stderr.trim() || 'gh error'}`
+				)
+			)
+			return applied
+		}
+		const label = `\`${RELEASE_ENVIRONMENT}\` environment with the authenticated user as required reviewer`
+		const r = await gh(
+			['api', '-X', 'PUT', `repos/${nwo}/environments/${RELEASE_ENVIRONMENT}`, '--input', '-'],
+			JSON.stringify({ reviewers: [{ type: 'User', id }] })
+		)
+		if (r.ok) applied.push(label)
+		else {
+			console.error(chalk.yellow(`   could not apply ${label}: ${r.stderr.trim() || 'gh error'}`))
+			return applied
+		}
+	}
+
+	if (publish.environment === null) {
+		const file = path.join(dir, '.github', 'workflows', publish.file)
+		const updated = addJobEnvironment(
+			await fs.readFile(file, 'utf-8'),
+			publish.job,
+			RELEASE_ENVIRONMENT
+		)
+		if (updated === null) {
+			console.error(
+				chalk.yellow(
+					`   could not add \`environment:\` to ${publish.file} \`${publish.job}\` — add it by hand`
+				)
+			)
+		} else {
+			await fs.writeFile(file, updated)
+			applied.push(`environment: ${RELEASE_ENVIRONMENT} on ${publish.file} \`${publish.job}\``)
+		}
 	}
 
 	if (applied.length === 0) console.error(chalk.gray('   already configured — nothing to apply'))

--- a/tests/base/github-settings.test.ts
+++ b/tests/base/github-settings.test.ts
@@ -2,7 +2,9 @@ import { join } from 'node:path'
 import fs from 'fs-extra'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+	addJobEnvironment,
 	applyGithubSettings,
+	applyReleaseEnvironment,
 	buildGhApplyCommands,
 	checkGitHubSettings,
 	type GhExec,
@@ -763,5 +765,154 @@ describe('applyGithubSettings', () => {
 		} finally {
 			warn.mockRestore()
 		}
+	})
+})
+
+describe('addJobEnvironment (#429)', () => {
+	const YAML = `name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: pnpm build
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: npx semantic-release
+`
+
+	it('inserts environment as the first key of the named job, matching its indent', () => {
+		const out = addJobEnvironment(YAML, 'release', 'release')
+		expect(out).toContain('  release:\n    environment: release\n    runs-on: ubuntu-latest')
+		// The other job is untouched.
+		expect(out).toContain('  build:\n    runs-on: ubuntu-latest')
+	})
+
+	it('returns null for a job that does not exist', () => {
+		expect(addJobEnvironment(YAML, 'publish', 'release')).toBeNull()
+	})
+
+	it('returns null when there is no jobs block', () => {
+		expect(addJobEnvironment('name: CI\n', 'release', 'release')).toBeNull()
+	})
+
+	it('never matches a nested key with the job name', () => {
+		const nested = `jobs:
+  build:
+    steps:
+      - run: echo hi
+    release:
+      inner: true
+`
+		// `release:` exists only nested inside `build` — not a job header.
+		expect(addJobEnvironment(nested, 'release', 'release')).toBeNull()
+	})
+})
+
+describe('applyReleaseEnvironment (#429)', () => {
+	function releaseWorkflow(env?: string): string {
+		return `name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+${env ? `    environment: ${env}\n` : ''}    steps:
+      - run: npx semantic-release
+`
+	}
+
+	function publishRepo(env?: string): string {
+		const dir = gitRepo()
+		fs.outputFileSync(join(dir, '.github/workflows/release.yml'), releaseWorkflow(env))
+		fs.writeJsonSync(join(dir, 'package.json'), { name: 'thing' })
+		return dir
+	}
+
+	/** Routes by inspecting the full args array — the PUT's path is not args[1]. */
+	function applyGh(overrides: { environments?: GhResult; put?: GhResult } = {}) {
+		const puts: Array<{ path: string; stdin?: string }> = []
+		const exec: GhExec = vi.fn(async (args: string[], stdin?: string) => {
+			const path = args.find((a) => a.startsWith('repos/') || a === 'user') ?? ''
+			if (args.includes('PUT')) {
+				puts.push({ path, stdin })
+				return overrides.put ?? ok('{}')
+			}
+			if (path === 'repos/{owner}/{repo}') return ok(COMPLIANT_REPO)
+			if (path === 'user') return ok('12345\n')
+			if (path.endsWith('/environments')) return overrides.environments ?? ok(NO_ENVIRONMENTS)
+			return fail('unexpected call')
+		})
+		return { exec, puts }
+	}
+
+	it('creates the environment with the authenticated user and wires the job', async () => {
+		const dir = publishRepo()
+		const { exec, puts } = applyGh()
+
+		const applied = await applyReleaseEnvironment(dir, exec)
+		expect(puts).toHaveLength(1)
+		expect(puts[0]?.path).toMatch(/\/environments\/release$/)
+		expect(JSON.parse(puts[0]?.stdin ?? '')).toEqual({
+			reviewers: [{ type: 'User', id: 12345 }],
+		})
+		const yaml = fs.readFileSync(join(dir, '.github/workflows/release.yml'), 'utf-8')
+		expect(yaml).toContain('  release:\n    environment: release\n    runs-on:')
+		expect(applied).toHaveLength(2)
+	})
+
+	it('adds reviewers to an existing unprotected release environment', async () => {
+		const dir = publishRepo('release')
+		const { exec, puts } = applyGh({
+			environments: ok(
+				JSON.stringify({
+					total_count: 1,
+					environments: [{ name: 'release', protection_rules: [] }],
+				})
+			),
+		})
+
+		const applied = await applyReleaseEnvironment(dir, exec)
+		expect(puts).toHaveLength(1)
+		expect(applied).toHaveLength(1)
+	})
+
+	it('is a no-op when the gate is already complete', async () => {
+		const dir = publishRepo('release')
+		const { exec, puts } = applyGh({
+			environments: ok(
+				JSON.stringify({
+					total_count: 1,
+					environments: [{ name: 'release', protection_rules: [{ type: 'required_reviewers' }] }],
+				})
+			),
+		})
+
+		expect(await applyReleaseEnvironment(dir, exec)).toEqual([])
+		expect(puts).toHaveLength(0)
+	})
+
+	it('never renames a job already behind a different environment', async () => {
+		const dir = publishRepo('production')
+		const { exec, puts } = applyGh()
+
+		expect(await applyReleaseEnvironment(dir, exec)).toEqual([])
+		expect(puts).toHaveLength(0)
+	})
+
+	it('does nothing when nothing publishes', async () => {
+		const { exec, puts } = applyGh()
+		expect(await applyReleaseEnvironment(gitRepo(), exec)).toEqual([])
+		expect(puts).toHaveLength(0)
 	})
 })

--- a/tests/languages/perl/fixers.test.ts
+++ b/tests/languages/perl/fixers.test.ts
@@ -67,15 +67,12 @@ describe('perl fixers', () => {
 		// Perl repo hasn't got. `lockfile` has no Perl preset to record yet (see
 		// the note atop src/languages/perl/fixers.ts). `Perl distribution` and
 		// `Perl tests` are content only the project can write. `Release gate` and
-		// `Release environment` (#429) report only — creating the environment needs
-		// a `required_reviewers` list only a human can supply.
+		// `Release environment` (#429) are covered by the base `release-environment` fixer.
 		expect(uncovered).toEqual([
 			'language',
 			'lockfile',
 			'Monorepo',
 			'Git identity',
-			'Release gate',
-			'Release environment',
 			'README badges',
 			'Coverage upload',
 			'Perl distribution',

--- a/tests/languages/python/fixers.test.ts
+++ b/tests/languages/python/fixers.test.ts
@@ -64,15 +64,12 @@ describe('python fixers', () => {
 		// Python repo hasn't got. `lockfile` has no Python preset to record yet
 		// (see the note atop src/languages/python/fixers.ts). `pyproject.toml` and
 		// `Python tests` are content only the project can write. `Release gate` and
-		// `Release environment` (#429) report only — creating the environment needs
-		// a `required_reviewers` list only a human can supply.
+		// `Release environment` (#429) are covered by the base `release-environment` fixer.
 		expect(uncovered).toEqual([
 			'language',
 			'lockfile',
 			'Monorepo',
 			'Git identity',
-			'Release gate',
-			'Release environment',
 			'README badges',
 			'Coverage upload',
 			'pyproject.toml',

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -69,14 +69,11 @@ describe('swift fixers', () => {
 		// tests` is the same shape as `Package.swift`: half of it is a manifest
 		// edit (#311). `Monorepo` states the audit's own root-only scope (#317) —
 		// there is no drift for a fixer to close. `Release gate` and `Release
-		// environment` (#429) report only — creating the environment needs a
-		// `required_reviewers` list only a human can supply.
+		// environment` (#429) are covered by the base `release-environment` fixer.
 		expect(uncovered).toEqual([
 			'language',
 			'Monorepo',
 			'Git identity',
-			'Release gate',
-			'Release environment',
 			'README badges',
 			'Coverage upload',
 			'Package.swift',


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on rtorcato's behalf.*

Closes #429 — the scaffolding half; the checks half shipped in #449. Off `main`, no dependency on the skill PRs.

`fix release-environment`:
- `PUT /repos/{nwo}/environments/release` with the **authenticated user** as required reviewer. An environment already carrying a `required_reviewers` rule is never touched; a job already behind a *different* environment is warned about, never renamed.
- Inserts `environment: release` into the publishing job (line-based, same no-YAML-dep approach as `workflowJobs`).
- `explicitOnly`: arming the gate changes what a merge does (the release run sits `waiting`), so it is a chosen per-repo rollout, not a side effect of a bare `fix`.

Deliberately out of scope: wiring `environment: release` into freshly-scaffolded release workflows at `setup` time — a new repo has no environment yet, and Actions would auto-create it unprotected. The doctor check then nudges toward this fixer instead.

Rollout per the decision on #429: repo-by-repo via `fix release-environment`, low-stakes repos first, repo-tooling last.