### PR TITLE
test(skills-install): harden commandLines against a command spanning lines

### DIFF
--- a/src/cli/utils/shell.ts
+++ b/src/cli/utils/shell.ts
@@ -1,8 +1,11 @@
 /**
  * Quote a value as one literal argument **for a POSIX `sh` command line, and
- * nothing else**. The result is wrong in `cmd.exe` and PowerShell, which do not
- * treat `'` as a quote, and wrong anywhere the value lands inside double quotes
- * or an existing quoted string — it is a whole argument, not a fragment.
+ * nothing else**. The result is wrong in `cmd.exe`, which does not treat `'` as
+ * a quote at all, and wrong in PowerShell, which does — but escapes an embedded
+ * `'` by doubling it rather than POSIX's `'\''`, so this output still mangles
+ * any value containing one. It is also wrong anywhere the value lands inside
+ * double quotes or an existing quoted string — it is a whole argument, not a
+ * fragment.
  *
  * POSIX single-quote escaping — the only form correct for arbitrary bytes.
  * Inside single quotes every character is literal, so `'` is the sole one

--- a/src/cli/utils/shell.ts
+++ b/src/cli/utils/shell.ts
@@ -1,4 +1,9 @@
 /**
+ * Quote a value as one literal argument **for a POSIX `sh` command line, and
+ * nothing else**. The result is wrong in `cmd.exe` and PowerShell, which do not
+ * treat `'` as a quote, and wrong anywhere the value lands inside double quotes
+ * or an existing quoted string — it is a whole argument, not a fragment.
+ *
  * POSIX single-quote escaping — the only form correct for arbitrary bytes.
  * Inside single quotes every character is literal, so `'` is the sole one
  * needing care: end the quote, escape it, start a new one. Double quotes are

--- a/tests/cli/generators/skills-install.test.ts
+++ b/tests/cli/generators/skills-install.test.ts
@@ -16,20 +16,30 @@ async function scaffoldSkill(dir: string, name: string): Promise<void> {
 }
 
 /**
- * Run one emitted command line through a real shell with `npx` swapped for a
- * printf that echoes its argv, and return what `npx` would have received. A
- * name the shell splits, expands or executes fails to come back intact.
+ * Run one emitted command through a real shell with `npx` swapped for a printf
+ * that echoes its argv, and return what `npx` would have received. A name the
+ * shell splits, expands or executes fails to come back intact. NUL separates the
+ * arguments — it is the one byte argv cannot carry, so a newline in a name round
+ * trips instead of reading as two arguments.
  */
 function shellArgv(command: string): string[] {
-	const out = execFileSync('sh', ['-c', command.replace(/^npx /, "printf '%s\\n' ")], {
+	const out = execFileSync('sh', ['-c', command.replace(/^npx /, "printf '%s\\0' ")], {
 		encoding: 'utf8',
 	})
-	return out.split('\n').slice(0, -1)
+	return out.split('\0').slice(0, -1)
 }
 
-/** The command lines inside the ```bash fence. */
+/**
+ * The commands inside the ```bash fence. A quoted name may contain a newline, so
+ * a command is not a line: each runs to the next `npx skills add ` boundary, and
+ * the last to the closing fence — which the generator emits as the final line.
+ */
 function commandLines(body: string): string[] {
-	return body.split('\n').filter((line) => line.startsWith('npx skills add '))
+	const lines = body.split('\n')
+	const open = lines.findIndex((line) => /^`{3,}bash$/.test(line))
+	if (open === -1) return []
+	const block = lines.slice(open + 1, -1).join('\n')
+	return block === '' ? [] : block.split(/\n(?=npx skills add )/)
 }
 
 describe('buildSkillsInstallBody', () => {
@@ -56,6 +66,9 @@ describe('buildSkillsInstallBody', () => {
 		['backticks and a variable', '`echo pwned`$HOME'],
 		['a double quote', 'we"rd'],
 		['a single quote', "it's"],
+		// Quoting does not escape a newline: this command spans two physical
+		// lines, so a per-line helper would drop the second and assert less.
+		['a newline', 'one\ntwo'],
 	])('hands %s to npx as one literal argument', (_what, skill) => {
 		const [command, ...rest] = commandLines(buildSkillsInstallBody('rtorcato', 'x', [skill]))
 		expect(rest).toEqual([])


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Two small hardening items from the #502 reviews. No behaviour change — a test helper and a doc comment.

## 1. `commandLines()` could quietly narrow its own assertion

It filtered lines starting with `npx skills add `, so it isolated only the **first physical line** of a command. Quoting does not escape a newline, so a skill name carrying one produces a multi-line command whose continuation was silently excluded from the `rest` the test asserts is empty — the assertion looked wider than it was.

It now takes the fenced block and splits on the next `npx skills add ` boundary. `shellArgv` also separates argv with NUL rather than a newline, so a newline-bearing name round trips instead of coming back as two arguments.

A new `a newline` case in the `it.each` table proves the fix rather than asserting it. Against the old helper it fails on the truncated, unbalanced-quote command:

```
Error: Command failed: sh -c printf '%s\0' skills add https://github.com/rtorcato/x --skill 'one
sh: -c: line 0: unexpected EOF while looking for matching `''
```

## 2. `shellQuote` is now documented as POSIX `sh` only

The implementation was already right; the bare name invited reuse where single-quoting is the wrong escape — `cmd.exe`/PowerShell, or a double-quoted context. The doc comment says so.

## Verification

`vitest run tests/cli/generators/skills-install.test.ts` — 13 passed. `biome check` and `tsc --noEmit --project src/cli/tsconfig.json` clean (pre-commit ran both).

`test:` type — semantic-release cuts no release.

Closes #503