### PR TITLE
fix(skills): resolve the stamped version from git tags in a checkout

### DIFF
--- a/src/base/fixers.ts
+++ b/src/base/fixers.ts
@@ -458,11 +458,15 @@ export const BASE_FIXERS: Fixer[] = [
 			for (const name of SHIPPED_SKILLS) {
 				const result = await installClaudeSkill(dir, name, { force: forceSkills })
 				if (result.status === 'declined-downgrade') {
+					// Say what was compared, not what is newer: the version is a label,
+					// and on a git checkout it can understate the content behind it
+					// (#522). Naming the escape hatch matters for exactly that case.
 					console.error(
 						chalk.yellow(
-							`   skipped — ${result.file} is at ${result.installedVersion}, newer than the ${result.shippedVersion} this package ships`
+							`   skipped — ${result.file} is stamped ${result.installedVersion}, above the ${result.shippedVersion} this package reports; not overwritten`
 						)
 					)
+					console.error(chalk.yellow('   overwrite anyway:  fix claude-skills --force-skills'))
 					continue
 				}
 				if (result.status === 'declined-fork') {

--- a/src/cli/generators/claude-skills.ts
+++ b/src/cli/generators/claude-skills.ts
@@ -9,8 +9,12 @@ import { createHash } from 'node:crypto'
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
+import { realGitExec } from '../../base/git-identity.js'
 import { getPackageRoot } from '../utils/copy-preset.js'
 import { shellQuote } from '../utils/shell.js'
+
+/** Injectable git runner — never rejects; a missing or failing git is null. */
+export type GitExec = (args: string[], cwd?: string) => Promise<string | null>
 
 /**
  * Skills this package owns the content of and keeps up to date. The loop first —
@@ -171,13 +175,47 @@ export interface ShippedSkill {
 	file: string
 }
 
+/**
+ * The version to stamp, given what `package.json` claims.
+ *
+ * In a published tarball that field is authoritative — `@semantic-release/npm`
+ * rewrites it before packing. In a *git checkout* it is not: this repo runs
+ * semantic-release without `@semantic-release/git` (#417), so nothing ever
+ * writes the released version back and the field sits at whatever it was last
+ * hand-set to. Observed 2026-08-22: `package.json` 3.11.0 against npm 3.21.1,
+ * ten minor versions of drift.
+ *
+ * That mattered because the stamp feeds the downgrade guard below: a skill
+ * installed from npm could not be updated from a local checkout, and the
+ * refusal claimed the installed copy was "newer" when only its *label* was.
+ *
+ * So when the package root is a git checkout, take the nearest tag as well and
+ * keep whichever is higher. Monotonic on purpose — this can only ever raise the
+ * answer, so a tagless, shallow, or git-less environment keeps today's
+ * behaviour rather than silently stamping something lower.
+ */
+export async function resolveShippedVersion(
+	root: string,
+	pkgVersion: string,
+	git: GitExec = realGitExec
+): Promise<string> {
+	if (!(await fs.pathExists(path.join(root, '.git')))) return pkgVersion
+	const described = await git(['describe', '--tags', '--abbrev=0'], root)
+	const tag = described?.trim().replace(/^v/, '')
+	if (!tag || !/^\d+\.\d+/.test(tag)) return pkgVersion
+	return isNewerVersion(tag, pkgVersion) ? tag : pkgVersion
+}
+
 /** The skill source and the package version that will be stamped into it. */
-export async function readShippedSkill(name: string = SHIPPED_SKILL): Promise<ShippedSkill> {
+export async function readShippedSkill(
+	name: string = SHIPPED_SKILL,
+	git: GitExec = realGitExec
+): Promise<ShippedSkill> {
 	const root = getPackageRoot()
 	const file = path.join(root, 'skills', name, 'SKILL.md')
 	const content = await fs.readFile(file, 'utf8')
 	const pkg = await fs.readJson(path.join(root, 'package.json'))
-	return { content, version: String(pkg.version), file }
+	return { content, version: await resolveShippedVersion(root, String(pkg.version), git), file }
 }
 
 export type SkillInstallStatus =
@@ -268,7 +306,12 @@ export async function installClaudeSkill(
 		shippedVersion: shipped.version,
 	}
 
-	if (installedVersion && isNewerVersion(installedVersion, shipped.version)) {
+	// `force` overrides this too, not just the fork check below. It already
+	// overrides the *stronger* protection — overwriting content someone
+	// deliberately edited — so refusing on a version comparison while allowing
+	// that was backwards, and left no escape hatch at all when the comparison
+	// was wrong (#522).
+	if (!force && installedVersion && isNewerVersion(installedVersion, shipped.version)) {
 		return { ...base, status: 'declined-downgrade' }
 	}
 

--- a/tests/cli/generators/claude-skills.test.ts
+++ b/tests/cli/generators/claude-skills.test.ts
@@ -8,6 +8,7 @@ import {
 	installClaudeSkill,
 	isNewerVersion,
 	readShippedSkill,
+	resolveShippedVersion,
 	readSkillVersion,
 	resolveSkillsDir,
 	SHIPPED_SKILL,
@@ -323,5 +324,70 @@ describe('SHIPPED_SKILLS', () => {
 		for (const name of SHIPPED_SKILLS) {
 			expect(await fs.pathExists(join(dir, name, 'SKILL.md')), name).toBe(true)
 		}
+	})
+})
+
+// #522: package.json is authoritative in a published tarball (semantic-release's
+// npm plugin rewrites it before packing) but stale in a git checkout, because
+// this repo runs semantic-release without @semantic-release/git (#417). The
+// stamp feeds the downgrade guard, so a stale label blocked real installs.
+describe('resolveShippedVersion', () => {
+	const gitSaying = (out: string | null) => async () => out
+
+	it('keeps package.json when the root is not a git checkout', async () => {
+		const dir = newTmpDir()
+		// Would be preferred if it were consulted — proves it is not.
+		expect(await resolveShippedVersion(dir, '3.11.0', gitSaying('v9.9.9'))).toBe('3.11.0')
+	})
+
+	it('prefers the nearest tag when it is ahead of package.json', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.git'))
+		expect(await resolveShippedVersion(dir, '3.11.0', gitSaying('v3.21.1'))).toBe('3.21.1')
+	})
+
+	it('never lowers the answer', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.git'))
+		expect(await resolveShippedVersion(dir, '4.0.0', gitSaying('v3.21.1'))).toBe('4.0.0')
+	})
+
+	it('falls back to package.json when git fails or has no tags', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.git'))
+		expect(await resolveShippedVersion(dir, '3.11.0', gitSaying(null))).toBe('3.11.0')
+		expect(await resolveShippedVersion(dir, '3.11.0', gitSaying(''))).toBe('3.11.0')
+	})
+
+	it('ignores a tag that is not a version', async () => {
+		const dir = newTmpDir()
+		await fs.ensureDir(join(dir, '.git'))
+		expect(await resolveShippedVersion(dir, '3.11.0', gitSaying('nightly'))).toBe('3.11.0')
+	})
+})
+
+describe('installClaudeSkill — downgrade guard (#522)', () => {
+	/** A pristine install stamped by a *newer* release than the one shipping now. */
+	async function installedByNewerRelease(skillsDir: string): Promise<void> {
+		const { content } = await readShippedSkill()
+		await fs.outputFile(skillFile(skillsDir), stampSkill(content, '99.0.0'))
+	}
+
+	it('still declines a genuine downgrade without --force', async () => {
+		const dir = newTmpDir()
+		await installedByNewerRelease(dir)
+		expect((await installClaudeSkill(dir)).status).toBe('declined-downgrade')
+	})
+
+	// The case that had no escape hatch: force gates the *stronger* fork check,
+	// so refusing on a version comparison while allowing a fork overwrite was
+	// backwards — and a stale stamp made the comparison wrong.
+	it('force overrides the downgrade guard', async () => {
+		const dir = newTmpDir()
+		await installedByNewerRelease(dir)
+		const result = await installClaudeSkill(dir, SHIPPED_SKILL, { force: true })
+		expect(result.status).toBe('updated')
+		const written = await fs.readFile(skillFile(dir), 'utf8')
+		expect(readSkillVersion(written)).not.toBe('99.0.0')
 	})
 })


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on rtorcato's behalf.*

Closes #522.

Two independent bugs with different right answers, so both are here:

**1. The stamp was a decade-stale label.** `package.json` is authoritative in a published tarball — `@semantic-release/npm` rewrites it before packing — but never in a git checkout, because this repo deliberately runs without `@semantic-release/git` (#417). Measured 3.11.0 against npm 3.21.1.

`resolveShippedVersion` now takes the nearest git tag when it is *ahead*, and only then. Monotonic on purpose: no `.git` (every npm install), no tags, a shallow clone, or a non-version tag all keep today's behaviour, so this can only raise the answer, never lower it. Verified against this repo: resolves `3.21.1`.

**2. `--force-skills` didn't mean force.** It gated only `declined-fork`, so the version comparison could refuse with no escape hatch — while the *stronger* protection (overwriting content someone deliberately edited) was overridable. Now both are behind `force`.

The declined-downgrade message also stops asserting the installed copy is "newer", which it cannot know: a version is a label, and on a checkout it understated the content behind it. It now names what was compared and how to override.

Tests cover both directions of the guard and the npm-installed-then-local-build case that nothing exercised before. `pnpm verify`: 1078 passed.