### PR TITLE
docs(skills): hand over ready PRs at burst completion instead of waiting for a tick

### DIFF
--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -281,21 +281,15 @@ here**. A second copy of the handoff logic is drift with two files to keep
 honest; deferring means changes to Pass 1 (e.g. a future `merge-ready` label)
 take effect here without touching this file.
 
-- **Both arms passed** → Pass 1's ready-handoff, its `mergeStateStatus` check
-  included:
-  - `CLEAN` → Pass 1's assign-and-clear, exactly as it states it.
-  - `BEHIND` / `DIRTY` / `BLOCKED` → Pass 1's send-back (`ai-changes`, strip
-    the pass labels, marker-upsert comment naming the unblock) — the loop's
-    fix round then handles the rebase or conflict.
-  - `UNKNOWN` (GitHub still computing, CI mid-run) → do nothing; the loop's
-    next tick resolves it. Do **not** poll CI — the existing rule stands.
-    This step only closes the "reviews finished while the human is watching"
-    window.
+- **Both arms passed** → run ai-issue-loop's Pass 1 handoff/send-back logic
+  on this PR, per its current text — with one carve-out: `mergeStateStatus`
+  `UNKNOWN` (GitHub still computing, CI mid-run) ⇒ do nothing; the loop's next
+  tick resolves it. Do **not** poll CI — the existing rule stands. This step
+  only closes the "reviews finished while the human is watching" window.
 - **An arm requested changes** → do nothing; the PR carries `ai-changes` and
   the loop's fix round owns it.
 - **`pr: null` (blocked)** → verify the issue ended per the `ai-blocked`
-  contract in the loop skill — `ai-blocked` without `ai-wip`, assigned to the
-  human only, no `AGENT_USER` — and repair with `gh issue edit` if the
+  contract in the loop skill, and repair with `gh issue edit` if the
   implementer left it half-done.
 
 Then report — one block, nothing else:

--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -269,9 +269,36 @@ Notes on the script, so it doesn't get "tidied" into breakage:
   same verdict markers the loop's Pass 3 reads — so a later tick adopts their
   verdicts instead of re-reviewing.
 
-## 4. Report
+## 4. Hand over, then report
 
-One block, nothing else:
+The loop's next tick would hand these PRs over in Pass 1, but a human watching
+the burst beats a 15-minute tick and inherits unassigned PRs — #537 and #539
+were merged by hand before any tick ran, never appearing in *Assigned to you*
+and still wearing a stale `ai-review`. Close that window here: once per PR
+whose two review arms both completed, apply the `ai-issue-loop` skill's Pass 1
+**by reference — execute what its text currently says, never a copy of it
+here**. A second copy of the handoff logic is drift with two files to keep
+honest; deferring means changes to Pass 1 (e.g. a future `merge-ready` label)
+take effect here without touching this file.
+
+- **Both arms passed** → Pass 1's ready-handoff, its `mergeStateStatus` check
+  included:
+  - `CLEAN` → Pass 1's assign-and-clear, exactly as it states it.
+  - `BEHIND` / `DIRTY` / `BLOCKED` → Pass 1's send-back (`ai-changes`, strip
+    the pass labels, marker-upsert comment naming the unblock) — the loop's
+    fix round then handles the rebase or conflict.
+  - `UNKNOWN` (GitHub still computing, CI mid-run) → do nothing; the loop's
+    next tick resolves it. Do **not** poll CI — the existing rule stands.
+    This step only closes the "reviews finished while the human is watching"
+    window.
+- **An arm requested changes** → do nothing; the PR carries `ai-changes` and
+  the loop's fix round owns it.
+- **`pr: null` (blocked)** → verify the issue ended per the `ai-blocked`
+  contract in the loop skill — `ai-blocked` without `ai-wip`, assigned to the
+  human only, no `AGENT_USER` — and repair with `gh issue edit` if the
+  implementer left it half-done.
+
+Then report — one block, nothing else:
 
 - PRs opened, with numbers and review verdicts.
 - Anything `ai-blocked`, and why.


### PR DESCRIPTION
🤖 *Automated — implementer via ai-issue-loop.*

Closes #542

The burst opened PRs, reviewed them, and stopped — handover to the human waited for the next `ai-issue-loop` tick, so a human watching the burst inherited unassigned PRs with stale `ai-review` labels (#537, #539 were merged by hand before any tick ran).

Step 4 of `skills/ai-workflow/SKILL.md` is now "Hand over, then report": once per PR whose two review arms both completed, it applies the loop skill's Pass 1 **by reference** — executing whatever Pass 1's text currently says, never a copy — so the two skills cannot drift (a future `merge-ready` label lands here for free):

- Both passed → Pass 1's ready-handoff with its `mergeStateStatus` check: `CLEAN` assigns and clears; `BEHIND`/`DIRTY`/`BLOCKED` takes Pass 1's send-back (`ai-changes`, strip pass labels, marker-upsert comment naming the unblock); `UNKNOWN` does nothing — no CI polling, the next tick resolves it.
- An arm requested changes → nothing; the loop's fix round owns it.
- `pr: null` → verify (and repair) the `ai-blocked` contract: `ai-blocked` without `ai-wip`, human-only assignee.

Checks: `pnpm run check` and `pnpm run typecheck` pass; `tests/base/labels.test.ts` (the skill-content test) passes 17/17.
