### PR TITLE
feat(cli): add `loop guard` for bare-checkout repair and node_modules rebuild gating

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Every command supports `--json` and a non-interactive mode. Combine with `--yes`
 | `fix --dry-run` | ✅ | ✅ | Print what each fixer would write without writing. Combine with `--json`. |
 | `list --json` | ✅ | ✅ | Enumerate the library's surface area. Each entry has `{ name, description, exports, fixTarget }`. |
 | `copy <name>` | ✅ | text only | Copy a single preset (`biome`, `tsconfig`) into the current directory. |
+| `loop guard --root <path>` | ✅ | ✅ | Guard an `ai-issue-loop` tick: repair a wrongly-bare main checkout, gate the `node_modules` rebuild (`--removed`). Exit `0` continue, `1` repair failed, `2` root is not a repairable checkout — both non-zero halt the tick. |
 
 ## Recommended workflows
 
@@ -104,6 +105,7 @@ A fixer may also **refuse** — the target file holds something the generator ca
 - `src/cli/commands/doctor.ts` — all checks and the public `runDoctor(dir)` / `evaluateNodeVersion(version)` / `nextStepSuggestions(results)`
 - `src/cli/commands/fix.ts` — `Fixer` interface, fixer registry, `fixCommand`
 - `src/cli/commands/fix-targets.ts` — shared check → fix target map (used by both doctor's footer and fix's lookup)
+- `src/cli/commands/loop-guard.ts` — `loop guard`: the `--is-inside-work-tree` / `.git` invariant table and the `node_modules` rebuild gate, drained out of the ai-issue-loop skill's prose (#519)
 - `src/cli/generators/` — one file per concern (linting, testing, build, git, github-actions, security, misc)
 - `tooling/` — every shipped preset, mirrored 1:1 with `package.json` `exports`
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ See the [Getting Started guide](https://rtorcato.github.io/repo-tooling/guides/g
 | `copy <config>` | Copy a single config file into the current project. | `npx @rtorcato/repo-tooling copy biome` |
 | `doctor` | Diagnose an existing project for missing or drifted tooling. | `npx @rtorcato/repo-tooling doctor` |
 | `fix [target]` | Apply scaffolders for what `doctor` flagged (`--yes`, `--dry-run`, `--diff`). | `npx @rtorcato/repo-tooling fix` |
+| `loop guard` | Repair a main checkout that has gone `core.bare = true`, and gate the `node_modules` rebuild after a worktree removal. Exits `1` if the repair failed and `2` if the root is not a repairable checkout — see `--help`. | `npx @rtorcato/repo-tooling loop guard --root .` |
 
 Prefer to run the audit in CI? `doctor` also ships as a GitHub Action:
 

--- a/src/base/git-identity.ts
+++ b/src/base/git-identity.ts
@@ -75,6 +75,31 @@ export type GitExec = (args: string[]) => Promise<string | null>
 
 const GIT_TIMEOUT_MS = 5_000
 
+/**
+ * Git exports these to everything a hook runs, and they outrank `cwd`/`-C`: a
+ * child spawned from a `pre-push` answers about the *hook's* repository, not
+ * the directory it was handed. Harmless for a config read; not harmless for
+ * `loop guard`, whose whole job is deciding whether one specific checkout has
+ * gone bare (#519). Every caller here names its repo explicitly, so the
+ * ambient one is never what was meant.
+ */
+const AMBIENT_REPO_VARS = [
+	'GIT_DIR',
+	'GIT_WORK_TREE',
+	'GIT_INDEX_FILE',
+	'GIT_COMMON_DIR',
+	'GIT_OBJECT_DIRECTORY',
+	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_PREFIX',
+	'GIT_NAMESPACE',
+]
+
+function repoScopedEnv(): NodeJS.ProcessEnv {
+	const env = { ...process.env }
+	for (const key of AMBIENT_REPO_VARS) delete env[key]
+	return env
+}
+
 /** Never rejects; a missing or failing git resolves to null. */
 export const realGitExec = (args: string[], cwd?: string): Promise<string | null> =>
 	new Promise((resolve) => {
@@ -87,7 +112,11 @@ export const realGitExec = (args: string[], cwd?: string): Promise<string | null
 		}
 		// Args are internal constants, never user free-text — shell:false keeps
 		// this injection-safe.
-		const child = spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+		const child = spawn('git', args, {
+			cwd,
+			env: repoScopedEnv(),
+			stdio: ['ignore', 'pipe', 'ignore'],
+		})
 		let stdout = ''
 		const timer = setTimeout(() => {
 			child.kill()

--- a/src/cli/commands/loop-guard.ts
+++ b/src/cli/commands/loop-guard.ts
@@ -1,0 +1,277 @@
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import chalk from 'chalk'
+import fs from 'fs-extra'
+import { type GitExec, realGitExec } from '../../base/git-identity.js'
+
+/**
+ * `repo-tooling loop guard` — the two most dangerous mechanics of the
+ * ai-issue-loop skill, moved out of prose-with-shell into code a test can hold
+ * (#519). Prose drifts and nothing fails when it does; PR #500 (a
+ * `0 additions, 67703 deletions` commit) happened in exactly that gap.
+ *
+ * 1. **Bare-checkout detection and repair.** The main checkout has gone
+ *    `core.bare = true` on its own, repeatedly. A bare main checkout wipes a
+ *    worktree's index while every file sits untouched on disk, and the next
+ *    commit faithfully records the whole repository as deleted.
+ * 2. **`node_modules` rebuild gating.** Removing a worktree can destroy the
+ *    main checkout's `node_modules/.bin`, because a pnpm run from inside a
+ *    worktree anchors the main checkout's shims at the worktree path.
+ *
+ * Exit codes — the loop's shell snippets are one line each and branch on these:
+ *
+ * | Code | Meaning | What the caller does |
+ * |---|---|---|
+ * | `0` | Root is a usable work tree — healthy, or repaired in place. | Continue the tick. |
+ * | `1` | Repair was attempted and failed; the root is still bare. | **Halt the tick.** |
+ * | `2` | Root is not a repairable main checkout (genuinely bare, a linked worktree, or not a repo). | **Halt the tick**; needs a human. |
+ *
+ * A deferred or failed `node_modules` rebuild never changes the exit code — it
+ * cannot corrupt a commit, so it is reported, not fatal. Read `rebuild` from
+ * `--json` (or the printed line) and carry it into the tick's report.
+ */
+
+/** What the `--is-inside-work-tree` / `.git` pair says about a root. */
+export type RootState =
+	| 'work-tree'
+	| 'wrongly-bare'
+	| 'genuinely-bare'
+	| 'linked-worktree'
+	| 'not-a-repo'
+
+export type GitEntry = 'directory' | 'file' | 'absent'
+
+/**
+ * The invariant table from the skill, verified on git 2.55.0:
+ *
+ * | repo state | `--is-inside-work-tree` | `.git` |
+ * |---|---|---|
+ * | healthy checkout | `true`, exit 0 | directory |
+ * | **wrongly bare** | `false`, **exit 0** | directory |
+ * | genuinely bare | `false`, exit 0 | absent |
+ * | linked worktree | `true`, exit 0 | file |
+ *
+ * Two things it encodes. **Stdout, not the exit code** — `rev-parse
+ * --is-inside-work-tree` exits `0` either way and only *prints* the answer, so
+ * an exit-code probe is dead code (`insideWorkTree` is `null` only when git
+ * itself failed, i.e. there is no repo here). And **`.git` must be a directory
+ * before repairing** — a genuinely bare repo prints `false` too, and nothing
+ * else separates the two. This ships to consumers' machines, where "repairing"
+ * someone's real bare clone is the damage rather than the fix.
+ */
+export function classifyRoot(insideWorkTree: string | null, gitEntry: GitEntry): RootState {
+	if (insideWorkTree === null) return 'not-a-repo'
+	if (insideWorkTree.trim() === 'true') return 'work-tree'
+	if (gitEntry === 'directory') return 'wrongly-bare'
+	// A linked worktree's `.git` is a file; its main checkout is where a repair
+	// belongs, and that is not the path we were handed.
+	if (gitEntry === 'file') return 'linked-worktree'
+	return 'genuinely-bare'
+}
+
+export type BareVerdict = 'healthy' | 'repaired' | 'repair-failed' | 'unrepairable'
+
+export type RebuildOutcome =
+	| 'not-requested'
+	| 'skipped-no-lockfile'
+	| 'skipped-root-unusable'
+	| 'deferred'
+	| 'rebuilt'
+	| 'rebuild-failed'
+
+export interface LoopGuardResult {
+	root: string
+	worktreeRoot: string
+	state: RootState
+	bare: BareVerdict
+	rebuild: RebuildOutcome
+	/** Absolute paths of `ai-*` worktrees still on disk. */
+	live: string[]
+	exitCode: 0 | 1 | 2
+	/** Human-readable lines, in the order they happened. */
+	messages: string[]
+}
+
+export interface LoopGuardOptions {
+	root?: string
+	worktreeRoot?: string
+	/** A worktree was removed this tick — the `$REMOVED` condition. */
+	removed?: boolean
+	json?: boolean
+	/** Test seams. */
+	git?: GitExec
+	install?: InstallExec
+}
+
+/** Runs the rebuild in `cwd`; resolves false rather than throwing. */
+export type InstallExec = (cwd: string) => Promise<boolean>
+
+/**
+ * `--frozen-lockfile` forbids re-resolution, so neither `pnpm-lock.yaml` nor a
+ * `pnpm-workspace.yaml` carve-out moves as a side effect of a cleanup.
+ * `--config.confirmModulesPurge=false` gets past
+ * `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` — which is why a bare `pnpm
+ * install` cannot repair this.
+ */
+export const REBUILD_ARGS = [
+	'install',
+	'--frozen-lockfile',
+	'--config.confirmModulesPurge=false',
+] as const
+
+const realInstall: InstallExec = (cwd) =>
+	new Promise((resolve) => {
+		// stdout stays clean for the `--json` payload; pnpm's diagnostics are
+		// still visible on stderr.
+		const child = spawn('pnpm', [...REBUILD_ARGS], {
+			cwd,
+			stdio: ['ignore', 'ignore', 'inherit'],
+		})
+		child.on('close', (code) => resolve(code === 0))
+		child.on('error', () => resolve(false))
+	})
+
+async function gitEntryKind(root: string): Promise<GitEntry> {
+	// lstat, not stat: the file/directory distinction is the whole discriminator.
+	try {
+		const stat = await fs.lstat(path.join(root, '.git'))
+		return stat.isDirectory() ? 'directory' : 'file'
+	} catch {
+		return 'absent'
+	}
+}
+
+/** `ai-*` directories one level down, in either place worktrees are kept. */
+async function findLive(dirs: string[]): Promise<string[]> {
+	const live: string[] = []
+	for (const dir of dirs) {
+		// A missing worktree root is the normal case, not an error.
+		const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+		for (const entry of entries) {
+			if (entry.isDirectory() && entry.name.startsWith('ai-')) live.push(path.join(dir, entry.name))
+		}
+	}
+	return live
+}
+
+/** The sibling layout the skill uses: `<parent>/<name>-worktrees`. */
+export function defaultWorktreeRoot(root: string): string {
+	return path.join(path.dirname(root), `${path.basename(root)}-worktrees`)
+}
+
+const stamp = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+
+const UNUSABLE: Record<Exclude<RootState, 'work-tree' | 'wrongly-bare'>, string> = {
+	'genuinely-bare':
+		'main checkout is a genuinely bare repository (.git absent) — refusing to flip core.bare on a real bare clone',
+	'linked-worktree':
+		'--root points at a linked worktree (.git is a file), not the main checkout — repair belongs on the main checkout',
+	'not-a-repo': 'not a git repository',
+}
+
+/**
+ * One tick's worth of guarding, as data. The command wrapper prints it and
+ * sets the exit code; tests call this directly.
+ */
+export async function runLoopGuard(options: LoopGuardOptions = {}): Promise<LoopGuardResult> {
+	const root = path.resolve(options.root ?? process.cwd())
+	const worktreeRoot = options.worktreeRoot
+		? path.resolve(options.worktreeRoot)
+		: defaultWorktreeRoot(root)
+	const git: GitExec = options.git ?? ((args) => realGitExec(args, root))
+	const install = options.install ?? realInstall
+	const messages: string[] = []
+
+	const state = classifyRoot(
+		await git(['rev-parse', '--is-inside-work-tree']),
+		await gitEntryKind(root)
+	)
+
+	let bare: BareVerdict = 'healthy'
+	let exitCode: 0 | 1 | 2 = 0
+	if (state === 'wrongly-bare') {
+		messages.push(`⚠ main checkout bare at ${stamp()} — repairing`)
+		// Writes $ROOT/.git/config, which a restrictive sandbox refuses with
+		// `error: could not lock config file .git/config`. Aborting beats
+		// reporting a healthy repo while it stays broken.
+		if ((await git(['config', 'core.bare', 'false'])) === null) {
+			bare = 'repair-failed'
+			exitCode = 1
+			messages.push('⚠ repair FAILED — main checkout still bare')
+		} else {
+			bare = 'repaired'
+			messages.push('main checkout repaired — core.bare is false')
+		}
+	} else if (state !== 'work-tree') {
+		bare = 'unrepairable'
+		exitCode = 2
+		messages.push(`⚠ ${UNUSABLE[state]}`)
+	} else {
+		messages.push('main checkout is a work tree')
+	}
+
+	const live = await findLive([worktreeRoot, path.join(root, '.claude', 'worktrees')])
+	const rebuild = await decideRebuild({ root, removed: options.removed === true, exitCode, live })
+
+	let outcome = rebuild
+	if (rebuild === 'deferred') {
+		messages.push(`rebuild deferred — ${live.length} worktree(s) still live`)
+	} else if (rebuild === 'rebuilt') {
+		messages.push('rebuilding the main checkout’s node_modules')
+		if (!(await install(root))) {
+			outcome = 'rebuild-failed'
+			// Not fatal: a broken .bin cannot corrupt a commit the way a bare
+			// checkout does. Loud, though — a silent skip is the breakage this
+			// guard exists to end.
+			messages.push('⚠ node_modules rebuild FAILED — main checkout may be unbuildable')
+		} else {
+			messages.push('node_modules rebuilt')
+		}
+	}
+
+	return { root, worktreeRoot, state, bare, rebuild: outcome, live, exitCode, messages }
+}
+
+/**
+ * The three load-bearing conditions, kept separate from the run so a test can
+ * assert them without a pnpm install:
+ *
+ * - **`removed`** — set by every removal path, merged-PR cleanup *and* stall
+ *   reaping. A reaped worktree needs this most: its agent died mid-command.
+ * - **`pnpm-lock.yaml`** — non-pnpm repos skip the whole thing.
+ * - **no live worktrees** — the rebuild *purges* the shared modules dir, which
+ *   would be yanked out from under any agent still running in a surviving
+ *   worktree. Deferring costs a broken main checkout until the last worktree
+ *   clears; not deferring costs a live implementer run.
+ */
+export async function decideRebuild(input: {
+	root: string
+	removed: boolean
+	exitCode: number
+	live: string[]
+}): Promise<RebuildOutcome> {
+	if (!input.removed) return 'not-requested'
+	// Nothing runs against a root we are about to halt the tick over.
+	if (input.exitCode !== 0) return 'skipped-root-unusable'
+	if (!(await fs.pathExists(path.join(input.root, 'pnpm-lock.yaml')))) return 'skipped-no-lockfile'
+	return input.live.length > 0 ? 'deferred' : 'rebuilt'
+}
+
+export async function loopGuardCommand(options: {
+	root?: string
+	worktreeRoot?: string
+	removed?: boolean
+	json?: boolean
+}): Promise<void> {
+	const result = await runLoopGuard(options)
+	if (options.json) {
+		console.log(JSON.stringify(result, null, 2))
+	} else {
+		console.log()
+		for (const line of result.messages) {
+			console.log(`  ${line.startsWith('⚠') ? chalk.yellow(line) : chalk.gray(line)}`)
+		}
+		console.log()
+	}
+	process.exitCode = result.exitCode
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra'
 import packageJson from '../../package.json' with { type: 'json' }
 import { doctorCommand } from './commands/doctor.js'
 import { fixCommand } from './commands/fix.js'
+import { loopGuardCommand } from './commands/loop-guard.js'
 import { setupProject } from './commands/setup.js'
 import { copyPreset, PRESETS, type PresetName } from './utils/copy-preset.js'
 
@@ -383,6 +384,27 @@ program
 			forceSkills: options.forceSkills,
 		})
 	)
+
+// Mechanics the ai-issue-loop skill used to describe in prose-with-shell (#519).
+// Deliberately outside the isSelfRepo hook below: the loop runs against this
+// repo like any other, and a guard that refuses here would guard nothing.
+const loop = program.command('loop').description('🔁 ai-issue-loop mechanics as tested commands')
+
+loop
+	.command('guard')
+	.description('🛡️  Repair a wrongly-bare main checkout and gate the node_modules rebuild')
+	.option('--root <path>', 'Main checkout the loop branches worktrees from', process.cwd())
+	.option('--worktree-root <path>', 'Where ai-* worktrees live (default: <root>-worktrees)')
+	.option('--removed', 'A worktree was removed this tick — consider rebuilding node_modules')
+	.option('--json', 'Emit machine-readable JSON output')
+	.addHelpText(
+		'after',
+		'\nExit codes:\n' +
+			'  0  root is a usable work tree (healthy, or repaired in place) — continue the tick\n' +
+			'  1  repair was attempted and failed; the root is still bare — halt the tick\n' +
+			'  2  root is not a repairable main checkout (bare clone, linked worktree, or not a repo) — halt the tick\n'
+	)
+	.action(loopGuardCommand)
 
 program.hook('preAction', async (_, actionCommand) => {
 	const name = actionCommand.name()

--- a/tests/cli/commands/loop-guard.test.ts
+++ b/tests/cli/commands/loop-guard.test.ts
@@ -1,0 +1,256 @@
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import {
+	classifyRoot,
+	decideRebuild,
+	defaultWorktreeRoot,
+	type InstallExec,
+	REBUILD_ARGS,
+	runLoopGuard,
+} from '../../../src/cli/commands/loop-guard.js'
+import type { GitExec } from '../../../src/base/git-identity.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+/**
+ * The spec is the invariant table in skills/ai-issue-loop/SKILL.md (#519). It
+ * is asserted twice on purpose: once against `classifyRoot` (fast, exhaustive)
+ * and once against repositories git actually created, because the table is a
+ * claim about git's behaviour and a pure test can only re-state it.
+ */
+
+const newTmpDir = useTmpDir()
+
+const git = (cwd: string, ...args: string[]) =>
+	execFileSync('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] })
+		.toString()
+		.trim()
+
+/** A checkout with one commit, so `worktree add` has something to branch from. */
+function healthyCheckout(parent: string, name = 'repo'): string {
+	const dir = join(parent, name)
+	fs.ensureDirSync(dir)
+	git(dir, 'init', '-q', '-b', 'main')
+	git(dir, 'config', 'user.email', 'test@example.com')
+	git(dir, 'config', 'user.name', 'Test')
+	fs.writeFileSync(join(dir, 'README.md'), '# test\n')
+	git(dir, 'add', '-A')
+	git(dir, 'commit', '-qm', 'init')
+	return dir
+}
+
+const neverInstalls: InstallExec = async () => {
+	throw new Error('install must not run')
+}
+
+describe('classifyRoot — the SKILL.md invariant table', () => {
+	it('reads a healthy checkout as a work tree', () => {
+		expect(classifyRoot('true', 'directory')).toBe('work-tree')
+	})
+
+	it('reads false + a .git directory as wrongly bare', () => {
+		expect(classifyRoot('false', 'directory')).toBe('wrongly-bare')
+	})
+
+	it('reads false + no .git as a genuinely bare repo', () => {
+		expect(classifyRoot('false', 'absent')).toBe('genuinely-bare')
+	})
+
+	it('reads a linked worktree as a work tree, and never repairs one', () => {
+		expect(classifyRoot('true', 'file')).toBe('work-tree')
+		// The discriminator that matters: `.git` is a file, so even a false probe
+		// is not ours to repair.
+		expect(classifyRoot('false', 'file')).toBe('linked-worktree')
+	})
+
+	it('treats a git that could not answer as no repo at all', () => {
+		expect(classifyRoot(null, 'directory')).toBe('not-a-repo')
+	})
+
+	it('trims, because the probe answer arrives with a newline', () => {
+		expect(classifyRoot('true\n', 'directory')).toBe('work-tree')
+	})
+})
+
+describe('runLoopGuard — bare detection and repair', () => {
+	it('leaves a healthy checkout alone and exits 0', async () => {
+		const root = healthyCheckout(newTmpDir())
+		const result = await runLoopGuard({ root })
+		expect(result.state).toBe('work-tree')
+		expect(result.bare).toBe('healthy')
+		expect(result.exitCode).toBe(0)
+	})
+
+	it('repairs a wrongly-bare checkout and exits 0', async () => {
+		const root = healthyCheckout(newTmpDir())
+		git(root, 'config', 'core.bare', 'true')
+		const result = await runLoopGuard({ root })
+		expect(result.state).toBe('wrongly-bare')
+		expect(result.bare).toBe('repaired')
+		expect(result.exitCode).toBe(0)
+		expect(git(root, 'config', 'core.bare')).toBe('false')
+		expect(git(root, 'rev-parse', '--is-inside-work-tree')).toBe('true')
+	})
+
+	it('detects the flip from stdout, not the exit code', async () => {
+		const root = healthyCheckout(newTmpDir())
+		git(root, 'config', 'core.bare', 'true')
+		// The probe git actually runs: `false` on stdout, exit 0. An exit-code
+		// probe would call this healthy and hand a bare root to the tick.
+		expect(
+			execFileSync('git', ['-C', root, 'rev-parse', '--is-inside-work-tree']).toString().trim()
+		).toBe('false')
+		expect((await runLoopGuard({ root })).bare).toBe('repaired')
+	})
+
+	it('refuses to touch a genuinely bare repository and exits 2', async () => {
+		const root = join(newTmpDir(), 'bare.git')
+		fs.ensureDirSync(root)
+		git(root, 'init', '-q', '--bare')
+		const result = await runLoopGuard({ root })
+		expect(result.state).toBe('genuinely-bare')
+		expect(result.bare).toBe('unrepairable')
+		expect(result.exitCode).toBe(2)
+		// The damage this guard must never do: flipping a real bare clone.
+		expect(git(root, 'config', 'core.bare')).toBe('true')
+	})
+
+	it('treats a linked worktree as healthy — its .git is a file', async () => {
+		const parent = newTmpDir()
+		const root = healthyCheckout(parent)
+		const wt = join(parent, 'repo-worktrees', 'ai-1-thing')
+		git(root, 'worktree', 'add', '-q', wt, '-b', 'ai-1-thing')
+		expect(fs.lstatSync(join(wt, '.git')).isFile()).toBe(true)
+		const result = await runLoopGuard({ root: wt })
+		expect(result.state).toBe('work-tree')
+		expect(result.exitCode).toBe(0)
+	})
+
+	it('exits 2 when --root is not a repository at all', async () => {
+		const result = await runLoopGuard({ root: newTmpDir() })
+		expect(result.state).toBe('not-a-repo')
+		expect(result.exitCode).toBe(2)
+	})
+
+	it('exits 1 when the repair fails, so the tick halts', async () => {
+		// The observed failure: a sandbox refusing to lock .git/config. Injected
+		// rather than staged, because the real one needs a sandbox to reproduce.
+		const failingConfig: GitExec = async (args) => (args[0] === 'config' ? null : 'false')
+		const root = healthyCheckout(newTmpDir())
+		const result = await runLoopGuard({ root, git: failingConfig })
+		expect(result.bare).toBe('repair-failed')
+		expect(result.exitCode).toBe(1)
+		expect(result.messages.join('\n')).toContain('repair FAILED')
+	})
+})
+
+describe('runLoopGuard — node_modules rebuild gating', () => {
+	const pnpmRepo = (): string => {
+		const root = healthyCheckout(newTmpDir())
+		fs.writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+		return root
+	}
+
+	it('does nothing when no worktree was removed', async () => {
+		const result = await runLoopGuard({ root: pnpmRepo(), install: neverInstalls })
+		expect(result.rebuild).toBe('not-requested')
+	})
+
+	it('rebuilds when a worktree was removed and none are left', async () => {
+		const root = pnpmRepo()
+		let ranIn: string | null = null
+		const result = await runLoopGuard({
+			root,
+			removed: true,
+			install: async (cwd) => {
+				ranIn = cwd
+				return true
+			},
+		})
+		expect(result.rebuild).toBe('rebuilt')
+		expect(ranIn).toBe(root)
+	})
+
+	it('defers while an ai-* worktree is still live', async () => {
+		const parent = newTmpDir()
+		const root = healthyCheckout(parent)
+		fs.writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+		fs.ensureDirSync(join(parent, 'repo-worktrees', 'ai-42-live'))
+		const result = await runLoopGuard({ root, removed: true, install: neverInstalls })
+		expect(result.rebuild).toBe('deferred')
+		expect(result.live).toEqual([join(parent, 'repo-worktrees', 'ai-42-live')])
+		expect(result.messages.join('\n')).toContain('rebuild deferred — 1 worktree(s) still live')
+	})
+
+	it('also scans the in-repo .claude/worktrees location', async () => {
+		const root = pnpmRepo()
+		fs.ensureDirSync(join(root, '.claude', 'worktrees', 'ai-7-legacy'))
+		const result = await runLoopGuard({ root, removed: true, install: neverInstalls })
+		expect(result.rebuild).toBe('deferred')
+	})
+
+	it('ignores directories that are not ai-*', async () => {
+		const parent = newTmpDir()
+		const root = healthyCheckout(parent)
+		fs.writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+		fs.ensureDirSync(join(parent, 'repo-worktrees', 'scratch'))
+		const result = await runLoopGuard({ root, removed: true, install: async () => true })
+		expect(result.live).toEqual([])
+		expect(result.rebuild).toBe('rebuilt')
+	})
+
+	it('skips a non-pnpm repo entirely', async () => {
+		const root = healthyCheckout(newTmpDir())
+		const result = await runLoopGuard({ root, removed: true, install: neverInstalls })
+		expect(result.rebuild).toBe('skipped-no-lockfile')
+	})
+
+	it('reports a failed rebuild loudly without changing the exit code', async () => {
+		const result = await runLoopGuard({
+			root: pnpmRepo(),
+			removed: true,
+			install: async () => false,
+		})
+		expect(result.rebuild).toBe('rebuild-failed')
+		expect(result.exitCode).toBe(0)
+		expect(result.messages.join('\n')).toContain('rebuild FAILED')
+	})
+
+	it('never installs into a root the tick is about to halt over', async () => {
+		const root = join(newTmpDir(), 'bare.git')
+		fs.ensureDirSync(root)
+		git(root, 'init', '-q', '--bare')
+		fs.writeFileSync(join(root, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\n")
+		const result = await runLoopGuard({ root, removed: true, install: neverInstalls })
+		expect(result.rebuild).toBe('skipped-root-unusable')
+		expect(result.exitCode).toBe(2)
+	})
+
+	it('keeps both pnpm flags — neither is optional', () => {
+		expect([...REBUILD_ARGS]).toEqual([
+			'install',
+			'--frozen-lockfile',
+			'--config.confirmModulesPurge=false',
+		])
+	})
+
+	it('decides purely, so the conditions can be read without a pnpm install', async () => {
+		const root = pnpmRepo()
+		expect(await decideRebuild({ root, removed: false, exitCode: 0, live: [] })).toBe(
+			'not-requested'
+		)
+		expect(await decideRebuild({ root, removed: true, exitCode: 1, live: [] })).toBe(
+			'skipped-root-unusable'
+		)
+		expect(await decideRebuild({ root, removed: true, exitCode: 0, live: ['/x/ai-1'] })).toBe(
+			'deferred'
+		)
+	})
+})
+
+describe('defaultWorktreeRoot', () => {
+	it('is a sibling of the repo, never inside it', () => {
+		expect(defaultWorktreeRoot('/Volumes/W/repo-tooling')).toBe('/Volumes/W/repo-tooling-worktrees')
+	})
+})

--- a/tests/cli/commands/loop-guard.test.ts
+++ b/tests/cli/commands/loop-guard.test.ts
@@ -133,6 +133,27 @@ describe('runLoopGuard — bare detection and repair', () => {
 		expect(result.exitCode).toBe(2)
 	})
 
+	it('ignores an ambient GIT_DIR — the verdict is about --root, nothing else', async () => {
+		const parent = newTmpDir()
+		const root = healthyCheckout(parent)
+		const elsewhere = join(parent, 'other.git')
+		fs.ensureDirSync(elsewhere)
+		git(elsewhere, 'init', '-q', '--bare')
+		const saved = process.env.GIT_DIR
+		// Set by git for everything a hook runs, and it outranks `-C`. Unscrubbed,
+		// the probe answers `false` about *that* repo and the guard flips
+		// core.bare on a checkout that was fine.
+		process.env.GIT_DIR = elsewhere
+		try {
+			const result = await runLoopGuard({ root })
+			expect(result.state).toBe('work-tree')
+			expect(result.bare).toBe('healthy')
+		} finally {
+			if (saved === undefined) delete process.env.GIT_DIR
+			else process.env.GIT_DIR = saved
+		}
+	})
+
 	it('exits 1 when the repair fails, so the tick halts', async () => {
 		// The observed failure: a sandbox refusing to lock .git/config. Injected
 		// rather than staged, because the real one needs a sandbox to reproduce.

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,6 +1,25 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 import base from './tooling/vitest/vitest.config.mjs'
 
+// Git exports GIT_DIR / GIT_INDEX_FILE to everything a hook runs, so under the
+// pre-push hook every test that spawns `git` in a temp directory silently
+// operates on *this* repo instead — `git init` in a tmp dir, then a commit
+// against the real index. CI has no hook environment, so this only ever failed
+// on the developer's machine, which is the worst place for it to fail (#519).
+// Nothing here wants git's ambient repo: every call passes `cwd` or `-C`.
+for (const key of [
+	'GIT_DIR',
+	'GIT_WORK_TREE',
+	'GIT_INDEX_FILE',
+	'GIT_COMMON_DIR',
+	'GIT_OBJECT_DIRECTORY',
+	'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+	'GIT_PREFIX',
+	'GIT_NAMESPACE',
+]) {
+	delete process.env[key]
+}
+
 // repo-tooling-specific coverage scope and thresholds. The shared preset only
 // provides generic v8 defaults so consumers don't inherit our paths.
 export default mergeConfig(


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Closes #519

First slice of #519: the two most dangerous prose-with-shell blocks in `skills/ai-issue-loop/SKILL.md` become one tested command. Prose drifts and nothing fails when it does — PR #500's `0 additions, 67703 deletions` commit happened in exactly that gap.

## `repo-tooling loop guard --root <path>`

**Bare-checkout detection and repair.** Every detail the prose established is preserved and now held by a test:

- Probes **stdout, not the exit code** — `git rev-parse --is-inside-work-tree` exits `0` either way and only *prints* the answer, so an exit-code probe is dead code.
- Repairs only when `.git` is a **directory**. A genuinely bare repo prints `false` too, and this ships to consumers' machines, where flipping a real bare clone is the damage rather than the fix. The same discriminator skips a linked worktree, whose `.git` is a file.
- A failed repair exits non-zero so the tick halts, instead of reporting a healthy repo while it stays broken.

**`node_modules` rebuild gating.** The three load-bearing conditions (`--removed`, a `pnpm-lock.yaml`, no live `ai-*` worktree in either location) and `--frozen-lockfile --config.confirmModulesPurge=false`. A deferral or a failed rebuild is reported, never fatal — it cannot corrupt a commit the way a bare checkout does.

**Documented exit codes**, so each skill snippet can become one line:

| Code | Meaning | Caller |
|---|---|---|
| `0` | Root is a usable work tree — healthy, or repaired in place | Continue the tick |
| `1` | Repair attempted and failed; still bare | **Halt the tick** |
| `2` | Not a repairable main checkout (bare clone, linked worktree, not a repo) | **Halt the tick**; needs a human |

Also on `--help`, in `README.md` and `AGENTS.md`.

## Tests

The SKILL.md invariant table is the spec, asserted twice: against the classifier, and against repositories git actually created — healthy checkout, wrongly bare, genuinely bare, linked worktree. The table is a claim about git's behaviour, and a pure test can only re-state it. The genuinely-bare case additionally asserts `core.bare` is still `true` afterwards: not damaging a real bare clone is the invariant, not a side effect.

## Second commit — a real bug found while testing

`git` exports `GIT_DIR` / `GIT_INDEX_FILE` to everything a hook runs, and they outrank both `cwd` and `-C`. Under `pre-push`, `realGitExec` answered about *this* repo rather than the directory it was handed — for a guard whose entire job is deciding whether one specific checkout has gone bare, that is the mass-deletion failure mode itself. It also already broke `tests/cli/generators/security.test.ts`, which does `git init` in a temp dir and was silently operating on the real index; CI has no hook environment, so it only ever failed on a developer's machine. `realGitExec` now strips the ambient repo vars, `vitest.config.mjs` drops them for the whole run, and a test covers it (verified failing without the fix).

## Not in this PR

**`skills/ai-issue-loop/SKILL.md` is untouched** — wiring the skill to this command is a deliberate follow-up, kept separate to avoid conflicting with concurrent edits to that file. The later slices in #519 (`loop comment`, `loop verdict`, `loop status`) each get their own issue when ripe.

---

`pnpm verify` (biome + tsc + 1122 tests + build) passes; the full suite also passes under a simulated hook environment.
