### PR TITLE
docs(skills): make ai-workflow the single entry point and the loop its engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ ln -sf ../../node_modules/@rtorcato/repo-tooling/tooling/claude/repo-tooling.md 
 
 This repo is also a self-hosted Claude Code marketplace. Install the plugin to
 get six skills — `repo-tooling` (adopt/audit the presets via the CLI),
-`npm-publish` (never hand-cut a release), `ai-issue-loop` (the label-driven
-issue → PR pipeline), `ai-workflow` (burst the `ai-ready` queue in parallel
-worktrees), `ai-issue` (file agent-executable issues) and `ai-loop-status`
-(read-only pipeline status) — in any session:
+`npm-publish` (never hand-cut a release), `ai-workflow` (**the entry point** to
+the `ai-ready` issue → PR pipeline: bursts the queue in parallel worktrees, then
+schedules the engine below), `ai-issue-loop` (that engine — one stateless tick;
+it runs on a loop rather than being typed), `ai-issue` (file agent-executable
+issues) and `ai-loop-status` (read-only pipeline status) — in any session:
 
 ```
 /plugin marketplace add rtorcato/repo-tooling

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -2,11 +2,14 @@
 name: ai-issue-loop
 model: sonnet
 description: |
-  Run one tick of the label-driven GitHub issue pipeline: pick up `ai-ready`
-  issues into per-issue worktrees, review the resulting PRs with other agents,
-  and auto-merge once both reviewers pass. Use when the user says "run the
-  issue loop", "work the ai-ready issues", "babysit the AI PRs", or invokes
-  `/ai-issue-loop`. Designed to be driven by `/loop 15m /ai-issue-loop`.
+  **The engine behind `/ai-workflow` — normally you do not invoke this
+  directly.** One stateless tick over the GitHub label state: answer
+  `ai-changes` with a fix round, merge Dependabot PRs, hand passed issue PRs to
+  the human, clean up merged worktrees, reap stalled agents, and pick up any
+  remaining `ai-ready` issues. `/ai-workflow` is the entry point and schedules
+  this itself via `/loop 15m /ai-issue-loop`; reach for it directly only to
+  force a tick early — "run one tick", "babysit the AI PRs" — or when the user
+  invokes `/ai-issue-loop`. Only Dependabot PRs ever merge unattended.
   GitHub only (`gh`) — not GitLab.
 ---
 

--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ai-workflow
 description: |
-  Implement the `ai-ready` GitHub issue queue in parallel — one agent per issue,
-  each in its own git worktree, ending at open PRs reviewed by two agents. Use
-  when the user says "burst the queue", "work all the ai-ready issues in
-  parallel", or invokes `/ai-workflow`. Hands off to the ai-issue-loop skill for
-  fix rounds and merging. GitHub only (`gh`) — not GitLab.
+  **The entry point for the `ai-ready` issue pipeline — start here.** Implements
+  the queue in parallel, one agent per issue, each in its own git worktree,
+  ending at open PRs reviewed by two agents; then registers the ai-issue-loop
+  engine on a 15-minute loop to carry those PRs through fix rounds and cleanup.
+  Use when the user says "burst the queue", "run the AI pipeline", "work the
+  ai-ready issues", or invokes `/ai-workflow`. Never merges. GitHub only
+  (`gh`) — not GitLab.
 ---
 
 # ai-workflow


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Two skills that both read as commands left it ambiguous which one to run. They
are sequential stages, not alternatives — `/ai-workflow` bursts the queue and
already registers `/ai-issue-loop` itself at step 5, and only the loop can answer
an `ai-changes` label, merge a Dependabot PR, or clean up a merged worktree,
because a `Workflow` call runs once and returns.

So this says which one you type:

- **`ai-workflow`** — description now leads with *"the entry point … start here"*.
- **`ai-issue-loop`** — leads with *"the engine behind `/ai-workflow` — normally
  you do not invoke this directly"*, keeping its trigger phrases so a forced
  early tick still works.
- **README** listed the two as flat peers, which is where a consumer meets the
  ambiguity first. It now names the entry point and marks the loop as scheduled
  rather than typed.

Also drops the loop description's *"auto-merge once both reviewers pass"* — only
Dependabot PRs merge unattended (or a release-environment-gated repo), so that
line implied the loop would publish an issue PR by itself.

## Deliberately not touched

Renaming the skill *directory* was considered and rejected as a separate,
larger change with two hazards:

1. `<!-- ai-issue-loop:verdict:* -->` and `<!-- ai-issue-loop:decision -->` are
   **wire format** — written into GitHub review bodies and read back by Pass 3
   and Pass 1. They must keep that prefix whatever the skill is called, or
   in-flight verdicts become unreadable and decision comments start duplicating.
2. `SHIPPED_SKILLS` in `src/cli/generators/claude-skills.ts` drives the installed
   directory name. A rename would leave every existing consumer with a stale
   `~/.claude/skills/ai-issue-loop/` alongside the new one, still matching
   `/ai-issue-loop`, with nothing removing it.

Descriptions only. No test asserts skill description text (`pnpm vitest run
tests/base/labels.test.ts tests/cli/generators/claude-skills.test.ts` — 55 pass).