### PR TITLE
feat(doctor): flag an older lockfile and migrate it in place with fix lockfile

### DIFF
--- a/.repo-tooling.json
+++ b/.repo-tooling.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://rtorcato.github.io/repo-tooling/schemas/lockfile.json",
-  "version": 2,
+  "version": 3,
   "config": {
+    "language": "js",
     "projectName": "@rtorcato/repo-tooling",
     "projectType": "library",
     "typescript": {
@@ -23,12 +24,15 @@
     "commitLint": true,
     "semanticRelease": true,
     "securityAutomation": true,
-    "bundler": "none",
-    "language": "js"
+    "bundler": "none"
+  },
+  "assets": {
+    "docusaurus-sync-changelog": "de05aecb200657c2023dc3540dbdd2f9f2f17f1027e67a06266119d12cc05fea",
+    "docusaurus-theme": "3ead9ab407c2676bc404f7df552977a0fb0412b0f0d0bcde223c271a51860005"
   },
   "aiLoop": {
     "agentUser": "rtorcato-bot"
   },
   "writtenBy": "@rtorcato/repo-tooling@3.11.0",
-  "writtenAt": "2026-08-20T17:32:17.649Z"
+  "writtenAt": "2026-08-26T14:58:22.032Z"
 }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -184,6 +184,16 @@ function checkLockfile(lock: Lockfile | null): CheckResult {
 			hint: 'Upgrade @rtorcato/repo-tooling to a release that supports this lockfile version',
 		}
 	}
+	// Not drift: nothing is wrong, a newer capability (e.g. v3 asset-drift
+	// tracking) is just dormant until the file is rewritten (#531).
+	if (lock.version < LOCKFILE_VERSION) {
+		return {
+			check: 'lockfile',
+			status: 'optional-missing',
+			detail: `.repo-tooling.json is v${lock.version}; this CLI writes v${LOCKFILE_VERSION} — newer doctor capabilities stay dormant until it's migrated`,
+			hint: 'Run `npx @rtorcato/repo-tooling fix lockfile` to migrate it in place',
+		}
+	}
 	return {
 		check: 'lockfile',
 		status: 'ok',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -393,6 +393,15 @@ program.hook('preAction', async (_, actionCommand) => {
 		// so CI can audit our own config the same way it does consumers'. Scoped
 		// to doctor — the mutating setup/fix stay blocked even with the flag set.
 		if (name === 'doctor' && process.env.REPO_TOOLING_ALLOW_SELF === '1') return
+		// One mutating exception (#531): `fix lockfile` writes only
+		// .repo-tooling.json — no scaffolding — so our own lockfile can be
+		// migrated by the fixer we ship instead of by hand.
+		if (
+			name === 'fix' &&
+			actionCommand.args[0] === 'lockfile' &&
+			process.env.REPO_TOOLING_ALLOW_SELF === '1'
+		)
+			return
 		const dir = (actionCommand.opts().directory as string | undefined) ?? process.cwd()
 		if (await isSelfRepo(dir)) {
 			console.log(

--- a/src/cli/utils/copied-assets.ts
+++ b/src/cli/utils/copied-assets.ts
@@ -63,6 +63,26 @@ export async function classifyCopiedAssets(dir: string): Promise<CopiedAssetStat
 	return statuses
 }
 
+/**
+ * Preset hashes `fix lockfile` can record with confidence (#531): the target
+ * file exists and matches the shipped asset byte-for-byte, so it is provably an
+ * unmodified copy of what this package ships. A file that differs could be a
+ * local fork or a stale copy of an older release — indistinguishable without a
+ * recorded hash, so those stay untracked, which is the honest answer.
+ */
+export async function identifiablePresetHashes(dir: string): Promise<Record<string, string>> {
+	const packageRoot = getPackageRoot()
+	const hashes: Record<string, string> = {}
+	for (const name of Object.keys(PRESETS) as PresetName[]) {
+		const preset = PRESETS[name]
+		const current = await hashFile(path.join(dir, preset.target))
+		if (current === null) continue
+		const shipped = await hashFile(path.join(packageRoot, preset.source))
+		if (shipped !== null && shipped === current) hashes[name] = current
+	}
+	return hashes
+}
+
 const listOf = (s: CopiedAssetStatus[]) => s.map((a) => a.preset).join(', ')
 
 export async function checkCopiedAssets(dir: string): Promise<CheckResult> {

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -125,13 +125,14 @@ export function lockfileSchema() {
 /**
  * Upgrade an older lockfile in-memory. Only touches files older than the
  * current version, so a newer-than-supported file is left as-is for
- * checkLockfile to flag. The file is rewritten to v3 next time it's saved.
+ * checkLockfile to flag. `version` stays at the on-disk value — bumping it here
+ * hid every older file from doctor's older-than-current check (#531); the write
+ * path stamps LOCKFILE_VERSION anyway, so the file is v3 next time it's saved.
  */
 function migrate(lock: Lockfile): Lockfile {
 	if (lock.version >= LOCKFILE_VERSION) return lock
 	return {
 		...lock,
-		version: LOCKFILE_VERSION,
 		config: { language: 'js', ...lock.config },
 		assets: lock.assets ?? {},
 	}

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -109,6 +109,7 @@ import { generateBun } from '../../cli/generators/bun.js'
 import { generateDocsSite } from '../../cli/generators/docs-site.js'
 import { generateTypedocConfig, generateTypedocWorkflow } from '../../cli/generators/typedoc.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
+import { identifiablePresetHashes } from '../../cli/utils/copied-assets.js'
 import { LOCKFILE_NAME, writeLockfile } from '../../cli/utils/lockfile.js'
 import type { ProjectConfig } from '../../cli/commands/setup.js'
 
@@ -930,13 +931,19 @@ export const FIXERS: Fixer[] = [
 		outputs: [LOCKFILE_NAME],
 		riskLevel: 'safe-add',
 		canFixDrift: false,
-		async run({ targetDir, pkg }) {
-			if (!pkg) {
+		async run({ targetDir, pkg, lock }) {
+			// An existing lockfile keeps its recorded config — this path migrates the
+			// file to the current version on disk (#531), it never re-infers over
+			// choices the repo already made.
+			if (!lock && !pkg) {
 				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
-			const config = inferProjectConfig(pkg)
-			await writeLockfile(targetDir, config)
+			const config = lock ? lock.config : inferProjectConfig(pkg as Record<string, unknown>)
+			// Recorded hashes win: they capture the pristine content at copy time,
+			// which a byte-match against today's shipped asset can only approximate.
+			const assets = { ...(await identifiablePresetHashes(targetDir)), ...lock?.assets }
+			await writeLockfile(targetDir, config, assets)
 			return { filesWritten: [LOCKFILE_NAME] }
 		},
 	},

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../src/cli/generators/claude-skills.js'
 import { generateDependabotConfig } from '../../../src/cli/generators/security.js'
 import { copyPreset } from '../../../src/cli/utils/copy-preset.js'
+import { LOCKFILE_VERSION } from '../../../src/cli/utils/lockfile.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -1158,7 +1159,7 @@ describe('doctor + lockfile', () => {
 			...configPatch,
 		}
 		await fs.writeJson(join(dir, '.repo-tooling.json'), {
-			version: 1,
+			version: LOCKFILE_VERSION,
 			config,
 			writtenBy: '@rtorcato/repo-tooling@test',
 			writtenAt: new Date().toISOString(),
@@ -1179,6 +1180,35 @@ describe('doctor + lockfile', () => {
 		const results = await runDoctor(dir)
 		const lock = results.find((r) => r.check === 'lockfile')
 		expect(lock?.status).toBe('optional-missing')
+		expect(lock?.hint).toMatch(/fix lockfile/)
+	})
+
+	it('reports an older lockfile as optional-missing with the fix lockfile hint (#531)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await fs.writeJson(join(dir, '.repo-tooling.json'), {
+			version: 2,
+			config: {
+				projectName: 'demo',
+				projectType: 'library',
+				typescript: { enabled: true, config: 'base' },
+				linting: { tool: 'biome' },
+				formatting: { tool: 'biome' },
+				testing: { framework: 'vitest', environment: 'node' },
+				gitHooks: true,
+				commitLint: true,
+				semanticRelease: true,
+				securityAutomation: true,
+				bundler: 'tsup',
+				language: 'js',
+			},
+			writtenBy: '@rtorcato/repo-tooling@test',
+			writtenAt: new Date().toISOString(),
+		})
+		const results = await runDoctor(dir)
+		const lock = results.find((r) => r.check === 'lockfile')
+		expect(lock?.status).toBe('optional-missing')
+		expect(lock?.detail).toMatch(/v2/)
 		expect(lock?.hint).toMatch(/fix lockfile/)
 	})
 

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -14,6 +14,7 @@ import {
 	DEPENDABOT_AUTOMERGE_WORKFLOW,
 	DEPENDABOT_CONFIG,
 } from '../../../src/cli/generators/security.js'
+import { copyPreset } from '../../../src/cli/utils/copy-preset.js'
 import { LOCKFILE_VERSION } from '../../../src/cli/utils/lockfile.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -1161,6 +1162,23 @@ describe('fix + lockfile', () => {
 		expect(lock.version).toBe(LOCKFILE_VERSION)
 		expect(lock.config.projectName).toBe('demo')
 		expect(lock.config.linting.tool).toBe('biome')
+	})
+
+	it('fix lockfile --yes migrates an older lockfile in place, keeping its config (#531)', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		// An unmodified copy of the shipped biome preset — identifiable, so the
+		// migration records its hash even though the v1 file tracked no assets.
+		await copyPreset('biome', dir)
+		await writeLock(dir, { testing: { framework: 'jest', environment: 'node' } })
+
+		await fixCommand('lockfile', { directory: dir, yes: true })
+
+		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(lock.version).toBe(LOCKFILE_VERSION)
+		// Recorded choices survive — no re-inference over an existing lockfile.
+		expect(lock.config.testing.framework).toBe('jest')
+		expect(lock.assets.biome).toMatch(/^[0-9a-f]{64}$/)
 	})
 
 	it('fix vitest --yes regenerates the config but keeps an existing vitest.setup.ts', async () => {

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -72,13 +72,14 @@ describe('readLockfile', () => {
 		})
 
 		const lock = await readLockfile(dir)
-		expect(lock?.version).toBe(LOCKFILE_VERSION)
+		// The on-disk version is preserved so doctor can flag it as older (#531).
+		expect(lock?.version).toBe(1)
 		expect(lock?.config.language).toBe('js')
 		// Existing fields survive the migration untouched.
 		expect(lock?.config.projectName).toBe('demo')
 	})
 
-	it('migrates a v2 file to v3 with no recorded asset hashes (#428)', async () => {
+	it('migrates a v2 file in memory with no recorded asset hashes (#428)', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, LOCKFILE_NAME), {
 			version: 2,
@@ -88,7 +89,8 @@ describe('readLockfile', () => {
 		})
 
 		const lock = await readLockfile(dir)
-		expect(lock?.version).toBe(3)
+		// The on-disk version is preserved so doctor can flag it as older (#531).
+		expect(lock?.version).toBe(2)
 		expect(lock?.assets).toEqual({})
 		expect(lock?.config.projectName).toBe('demo')
 	})


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on rtorcato's behalf.*

Closes #531

## What

- `doctor` now reports an older-than-current `.repo-tooling.json` as `optional-missing` (not `drift` — nothing is wrong, a capability is just dormant), with the hint to run `fix lockfile`. Root cause: `migrate()` bumped `version` in memory on read, so doctor could never see the on-disk value; it now preserves it, and the write path stamps `LOCKFILE_VERSION` as before.
- `fix lockfile` migrates an existing file on disk instead of re-inferring: it keeps the recorded config and populates `assets` hashes for presets it can identify — target file byte-matches the shipped asset, so it is provably an unmodified copy. Files that differ stay untracked (indistinguishable fork vs stale copy), and recorded hashes always win over identification.
- Self-repo guard: `REPO_TOOLING_ALLOW_SELF=1 fix lockfile` is the one mutating escape (it writes only `.repo-tooling.json`, no scaffolding), per the issue's preferred option.
- Dogfood proof: this repo's own lockfile is migrated v2 → v3 by the new fixer in this PR, picking up two identifiable docusaurus asset hashes; `doctor` on self now reports the lockfile `ok` at v3.

## Tests

- doctor: older lockfile → `optional-missing` with `fix lockfile` hint
- lockfile utils: read preserves on-disk version for v1/v2 files
- fix: migrating an older lockfile keeps its recorded config and records an identifiable preset hash

1091 tests pass; `biome check` and `tsc` clean.