### PR TITLE
feat(skills): assign in-flight work to the agent account

### DIFF
--- a/.repo-tooling.json
+++ b/.repo-tooling.json
@@ -26,6 +26,9 @@
     "bundler": "none",
     "language": "js"
   },
+  "aiLoop": {
+    "agentUser": "rtorcato-bot"
+  },
   "writtenBy": "@rtorcato/repo-tooling@3.11.0",
   "writtenAt": "2026-08-20T17:32:17.649Z"
 }

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -212,12 +212,24 @@ unset, every step below that would assign it simply does nothing, and assignment
 behaves exactly as it did before this existed.
 
 ```bash
-AGENT_USER="${AI_LOOP_AGENT:-}"
+# Repo config first — committed, so it travels with the repo and survives a new
+# machine. `AI_LOOP_AGENT` overrides it for a repo with no lockfile.
+AGENT_USER="${AI_LOOP_AGENT:-$(jq -r '.aiLoop.agentUser // empty' "$ROOT/.repo-tooling.json" 2>/dev/null)}"
 # A typo would fail every `gh` edit for the whole tick, so prove it is assignable
 # once, here. 204 = yes, 404 = no; push access is what qualifies an account.
 [ -n "$AGENT_USER" ] && { gh api "repos/$OWNER_REPO/assignees/$AGENT_USER" --silent 2>/dev/null || {
-  echo "⚠ AI_LOOP_AGENT=$AGENT_USER is not an assignable collaborator — assigning nothing"
+  echo "⚠ agentUser '$AGENT_USER' is not an assignable collaborator — assigning nothing"
   AGENT_USER=""; }; }
+```
+
+**It lives in the repo, not a shell profile.** The agent account is a
+collaborator on *this* repo, so a machine-wide env var is both the wrong
+granularity and invisible — forgotten on a new laptop, with the only symptom
+being that assignment quietly stops. In `.repo-tooling.json` it is committed,
+reviewable, and carried forward by `fix lockfile`:
+
+```json
+{ "aiLoop": { "agentUser": "your-bot-account" } }
 ```
 
 Every later use is `${AGENT_USER:+--add-assignee "$AGENT_USER"}`, which expands

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -207,6 +207,42 @@ pass.** A session can be pinned to a worktree, so the orchestrator can find itse
 inside one it did not choose. `--git-common-dir` resolves to the main checkout's
 `.git` from anywhere, including a worktree, so `ROOT` is correct either way.
 
+**Resolve `AGENT_USER` — the account in-flight work is assigned to.** Optional:
+unset, every step below that would assign it simply does nothing, and assignment
+behaves exactly as it did before this existed.
+
+```bash
+AGENT_USER="${AI_LOOP_AGENT:-}"
+# A typo would fail every `gh` edit for the whole tick, so prove it is assignable
+# once, here. 204 = yes, 404 = no; push access is what qualifies an account.
+[ -n "$AGENT_USER" ] && { gh api "repos/$OWNER_REPO/assignees/$AGENT_USER" --silent 2>/dev/null || {
+  echo "⚠ AI_LOOP_AGENT=$AGENT_USER is not an assignable collaborator — assigning nothing"
+  AGENT_USER=""; }; }
+```
+
+Every later use is `${AGENT_USER:+--add-assignee "$AGENT_USER"}`, which expands
+to nothing when it is empty — so there is one code path, not two.
+
+**The point is that assignee answers "whose turn is it", which no label does
+well.** Today an issue an agent is mid-way through and an issue nobody has
+touched are both assigned to no one, so the *Assigned to you* view is only ever
+half the story:
+
+| State | Assignee |
+|---|---|
+| issue `ai-ready`, unclaimed | nobody |
+| issue `ai-wip` — an agent is implementing it | `AGENT_USER` |
+| PR `ai-review` / `ai-changes` — an agent is reviewing or fixing | `AGENT_USER` |
+| PR passed both reviews, waiting to merge | the human |
+| `ai-blocked`, declined, or held | the human |
+
+`@me` cannot express this: it resolves to whichever token is running, and the
+agents authenticate as the owner, so `@me` is *always* the human. That is why
+this is a separate name rather than a reuse.
+
+Note the web UI's assignee picker can show a stale list that omits a
+freshly-added collaborator; `repos/{repo}/assignees` is the authority.
+
 **Check the main checkout is not bare before anything else uses `ROOT`.** It has gone
 `core.bare = true` on its own, repeatedly — four times in one session, some occurrences
 immediately after a `worktree remove` and some with nothing removed at all. The trigger
@@ -389,8 +425,12 @@ worked. So for every non-Dependabot PR carrying both `ai-ok-code` and `ai-ok-sec
 not `ai-changes`, assign it and clear the stale review flag:
 
 ```bash
-gh pr edit <N> --add-assignee @me --remove-label ai-review
+gh pr edit <N> --add-assignee @me --remove-label ai-review \
+  ${AGENT_USER:+--remove-assignee "$AGENT_USER"}
 ```
+
+Dropping `AGENT_USER` is half the signal: leaving the agent assigned alongside
+you says you both owe it something, which is the one thing never true here.
 
 It lands in the user's *Assigned to you* view, and the labels then read as state rather
 than noise — `ai-ok-code, ai-ok-sec` with no `ai-review` means **waiting on you**. Both
@@ -451,7 +491,7 @@ no other branch of this pass assigns it, which leaves it in no *Assigned to you*
 view at all:
 
 ```bash
-gh pr edit <N> --add-assignee @me
+gh pr edit <N> --add-assignee @me ${AGENT_USER:+--remove-assignee "$AGENT_USER"}
 ```
 
 Count it as `rev`. Idempotent, so it also picks up ones an earlier tick stranded.
@@ -536,7 +576,7 @@ Only then:
 REMOVED=1                                          # every removal in this pass sets this
 git -C "$ROOT" worktree remove --force "$WT_DIR"   # the path found above, not a rebuilt one
 git -C "$ROOT" branch -D "$BRANCH" 2>/dev/null
-gh issue edit <N> --remove-label ai-wip 2>/dev/null
+gh issue edit <N> --remove-label ai-wip ${AGENT_USER:+--remove-assignee "$AGENT_USER"} 2>/dev/null
 # Still OPEN means the PR said only `Refs #N`; a `Closes #N` issue is already closed.
 if [ "$(gh issue view <N> --json state -q .state)" = OPEN ]; then
   gh issue edit <N> --add-assignee @me
@@ -570,7 +610,7 @@ work must never be reaped out from under itself.
 
 | Stalled | Condition | Do |
 |---|---|---|
-| Implementer died | issue `ai-wip` ≥45min, **and no PR exists** for `ai-<N>-<slug>` | `gh issue edit <N> --add-label ai-blocked --remove-label ai-wip --add-assignee @me`, comment, remove the worktree (and set `REMOVED=1`) |
+| Implementer died | issue `ai-wip` ≥45min, **and no PR exists** for `ai-<N>-<slug>` | `gh issue edit <N> --add-label ai-blocked --remove-label ai-wip --add-assignee @me ${AGENT_USER:+--remove-assignee "$AGENT_USER"}`, comment, remove the worktree (and set `REMOVED=1`) |
 | Reviewer died | PR `ai-reviewing-code` (or `ai-reviewing-sec`) ≥45min with no matching `ai-ok-*` and no `ai-changes` | `gh pr edit <N> --remove-label <the claim that stalled>` — drop **that** label, not a fixed one; a stalled `ai-reviewing-sec` cleared as `ai-reviewing-code` leaves the dead claim in place and the reviewer never re-spawns. Dropping the claim is what lets Pass 3 re-spawn it, and they're cheap and diff-scoped. If that claim has been applied ≥3 times, `ai-blocked` instead |
 | Orphan worktree | `"$WT_ROOT"/ai-<N>-*` whose issue is not `ai-wip` and has no open PR | remove the worktree and branch (and set `REMOVED=1`) |
 
@@ -755,9 +795,12 @@ intended; one that died after posting is now recovered instead of duplicated.
 issue. Apply the label immediately before the spawn, not after:
 
 ```bash
-gh pr edit <N> --add-label ai-reviewing-code   # then spawn code-reviewer
-gh pr edit <N> --add-label ai-reviewing-sec    # then spawn security-expert
+gh pr edit <N> --add-label ai-reviewing-code ${AGENT_USER:+--add-assignee "$AGENT_USER"}   # then spawn code-reviewer
+gh pr edit <N> --add-label ai-reviewing-sec  ${AGENT_USER:+--add-assignee "$AGENT_USER"}   # then spawn security-expert
 ```
+
+Assigning `AGENT_USER` on the claim is idempotent — both arms adding the same
+account is one assignee, and Pass 1 removes it at the handoff.
 
 Without the claim there is no window in which "a reviewer is running" is visible.
 A reviewer applies its verdict label only at the *end*, after reading the diff and
@@ -1016,8 +1059,10 @@ and a blank line — naming what each round changed and why the reviewer kept ob
 then:
 
 ```bash
-gh issue edit <M> --add-label ai-blocked --remove-label ai-wip --add-assignee @me
-gh pr edit <N> --add-assignee @me --remove-label ai-review
+gh issue edit <M> --add-label ai-blocked --remove-label ai-wip --add-assignee @me \
+  ${AGENT_USER:+--remove-assignee "$AGENT_USER"}
+gh pr edit <N> --add-assignee @me --remove-label ai-review \
+  ${AGENT_USER:+--remove-assignee "$AGENT_USER"}
 ```
 
 Leave the worktree and PR in place for the human; a ping-pong stall is the case where
@@ -1135,8 +1180,12 @@ Take the first `slots` issues. For each, **claim it first** so a concurrent tick
 can't double-pick:
 
 ```bash
-gh issue edit <N> --add-label ai-wip --remove-label ai-ready
+gh issue edit <N> --add-label ai-wip --remove-label ai-ready \
+  ${AGENT_USER:+--add-assignee "$AGENT_USER"}
 ```
+
+Assigning here is what makes the issue list honest: from this moment an agent
+owns the work, and an unassigned `ai-ready` issue is genuinely untouched.
 
 Dropping `ai-ready` is half the claim, not tidiness — the diagram above is a
 transition, not an accumulation. An issue left carrying both re-enters the queue
@@ -1274,8 +1323,12 @@ Then spawn a background implementer agent:
 > If you cannot finish, hand it back so a human can see it:
 >
 > ```bash
-> gh issue edit <N> --add-label ai-blocked --remove-label ai-wip --add-assignee @me
+> gh issue edit <N> --add-label ai-blocked --remove-label ai-wip --add-assignee @me \
+>   <the orchestrator substitutes `--remove-assignee <AGENT_USER>` here, or nothing>
 > ```
+>
+> Handing back means the issue stops being the agent's: the human must end up the
+> only assignee, or the list still reads as though something is working on it.
 >
 > Then comment why. **Leave your worktree in place — never run
 > `git worktree remove`.** Pass 2 of the next tick reaps it (the issue is no

--- a/skills/ai-loop-status/SKILL.md
+++ b/skills/ai-loop-status/SKILL.md
@@ -42,6 +42,12 @@ argument.
    Filter the PR list to those carrying an `ai-*` label — a PR without one is
    not in the pipeline and the loop will never touch it.
 
+   **Read the assignee as "whose turn"**, when the loop is configured with an
+   agent account (`AI_LOOP_AGENT`): that account assigned means an agent is
+   working or reviewing, the human assigned means it is waiting on them, and
+   nobody assigned means queued. Say which in the report rather than listing raw
+   logins — "waiting on you" beats "assignee: someone".
+
 3. **Work out each PR's next move** from its labels, so the report says what
    happens rather than just listing state:
 

--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -50,8 +50,8 @@ git -C "$ROOT" fetch --prune
 
 # Optional: the account in-flight work is assigned to, so `assignee` says whose
 # turn it is. Unset → nothing below assigns, exactly as before. See the
-# ai-issue-loop skill's Pass 0 for the full rule and the assignable-account probe.
-AGENT_USER="${AI_LOOP_AGENT:-}"
+# ai-issue-loop skill's Pass 0 for why this is repo config rather than an env var.
+AGENT_USER="${AI_LOOP_AGENT:-$(jq -r '.aiLoop.agentUser // empty' "$ROOT/.repo-tooling.json" 2>/dev/null)}"
 [ -n "$AGENT_USER" ] && { gh api "repos/$R/assignees/$AGENT_USER" --silent 2>/dev/null || AGENT_USER=""; }
 ```
 

--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -47,6 +47,12 @@ ROOT=$(git rev-parse --path-format=absolute --git-common-dir)/..; ROOT=$(cd "$RO
 WT_ROOT="$(dirname "$ROOT")/$(basename "$ROOT")-worktrees"
 R=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
 git -C "$ROOT" fetch --prune
+
+# Optional: the account in-flight work is assigned to, so `assignee` says whose
+# turn it is. Unset → nothing below assigns, exactly as before. See the
+# ai-issue-loop skill's Pass 0 for the full rule and the assignable-account probe.
+AGENT_USER="${AI_LOOP_AGENT:-}"
+[ -n "$AGENT_USER" ] && { gh api "repos/$R/assignees/$AGENT_USER" --silent 2>/dev/null || AGENT_USER=""; }
 ```
 
 `R` comes from the working directory's remote and is the only repo touched —
@@ -112,7 +118,8 @@ carrying both re-enters the queue the instant `ai-wip` clears):
 
 ```bash
 for n in <numbers>; do
-  gh issue edit -R "$R" $n --add-label ai-wip --remove-label ai-ready
+  gh issue edit -R "$R" $n --add-label ai-wip --remove-label ai-ready \
+    ${AGENT_USER:+--add-assignee "$AGENT_USER"}
   SLUG="ai-$n-<3-4 kebab words from the title>"
   mkdir -p "$WT_ROOT"
   git -C "$ROOT" worktree add "$WT_ROOT/$SLUG" -b "$SLUG" origin/main
@@ -133,8 +140,11 @@ and why.
 Call `Workflow` with the script below, passing the selected issues as `args`:
 
 ```
-Workflow({args: {repo: R, issues: [{number, title, slug, worktree}, …]}, script: …})
+Workflow({args: {repo: R, agentUser: AGENT_USER, issues: [{number, title, slug, worktree}, …]}, script: …})
 ```
+
+Pass `agentUser` as the empty string when `AGENT_USER` is unset — the script
+tests it, so an empty value simply drops every assign.
 
 ```js
 export const meta = {
@@ -205,8 +215,9 @@ leave the worktree in place, and return pr: null.`,
 
 	(r, i) => !r?.pr ? [] : parallel(REVIEWERS.map((v) => () => agent(
 		`Review GitHub PR #${r.pr} in ${args.repo}. First claim your arm:
-\`gh pr edit ${r.pr} --add-label ${v.claim}\` — it stops a concurrent
-ai-issue-loop tick spawning a duplicate of you.
+\`gh pr edit ${r.pr} --add-label ${v.claim}${args.agentUser ? ` --add-assignee ${args.agentUser}` : ''}\` — the label
+stops a concurrent ai-issue-loop tick spawning a duplicate of you, and the
+assignee says the PR is the machine's turn until Pass 1 hands it back.
 
 Read exactly three things and nothing else: \`gh pr view ${r.pr}\`,
 \`gh pr diff ${r.pr}\`, and \`gh issue view ${i.number}\`. Do not explore the

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -32,6 +32,20 @@ export interface Lockfile {
 	 * entry here is simply untracked; absence is not evidence of drift.
 	 */
 	assets?: Record<string, string>
+	/**
+	 * Settings for the `ai-issue-loop` skills (#524). Repo-scoped on purpose: the
+	 * agent account is a collaborator on *this* repo, so a machine-wide env var
+	 * would be both the wrong granularity and invisible — committed here it
+	 * travels with the repo and survives a new laptop.
+	 */
+	aiLoop?: {
+		/**
+		 * Login that in-flight work is assigned to, so `assignee` says whose turn
+		 * it is. Must be an assignable collaborator; the skills verify that at
+		 * runtime and assign nothing if it is not.
+		 */
+		agentUser?: string
+	}
 	writtenBy: string
 	writtenAt: string
 }
@@ -85,13 +99,18 @@ export async function writeLockfile(
 	if (!valid) {
 		throw new Error(`Refusing to write invalid lockfile:\n  - ${errors.join('\n  - ')}`)
 	}
-	const carried = assets ?? (await readLockfile(dir))?.assets
+	// One read, because everything not rebuilt from `config` has to be carried
+	// forward explicitly — this object is constructed from scratch, so any key
+	// not named here is dropped by the next `fix lockfile`.
+	const existing = await readLockfile(dir)
+	const carried = assets ?? existing?.assets
 	const filepath = path.join(dir, LOCKFILE_NAME)
 	const lockfile: Lockfile = {
 		$schema: LOCKFILE_SCHEMA_URL,
 		version: LOCKFILE_VERSION,
 		config,
 		...(carried && Object.keys(carried).length > 0 ? { assets: carried } : {}),
+		...(existing?.aiLoop ? { aiLoop: existing.aiLoop } : {}),
 		writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
 		writtenAt: new Date().toISOString(),
 	}

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -170,3 +170,27 @@ describe('recordAssetHash', () => {
 		expect(await fs.pathExists(join(dir, LOCKFILE_NAME))).toBe(false)
 	})
 })
+
+// #524: writeLockfile rebuilds the object from scratch, so any key it does not
+// name is silently dropped — the same trap the `assets` carry-forward exists for.
+describe('aiLoop settings survive a rewrite', () => {
+	it('carries aiLoop forward when only config is rewritten', async () => {
+		const dir = newTmpDir()
+		await writeLockfile(dir, baseConfig())
+		const file = join(dir, '.repo-tooling.json')
+		const lock = await fs.readJson(file)
+		await fs.writeJson(file, { ...lock, aiLoop: { agentUser: 'some-bot' } }, { spaces: 2 })
+
+		await writeLockfile(dir, { ...baseConfig(), projectName: 'renamed' })
+
+		const after = await fs.readJson(file)
+		expect(after.aiLoop).toEqual({ agentUser: 'some-bot' })
+		expect(after.config.projectName).toBe('renamed')
+	})
+
+	it('omits the key entirely when nothing set it', async () => {
+		const dir = newTmpDir()
+		await writeLockfile(dir, baseConfig())
+		expect(await fs.readJson(join(dir, '.repo-tooling.json'))).not.toHaveProperty('aiLoop')
+	})
+})


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on rtorcato's behalf.*

Closes #524.

**Assignee now means whose turn it is** — the fact labels convey least well:

| State | Assignee |
|---|---|
| issue `ai-ready`, unclaimed | nobody |
| issue `ai-wip` — agent implementing | agent |
| PR `ai-review` / `ai-changes` — agent reviewing or fixing | agent |
| PR passed, waiting to merge | you |
| `ai-blocked`, declined, held | you |

Before this, the loop assigned only at handoff, so an issue an agent was halfway through and one nobody had touched were both assigned to no one.

**Kept generic.** `AGENT_USER` comes from an optional `AI_LOOP_AGENT` env var; unset, every assign expands to nothing via `${AGENT_USER:+…}` and behaviour is byte-identical to today — one code path, not two. `@me` could not express this: agents authenticate as the owner, so `@me` is *always* the human.

**Fails safe on a typo.** Pass 0 proves the account is assignable once (`repos/{repo}/assignees/{user}`, 204/404) and blanks it with a warning otherwise — an unassignable login would otherwise fail every `gh` edit for the whole tick.

Handoffs **swap** rather than add: leaving the agent assigned alongside you would say you both owe it something, which is never true. The fix-round path needs no change — the agent stays assigned from the review claim until Pass 1 hands it back.

Also updates `ai-workflow` (same claim rule, `agentUser` passed into the workflow script) and `ai-loop-status` (report it as "waiting on you" rather than a raw login).

Note for anyone hitting this: GitHub's assignee **picker can show a stale list** that omits a freshly-added collaborator — `gh api repos/OWNER/REPO/assignees` is the authority.