### PR TITLE
feat(schema): publish the .repo-tooling.json JSON Schema at its $schema URL

### DIFF
--- a/apps/docs/biome.json
+++ b/apps/docs/biome.json
@@ -3,6 +3,12 @@
   "root": false,
   "extends": ["../../tooling/biome/preset.json"],
   "files": {
-    "includes": ["!**/.docusaurus", "!**/build", "!**/node_modules", "!**/docs/changelog.md"]
+    "includes": [
+      "!**/.docusaurus",
+      "!**/build",
+      "!**/node_modules",
+      "!**/docs/changelog.md",
+      "!**/static/schemas"
+    ]
   }
 }

--- a/apps/docs/docs/reference/repo-tooling-json.mdx
+++ b/apps/docs/docs/reference/repo-tooling-json.mdx
@@ -1,0 +1,91 @@
+---
+title: .repo-tooling.json
+description: The lockfile the CLI writes — every field, rendered from the published JSON Schema.
+---
+
+import lockfileSchema from '@site/static/schemas/lockfile.json'
+
+export const typeOf = (prop) =>
+	prop.enum ? prop.enum.map(String).join(' | ') : prop.format ? `${prop.type} (${prop.format})` : prop.type
+
+export const Fields = ({ schema }) => (
+	<table>
+		<thead>
+			<tr>
+				<th>Field</th>
+				<th>Type</th>
+				<th>Required</th>
+				<th>Description</th>
+			</tr>
+		</thead>
+		<tbody>
+			{Object.entries(schema.properties).map(([name, prop]) => (
+				<tr key={name}>
+					<td>
+						<code>{name}</code>
+					</td>
+					<td>
+						<code>{typeOf(prop)}</code>
+					</td>
+					<td>{(schema.required ?? []).includes(name) ? 'yes' : 'no'}</td>
+					<td>{prop.description ?? ''}</td>
+				</tr>
+			))}
+		</tbody>
+	</table>
+)
+
+<p>{lockfileSchema.description}</p>
+
+`setup` creates it, `fix` keeps it current, and `doctor` reads it to know what the repo opted into.
+Commit it — it is the repo's memory of its own tooling choices.
+
+## Editor validation
+
+Every written file carries a `$schema` pointer, so editors that understand JSON Schema
+(VS Code out of the box) validate, autocomplete, and show these descriptions inline:
+
+<pre>
+<code>{JSON.stringify({ $schema: lockfileSchema.$id, version: 3 }, null, 2).replace('\n}', ',\n  ...\n}')}</code>
+</pre>
+
+The schema itself is published at <a href={lockfileSchema.$id}>{lockfileSchema.$id}</a>. It is
+generated from the `Lockfile` TypeScript interface (`pnpm schema:generate`), and CI fails when the
+published copy drifts from the type — this page renders from the same file, so what you read here
+is what your editor enforces.
+
+## Top-level fields
+
+<Fields schema={lockfileSchema} />
+
+Unknown fields are rejected (`additionalProperties: false`): the CLI rewrites the file from
+scratch on every save, so any key it doesn't know is a key it would silently drop.
+
+## `config` — the ProjectConfig
+
+The full setup configuration, identical to what `setup --config` accepts
+(its standalone schema is published at
+<a href="https://rtorcato.github.io/repo-tooling/schemas/project-config.json">/schemas/project-config.json</a>,
+printable with `setup --config-schema`):
+
+<Fields schema={lockfileSchema.properties.config} />
+
+The `object`-typed fields above (`typescript`, `linting`, `formatting`, `testing`) are small
+enum-valued records — see the schema for their exact shapes.
+
+## `aiLoop` — ai-issue-loop settings
+
+<Fields schema={lockfileSchema.properties.aiLoop} />
+
+See the [AI issue loop guide](../guides/ai-issue-loop.md) for how this is used.
+
+## Version history
+
+| Version | Change |
+| --- | --- |
+| 1 | Initial format. |
+| 2 | Added `config.language` (multi-language seam). Older files migrate to `js` on read. |
+| 3 | Added `assets` — pristine hashes of copied presets, so `doctor` can tell a local fork from a stale copy. |
+
+Older files are migrated in memory on read and rewritten at the current version on the next save.
+The pre-rename `.js-tooling.json` is still read as a fallback and replaced on the next write.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -66,6 +66,7 @@ const sidebars: SidebarsConfig = {
 				'reference/publint',
 				'reference/python',
 				'reference/release-please',
+				'reference/repo-tooling-json',
 				'reference/rolldown',
 				'reference/rollup',
 				'reference/semantic-release',

--- a/apps/docs/static/llms.txt
+++ b/apps/docs/static/llms.txt
@@ -20,6 +20,7 @@
 - [Semantic Release](https://rtorcato.github.io/repo-tooling/reference/semantic-release): `@rtorcato/repo-tooling/semantic-release{,/github,/docker}`.
 - [tsup](https://rtorcato.github.io/repo-tooling/reference/tsup): `@rtorcato/repo-tooling/tsup`.
 - [esbuild](https://rtorcato.github.io/repo-tooling/reference/esbuild): `@rtorcato/repo-tooling/esbuild`.
+- [.repo-tooling.json](https://rtorcato.github.io/repo-tooling/reference/repo-tooling-json): The lockfile the CLI writes. JSON Schemas: [lockfile](https://rtorcato.github.io/repo-tooling/schemas/lockfile.json), [ProjectConfig](https://rtorcato.github.io/repo-tooling/schemas/project-config.json).
 
 ## Source
 

--- a/apps/docs/static/schemas/lockfile.json
+++ b/apps/docs/static/schemas/lockfile.json
@@ -1,0 +1,243 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://rtorcato.github.io/repo-tooling/schemas/lockfile.json",
+	"title": "Lockfile",
+	"description": ".repo-tooling.json — the committed record of what @rtorcato/repo-tooling set up in this repo. Written by `setup` and `fix`, read by `doctor`.",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"version",
+		"config",
+		"writtenBy",
+		"writtenAt"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"description": "URL of this schema; stamped on every write so editors validate the file."
+		},
+		"version": {
+			"type": "integer",
+			"description": "Lockfile format version (current: 3). v2 added config.language, v3 added assets; older files are migrated on read."
+		},
+		"config": {
+			"title": "ProjectConfig",
+			"description": "The resolved setup configuration this repo was scaffolded or audited with.",
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"projectName",
+				"projectType",
+				"typescript",
+				"linting",
+				"formatting",
+				"testing",
+				"gitHooks",
+				"commitLint",
+				"semanticRelease",
+				"securityAutomation",
+				"bundler"
+			],
+			"properties": {
+				"projectName": {
+					"type": "string",
+					"minLength": 1
+				},
+				"language": {
+					"type": "string",
+					"enum": [
+						"js",
+						"swift",
+						"perl",
+						"python"
+					]
+				},
+				"projectType": {
+					"type": "string",
+					"enum": [
+						"library",
+						"web-app",
+						"node-api",
+						"nextjs-app",
+						"react-app"
+					]
+				},
+				"typescript": {
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"enabled",
+						"config"
+					],
+					"properties": {
+						"enabled": {
+							"type": "boolean"
+						},
+						"config": {
+							"type": "string",
+							"enum": [
+								"base",
+								"react",
+								"next",
+								"node",
+								"express"
+							]
+						}
+					}
+				},
+				"linting": {
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"tool"
+					],
+					"properties": {
+						"tool": {
+							"type": "string",
+							"enum": [
+								"biome",
+								"eslint",
+								"both",
+								"none"
+							]
+						},
+						"eslintConfig": {
+							"type": "string",
+							"enum": [
+								"base",
+								"nextjs"
+							]
+						}
+					}
+				},
+				"formatting": {
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"tool"
+					],
+					"properties": {
+						"tool": {
+							"type": "string",
+							"enum": [
+								"biome",
+								"prettier",
+								"none"
+							]
+						}
+					}
+				},
+				"testing": {
+					"type": "object",
+					"additionalProperties": false,
+					"required": [
+						"framework"
+					],
+					"properties": {
+						"framework": {
+							"type": "string",
+							"enum": [
+								"vitest",
+								"jest",
+								"playwright",
+								"cypress",
+								"none"
+							]
+						},
+						"environment": {
+							"type": "string",
+							"enum": [
+								"node",
+								"browser",
+								"both"
+							]
+						}
+					}
+				},
+				"gitHooks": {
+					"type": "boolean"
+				},
+				"commitLint": {
+					"type": "boolean"
+				},
+				"semanticRelease": {
+					"type": "boolean"
+				},
+				"changesets": {
+					"type": "boolean"
+				},
+				"releasePlease": {
+					"type": "boolean"
+				},
+				"oxlint": {
+					"type": "boolean"
+				},
+				"securityAutomation": {
+					"type": "boolean"
+				},
+				"bundler": {
+					"type": "string",
+					"enum": [
+						"tsup",
+						"esbuild",
+						"rollup",
+						"rolldown",
+						"vite",
+						"none"
+					]
+				},
+				"treeshakeCheck": {
+					"type": "boolean"
+				},
+				"publint": {
+					"type": "boolean"
+				},
+				"badges": {
+					"type": "boolean"
+				},
+				"aiSetup": {
+					"type": "boolean"
+				},
+				"turborepo": {
+					"type": "boolean"
+				},
+				"nx": {
+					"type": "boolean"
+				},
+				"tailwind": {
+					"type": "boolean"
+				},
+				"bun": {
+					"type": "boolean"
+				}
+			}
+		},
+		"assets": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "string"
+			},
+			"description": "Preset name → sha256 of the asset's pristine content at copy time. Lets doctor tell a deliberate local fork (file differs from this hash) from a copy the package has since moved past (file still matches, shipped asset doesn't). A preset with no entry is untracked, never drifted."
+		},
+		"aiLoop": {
+			"type": "object",
+			"additionalProperties": false,
+			"description": "Settings for the ai-issue-loop skills. Repo-scoped on purpose: committed here they travel with the repo and survive a new laptop.",
+			"properties": {
+				"agentUser": {
+					"type": "string",
+					"description": "Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime."
+				}
+			}
+		},
+		"writtenBy": {
+			"type": "string",
+			"description": "Package name and version that last wrote this file."
+		},
+		"writtenAt": {
+			"type": "string",
+			"format": "date-time",
+			"description": "ISO 8601 timestamp of the last write."
+		}
+	}
+}

--- a/apps/docs/static/schemas/project-config.json
+++ b/apps/docs/static/schemas/project-config.json
@@ -1,0 +1,194 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://rtorcato.github.io/repo-tooling/schemas/project-config.json",
+	"title": "ProjectConfig",
+	"description": "@rtorcato/repo-tooling setup configuration",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"projectName",
+		"projectType",
+		"typescript",
+		"linting",
+		"formatting",
+		"testing",
+		"gitHooks",
+		"commitLint",
+		"semanticRelease",
+		"securityAutomation",
+		"bundler"
+	],
+	"properties": {
+		"projectName": {
+			"type": "string",
+			"minLength": 1
+		},
+		"language": {
+			"type": "string",
+			"enum": [
+				"js",
+				"swift",
+				"perl",
+				"python"
+			]
+		},
+		"projectType": {
+			"type": "string",
+			"enum": [
+				"library",
+				"web-app",
+				"node-api",
+				"nextjs-app",
+				"react-app"
+			]
+		},
+		"typescript": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"enabled",
+				"config"
+			],
+			"properties": {
+				"enabled": {
+					"type": "boolean"
+				},
+				"config": {
+					"type": "string",
+					"enum": [
+						"base",
+						"react",
+						"next",
+						"node",
+						"express"
+					]
+				}
+			}
+		},
+		"linting": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"tool"
+			],
+			"properties": {
+				"tool": {
+					"type": "string",
+					"enum": [
+						"biome",
+						"eslint",
+						"both",
+						"none"
+					]
+				},
+				"eslintConfig": {
+					"type": "string",
+					"enum": [
+						"base",
+						"nextjs"
+					]
+				}
+			}
+		},
+		"formatting": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"tool"
+			],
+			"properties": {
+				"tool": {
+					"type": "string",
+					"enum": [
+						"biome",
+						"prettier",
+						"none"
+					]
+				}
+			}
+		},
+		"testing": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"framework"
+			],
+			"properties": {
+				"framework": {
+					"type": "string",
+					"enum": [
+						"vitest",
+						"jest",
+						"playwright",
+						"cypress",
+						"none"
+					]
+				},
+				"environment": {
+					"type": "string",
+					"enum": [
+						"node",
+						"browser",
+						"both"
+					]
+				}
+			}
+		},
+		"gitHooks": {
+			"type": "boolean"
+		},
+		"commitLint": {
+			"type": "boolean"
+		},
+		"semanticRelease": {
+			"type": "boolean"
+		},
+		"changesets": {
+			"type": "boolean"
+		},
+		"releasePlease": {
+			"type": "boolean"
+		},
+		"oxlint": {
+			"type": "boolean"
+		},
+		"securityAutomation": {
+			"type": "boolean"
+		},
+		"bundler": {
+			"type": "string",
+			"enum": [
+				"tsup",
+				"esbuild",
+				"rollup",
+				"rolldown",
+				"vite",
+				"none"
+			]
+		},
+		"treeshakeCheck": {
+			"type": "boolean"
+		},
+		"publint": {
+			"type": "boolean"
+		},
+		"badges": {
+			"type": "boolean"
+		},
+		"aiSetup": {
+			"type": "boolean"
+		},
+		"turborepo": {
+			"type": "boolean"
+		},
+		"nx": {
+			"type": "boolean"
+		},
+		"tailwind": {
+			"type": "boolean"
+		},
+		"bun": {
+			"type": "boolean"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"prepublishOnly": "./scripts/fix-bins.sh",
 		"dev": "pnpm --filter @rtorcato/docs dev",
 		"docs:build": "pnpm --filter @rtorcato/docs build",
+		"schema:generate": "pnpm build-cli && node scripts/generate-lockfile-schema.mjs",
 		"==================== Common ====================": "",
 		"lint": "pnpm exec biome lint .",
 		"format": "pnpm exec biome format .",

--- a/scripts/generate-lockfile-schema.mjs
+++ b/scripts/generate-lockfile-schema.mjs
@@ -1,0 +1,21 @@
+// Regenerate the published JSON Schemas from the source constants (#529).
+// Run via `pnpm schema:generate` (builds the CLI first — this imports dist/).
+// tests/cli/utils/lockfile-schema.test.ts fails CI when the committed copies
+// are stale against the source.
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { CONFIG_SCHEMA } from '../dist/cli/commands/setup-presets.js'
+import { lockfileSchema } from '../dist/cli/utils/lockfile.js'
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const outDir = path.join(root, 'apps/docs/static/schemas')
+fs.mkdirSync(outDir, { recursive: true })
+
+for (const [file, schema] of [
+	['lockfile.json', lockfileSchema()],
+	['project-config.json', CONFIG_SCHEMA],
+]) {
+	fs.writeFileSync(path.join(outDir, file), `${JSON.stringify(schema, null, '\t')}\n`)
+	console.log(`wrote apps/docs/static/schemas/${file}`)
+}

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import fs from 'fs-extra'
 import packageJson from '../../../package.json' with { type: 'json' }
-import { validateProjectConfig } from '../commands/setup-presets.js'
+import { CONFIG_SCHEMA, validateProjectConfig } from '../commands/setup-presets.js'
 import type { ProjectConfig } from '../commands/setup.js'
 
 export const LOCKFILE_NAME = '.repo-tooling.json'
@@ -48,6 +48,78 @@ export interface Lockfile {
 	}
 	writtenBy: string
 	writtenAt: string
+}
+
+/**
+ * JSON Schema for the lockfile, published with the docs site at the exact URL
+ * every written lockfile's `$schema` points to (#529). The `satisfies` clauses
+ * bind the property lists to the Lockfile interface, so adding or removing a
+ * field on the type is a compile error until the schema names it too. The
+ * committed copy under apps/docs/static/schemas/ is regenerated with
+ * `pnpm schema:generate` and gated by tests/cli/utils/lockfile-schema.test.ts.
+ *
+ * A function, not a const: lockfile.ts sits in an import cycle with
+ * setup-presets.ts (via the swift scaffolder), so CONFIG_SCHEMA is in its TDZ
+ * while this module evaluates.
+ */
+// ponytail: key sets are compiler-checked against the type; a changed field
+// *type* (string → number) still needs both lines edited by hand.
+export function lockfileSchema() {
+	// The published ProjectConfig schema, embedded (not $ref'd) so editors
+	// resolve the whole lockfile schema in one fetch. Its own $schema/$id are
+	// dropped: a nested $id would reset the base URI mid-document.
+	const { $schema: _meta, $id: _id, ...projectConfigSchema } = CONFIG_SCHEMA
+	return {
+		$schema: 'https://json-schema.org/draft/2020-12/schema',
+		$id: LOCKFILE_SCHEMA_URL,
+		title: 'Lockfile',
+		description: `${LOCKFILE_NAME} — the committed record of what @rtorcato/repo-tooling set up in this repo. Written by \`setup\` and \`fix\`, read by \`doctor\`.`,
+		type: 'object',
+		additionalProperties: false,
+		required: ['version', 'config', 'writtenBy', 'writtenAt'],
+		properties: {
+			$schema: {
+				type: 'string',
+				description: 'URL of this schema; stamped on every write so editors validate the file.',
+			},
+			version: {
+				type: 'integer',
+				description: `Lockfile format version (current: ${LOCKFILE_VERSION}). v2 added config.language, v3 added assets; older files are migrated on read.`,
+			},
+			config: {
+				...projectConfigSchema,
+				description: 'The resolved setup configuration this repo was scaffolded or audited with.',
+			},
+			assets: {
+				type: 'object',
+				additionalProperties: { type: 'string' },
+				description:
+					"Preset name → sha256 of the asset's pristine content at copy time. Lets doctor tell a deliberate local fork (file differs from this hash) from a copy the package has since moved past (file still matches, shipped asset doesn't). A preset with no entry is untracked, never drifted.",
+			},
+			aiLoop: {
+				type: 'object',
+				additionalProperties: false,
+				description:
+					'Settings for the ai-issue-loop skills. Repo-scoped on purpose: committed here they travel with the repo and survive a new laptop.',
+				properties: {
+					agentUser: {
+						type: 'string',
+						description:
+							'Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime.',
+					},
+				} satisfies Record<keyof NonNullable<Lockfile['aiLoop']>, object>,
+			},
+			writtenBy: {
+				type: 'string',
+				description: 'Package name and version that last wrote this file.',
+			},
+			writtenAt: {
+				type: 'string',
+				format: 'date-time',
+				description: 'ISO 8601 timestamp of the last write.',
+			},
+		} satisfies Record<keyof Lockfile, object>,
+	}
 }
 
 /**

--- a/tests/cli/utils/lockfile-schema.test.ts
+++ b/tests/cli/utils/lockfile-schema.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { CONFIG_SCHEMA } from '../../../src/cli/commands/setup-presets.js'
+import { lockfileSchema } from '../../../src/cli/utils/lockfile.js'
+
+const schemasDir = join(
+	fileURLToPath(new URL('.', import.meta.url)),
+	'../../../apps/docs/static/schemas'
+)
+
+const published = (file: string) =>
+	JSON.parse(readFileSync(join(schemasDir, file), 'utf8')) as unknown
+
+describe('published JSON Schemas', () => {
+	// The docs site serves apps/docs/static/ verbatim, so these committed files
+	// ARE the URLs the lockfiles point at. Stale copy → this fails CI.
+	it('lockfile.json matches lockfileSchema()', () => {
+		expect(published('lockfile.json'), 'run `pnpm schema:generate` and commit the result').toEqual(
+			lockfileSchema()
+		)
+	})
+
+	it('project-config.json matches CONFIG_SCHEMA', () => {
+		expect(
+			published('project-config.json'),
+			'run `pnpm schema:generate` and commit the result'
+		).toEqual(CONFIG_SCHEMA)
+	})
+
+	// The $id is the published URL: docs deploy to rtorcato.github.io/repo-tooling
+	// and static/schemas/lockfile.json lands at /schemas/lockfile.json. Every
+	// lockfile writeLockfile stamps carries this same constant as its $schema.
+	it('$ids match the deployed static paths', () => {
+		expect(lockfileSchema().$id).toBe(
+			'https://rtorcato.github.io/repo-tooling/schemas/lockfile.json'
+		)
+		expect(CONFIG_SCHEMA.$id).toBe(
+			'https://rtorcato.github.io/repo-tooling/schemas/project-config.json'
+		)
+	})
+})


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on rtorcato's behalf.*

Closes #529

Every lockfile the CLI writes stamps `https://rtorcato.github.io/repo-tooling/schemas/lockfile.json` as its `$schema`, and that URL served nothing. This publishes it — plus the equally dead `project-config.json` URL that `CONFIG_SCHEMA.$id` has claimed all along.

## What changed

- **`lockfileSchema()`** (`src/cli/utils/lockfile.ts`) builds the JSON Schema next to the `Lockfile` interface. `satisfies Record<keyof Lockfile, object>` clauses bind the property key sets (top level and `aiLoop`) to the type, so adding or removing a field is a **compile error** until the schema names it. `config` embeds the existing `CONFIG_SCHEMA` (the same one `setup --config-schema` prints), with its nested `$schema`/`$id` dropped so the base URI isn't reset mid-document. It's a function rather than a const because lockfile.ts sits in an import cycle with setup-presets.ts (via the swift scaffolder) — a module-level read of `CONFIG_SCHEMA` hits its TDZ.
- **`pnpm schema:generate`** (`scripts/generate-lockfile-schema.mjs`) writes both schemas into `apps/docs/static/schemas/`, which the existing docs deploy serves verbatim at the exact URLs the `$id`s claim.
- **CI staleness gate**: `tests/cli/utils/lockfile-schema.test.ts` (runs in the existing `pnpm test --run` CI step) fails when a committed schema differs from the source, and pins both `$id`s to the deployed static paths.
- **`reference/repo-tooling-json` docs page** (MDX) renders its field tables from the published `lockfile.json` itself, so descriptions live in one place and the page cannot drift from the schema. Added to the sidebar and `llms.txt`.
- Generated `static/schemas/` excluded from Biome (formatter output is owned by the generator).

## Notes for review

- Verified locally: `pnpm run verify` (biome + typecheck + 1084 tests + build) and `pnpm docs:build` both pass; the schemas land in `apps/docs/build/schemas/`.
- Deliberate ceiling (marked with a `ponytail:` comment): the `satisfies` binding catches added/removed fields, not a changed primitive type — that still needs both lines edited by hand. A full AST-driven generator would need a new dependency and the classic TS compiler API, which the repo's TypeScript 7 no longer ships.
- The issue's "descriptions live once, in the TS doc comments" ideal is approximated: descriptions live once *in the schema* (which the docs page renders); the interface's doc comments remain for code readers.