### PR TITLE
test(lockfile): validate this repo's own .repo-tooling.json against lockfileSchema()

### DIFF
--- a/tests/cli/utils/lockfile-schema.test.ts
+++ b/tests/cli/utils/lockfile-schema.test.ts
@@ -5,13 +5,10 @@ import { describe, expect, it } from 'vitest'
 import { CONFIG_SCHEMA } from '../../../src/cli/commands/setup-presets.js'
 import { lockfileSchema } from '../../../src/cli/utils/lockfile.js'
 
-const schemasDir = join(
-	fileURLToPath(new URL('.', import.meta.url)),
-	'../../../apps/docs/static/schemas'
-)
+const repoRoot = join(fileURLToPath(new URL('.', import.meta.url)), '../../..')
 
 const published = (file: string) =>
-	JSON.parse(readFileSync(join(schemasDir, file), 'utf8')) as unknown
+	JSON.parse(readFileSync(join(repoRoot, 'apps/docs/static/schemas', file), 'utf8')) as unknown
 
 describe('published JSON Schemas', () => {
 	// The docs site serves apps/docs/static/ verbatim, so these committed files
@@ -39,5 +36,97 @@ describe('published JSON Schemas', () => {
 		expect(CONFIG_SCHEMA.$id).toBe(
 			'https://rtorcato.github.io/repo-tooling/schemas/project-config.json'
 		)
+	})
+})
+
+interface JsonSchema {
+	type?: string
+	enum?: readonly string[]
+	minLength?: number
+	required?: readonly string[]
+	properties?: Record<string, JsonSchema>
+	additionalProperties?: boolean | JsonSchema
+}
+
+/**
+ * Validate against the keyword subset lockfileSchema() actually uses: type
+ * (object/string/integer/boolean), enum, minLength, required, properties and
+ * additionalProperties (`false` or a schema). Returns one message per problem.
+ *
+ * Hand-rolled because the repo has no JSON Schema validator, and the schema
+ * leans on six keywords — not enough to justify an ajv devDependency.
+ */
+// ponytail: `format: date-time` on writtenAt is not checked, and neither are
+// arrays or composition keywords — none appear in the schema. Reach for ajv the
+// day one does.
+function validate(value: unknown, schema: JsonSchema, path = '$'): string[] {
+	const errors: string[] = []
+	if (schema.enum && !schema.enum.includes(value as string)) {
+		errors.push(`${path}: ${JSON.stringify(value)} is not one of ${schema.enum.join(', ')}`)
+	}
+	if (schema.type === 'object') {
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+			return [`${path}: expected object`]
+		}
+		const obj = value as Record<string, unknown>
+		for (const key of schema.required ?? []) {
+			if (!(key in obj)) errors.push(`${path}: missing required property "${key}"`)
+		}
+		for (const [key, child] of Object.entries(obj)) {
+			const property = schema.properties?.[key]
+			if (property) errors.push(...validate(child, property, `${path}.${key}`))
+			else if (schema.additionalProperties === false) {
+				errors.push(`${path}: unknown property "${key}"`)
+			} else if (typeof schema.additionalProperties === 'object') {
+				errors.push(...validate(child, schema.additionalProperties, `${path}.${key}`))
+			}
+		}
+		return errors
+	}
+	if (schema.type === 'integer') {
+		if (!Number.isInteger(value)) errors.push(`${path}: expected integer`)
+	} else if (schema.type && typeof value !== schema.type) {
+		errors.push(`${path}: expected ${schema.type}, got ${typeof value}`)
+	}
+	if (
+		schema.minLength !== undefined &&
+		typeof value === 'string' &&
+		value.length < schema.minLength
+	) {
+		errors.push(`${path}: shorter than minLength ${schema.minLength}`)
+	}
+	return errors
+}
+
+describe("this repo's own lockfile", () => {
+	const schema = lockfileSchema() as unknown as JsonSchema
+	const lockfile = JSON.parse(readFileSync(join(repoRoot, '.repo-tooling.json'), 'utf8')) as Record<
+		string,
+		unknown
+	>
+
+	// The repo that publishes the schema must never carry a lockfile that fails
+	// it (#540). Hand-editing .repo-tooling.json, or adding a Lockfile field
+	// without teaching lockfileSchema() about it, breaks here rather than in a
+	// consumer's editor.
+	it('validates against lockfileSchema()', () => {
+		expect(validate(lockfile, schema)).toEqual([])
+	})
+
+	// Proves the assertion above is real: each mutation is a way the file could
+	// drift, and each must produce at least one error.
+	it('rejects a drifted lockfile', () => {
+		const missingRequired = { ...lockfile }
+		delete missingRequired.writtenBy
+		expect(validate(missingRequired, schema)).not.toEqual([])
+		expect(validate({ ...lockfile, strayKey: true }, schema)).not.toEqual([])
+		expect(validate({ ...lockfile, version: '3' }, schema)).not.toEqual([])
+		expect(validate({ ...lockfile, aiLoop: { agentUsr: 'typo' } }, schema)).not.toEqual([])
+		expect(
+			validate(
+				{ ...lockfile, config: { ...(lockfile.config as object), bundler: 'webpack' } },
+				schema
+			)
+		).not.toEqual([])
 	})
 })


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

#539 published the lockfile JSON Schema and gates the committed copy under `apps/docs/static/schemas/` against staleness — but nothing asserted that *this repo's own* `.repo-tooling.json` conforms to it. The repo that publishes the schema must never carry a lockfile that fails it.

## What this adds

Two tests in the existing `tests/cli/utils/lockfile-schema.test.ts`:

1. **`validates against lockfileSchema()`** — reads the repo's real `.repo-tooling.json` and walks it against the schema object returned by `lockfileSchema()`.
2. **`rejects a drifted lockfile`** — mutates an in-memory copy five ways and asserts each produces at least one error: missing required key, stray top-level key, wrong scalar type, unknown `aiLoop` key, out-of-enum `config.bundler`. This exists so the assertion above can never quietly go vacuous.

The walker covers the keyword subset the schema actually uses — `type` (object/string/integer/boolean), `enum`, `minLength`, `required`, `properties`, `additionalProperties` (`false` or a sub-schema) — and recurses, so the embedded `ProjectConfig` and `aiLoop` subtrees are validated too, not just the top level.

## Why hand-rolled instead of ajv

The repo has no JSON Schema validator today, and the schema leans on six keywords. That is not enough schema to justify a new devDependency and the lockfile churn. A `ponytail:` comment names the ceiling — `format: date-time`, arrays and composition keywords are unchecked because none appear in the schema — and says to reach for ajv the day one does.

Only refactor to existing code: `schemasDir` became a `repoRoot` constant, since the new tests need the repo root too.

## Verification

- `vitest run` — 1075 passed, 1 expected fail (pre-existing), 18 skipped.
- `biome check` on the touched file — clean.
- `tsc --noEmit` — clean.
- Confirmed the new check is non-vacuous via the drift test, which fails the walker on every mutation.

Commit type is `test:` deliberately — it cuts no release.

Closes #540
