### PR TITLE
fix(skills): send CI-red PRs back to a fix round and collapse the ready-PR labels

### DIFF
--- a/apps/docs/docs/guides/ai-issue-loop.md
+++ b/apps/docs/docs/guides/ai-issue-loop.md
@@ -67,7 +67,7 @@ below.
 Two consequences, and both are load-bearing:
 
 1. **Approval is a label**, not a review. `ai-ok-code` / `ai-ok-sec` record that
-   an agent passed the diff.
+   an agent passed the diff, until the handoff replaces them with `merge-ready`.
 2. **Required status checks stay the real merge gate.** Never set
    `required_pull_request_reviews` on the protected branch — required review
    deadlocks every PR the loop opens.
@@ -129,11 +129,23 @@ that state, so a missed tick, a crash, or a restart costs nothing.
 | `ai-review` | PR | Awaiting agent review. |
 | `ai-reviewing-code` | PR | `code-reviewer` claimed and running. Cleared with its verdict. |
 | `ai-reviewing-sec` | PR | `security-expert` claimed and running. Cleared with its verdict. |
-| `ai-ok-code` | PR | `code-reviewer` passed. |
-| `ai-ok-sec` | PR | `security-expert` passed. |
-| `ai-changes` | PR | A reviewer requested changes. |
+| `ai-ok-code` | PR | `code-reviewer` passed. In-flight only — the handoff strips it. |
+| `ai-ok-sec` | PR | `security-expert` passed. In-flight only — the handoff strips it. |
+| `ai-changes` | PR | A reviewer requested changes, or Pass 1 sent the PR back over red CI. |
 | `ai-notes` | PR | Passed, but a reviewer left something to read before merging. |
-| `merge-ready` | PR | Both agent reviews passed and the PR is mergeable — waiting on a human. |
+| `merge-ready` | PR | Both agent reviews passed and the PR is mergeable — waiting on a human. Supersedes the `ai-ok-*` pair rather than joining it. |
+
+A PR handed over for you to merge therefore carries exactly one of two label
+sets, and the difference is legible without opening anything:
+
+| Labels | Means |
+|---|---|
+| `merge-ready` | Merge freely. |
+| `merge-ready`, `ai-notes` | Passed, but open the comments first. |
+
+`merge-ready` asserts strictly more than `ai-ok-code` + `ai-ok-sec` — both
+reviews passed *and* GitHub reports the PR mergeable — so the handoff drops the
+pair rather than stacking three labels that all say "passed".
 
 Colours carry meaning here — `ai-ready` is green and `ai-blocked` red precisely
 so the two states a maintainer must tell apart are legible at a glance. `doctor`
@@ -151,7 +163,8 @@ PR: ai-review ─> ai-reviewing-* ─┬─> ai-ok-code + ai-ok-sec ─┬─ is
                                  │        (± ai-notes)       │              ─> YOU merge
                                  │                           └─ dependabot ─> auto-merge
                                  └─> ai-changes ─> fix round (max 2) ─> ai-review
-                                                             └─ round 3 ─> ai-blocked
+                                     ▲                       └─ round 3 ─> ai-blocked
+                                     └─ Pass 1 sends back: not CLEAN, or a required check FAILED
 ```
 
 `ai-reviewing-code` / `ai-reviewing-sec` are the claim step. Pass 3 applies one
@@ -193,8 +206,11 @@ gh api repos/$OWNER_REPO/branches/main/protection \
 ```
 
 Worktrees also want `node_modules` symlinked in, so an agent can typecheck
-without a full install per issue. `fix ai` writes that into
-`.claude/settings.json`.
+without a full install per issue. `fix ai` writes that list — the root plus every
+workspace package — into `.claude/settings.json` as
+`worktree.symlinkDirectories`, and Pass 4 reads it and creates the links itself.
+Without it the loop still works: each worktree gets a real `pnpm install`
+instead, which costs a duplicate `node_modules` per issue.
 
 ## The tick
 
@@ -203,7 +219,7 @@ Passes run cheapest first, so a quiet repo exits fast.
 | Pass | Does |
 |---|---|
 | **0 — orient** | Resolve the main checkout, fetch, list open PRs and `ai-wip` issues. Adopt unlabelled PRs — Dependabot's, and any the loop's own identity opened with the `🤖` header. Bail to Pass 5 with `idle` only if there is nothing at all: no labelled PR, no eligible issue, and no leftover worktree. |
-| **1 — merge** | Auto-merge only *Dependabot* PRs that passed both reviews. Assign every other ready PR to you and drop `ai-review`. Send back anything GitHub reports as not `CLEAN`. |
+| **1 — merge** | Auto-merge only *Dependabot* PRs that passed both reviews. Hand every other ready PR to you as `merge-ready`, dropping `ai-review` and both `ai-ok-*`. Send back anything GitHub reports as not `CLEAN`, or with a required check red. |
 | **2 — clean up** | Remove worktrees whose PR merged (confirming the squash is on `main` first), then reap stalls. |
 | **3 — review** | Spawn the missing reviewers for `ai-review` PRs; dispatch a fix round for `ai-changes`. |
 | **4 — pick up** | Claim eligible `ai-ready` issues, create the worktree, spawn an implementer. |

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -132,6 +132,18 @@ Only the `worktree.symlinkDirectories` key is touched — your `hooks`,
 yourself are kept. A file that doesn't parse is left alone rather than
 clobbered; `doctor` reports it as drift for you to repair by hand.
 
+### Two things honour that list
+
+`worktree.symlinkDirectories` is a **Claude Code** setting, and Claude Code
+honours it when *it* creates the worktree — i.e. via `EnterWorktree`. The `ai-*`
+skills never call that (they create worktrees with a plain `git worktree add`, in
+a sibling directory Claude Code would refuse), so the setting would otherwise be
+inert for exactly the worktrees the issue loop creates. Instead the loop **reads
+the same list and makes the symlinks itself**, which keeps one source of truth
+for *what* to link across two mechanisms for *how*. A repo with no list gets a
+real `pnpm install` per worktree — correct, just slower and a duplicate
+`node_modules` each time.
+
 :::warning Never run `pnpm install` inside a worktree
 The worktree's `node_modules` is a symlink, so pnpm writes *through* it and
 re-points the shared root `.bin` shims at that worktree's virtual store —

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -658,6 +658,15 @@ gh pr checks <N> --required --json name,state,link 2>/dev/null \
    fix-round prompt reads the PR's comments *as its instructions*, so without it
    the implementer arrives at a PR marked `ai-changes` with nothing telling it
    what changed or why.
+
+   **Write that excerpt to a file and pass `--body-file`; never interpolate the
+   log into the command.** A failing job prints whatever the branch told it to,
+   and on a public repo the branch is a stranger's — so the excerpt is untrusted
+   bytes that a contributor chooses. Inline `--body "$(gh run view …)"` puts
+   megabytes of it, control characters and all, through the shell and past
+   GitHub's comment size cap. The same rule already governs reviewer verdicts
+   further down; this is the one other place a body is assembled from output
+   nobody in this pipeline wrote. Trim to the failing lines before writing.
 3. Count it as `ci-red` for Pass 5, which carries the `⚠`.
 
 **Say in the comment that the fix may not be code.** #543's failure was the

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -80,11 +80,11 @@ drift with a second copy to maintain.
 | `ai-review` | PR | Awaiting agent review. |
 | `ai-reviewing-code` | PR | `code-reviewer` claimed and running. Cleared with its verdict. |
 | `ai-reviewing-sec` | PR | `security-expert` claimed and running. Cleared with its verdict. |
-| `ai-ok-code` | PR | `code-reviewer` passed. |
-| `ai-ok-sec` | PR | `security-expert` passed. |
-| `ai-changes` | PR | A reviewer requested changes. Reviewers never apply it to a Dependabot PR. |
+| `ai-ok-code` | PR | `code-reviewer` passed. In-flight only — Pass 1 strips it at handoff. |
+| `ai-ok-sec` | PR | `security-expert` passed. In-flight only — Pass 1 strips it at handoff. |
+| `ai-changes` | PR | A reviewer requested changes, **or** Pass 1 sent the PR back over CI. Reviewers never apply it to a Dependabot PR. |
 | `ai-notes` | PR | Passed, but a reviewer left something to read before merging. |
-| `merge-ready` | PR | Both agent reviews passed and the PR is mergeable — waiting on a human. Derived state; Pass 1 applies and strips it. |
+| `merge-ready` | PR | Both agent reviews passed and the PR is mergeable — waiting on a human. Derived state; Pass 1 applies and strips it, and it **supersedes** the `ai-ok-*` pair rather than joining it. |
 | `ai-suggested` | issue | Follow-up a reviewer filed. A triage queue, never auto-picked. Pass 2 closes it after 30 days untouched. |
 | `holding` | issue | A gate — closes on human judgement, never picked up. |
 
@@ -150,12 +150,13 @@ grep -qxF '.claude/ai-loop-status' .gitignore || echo '.claude/ai-loop-status' >
 
 ```
 issue: ai-ready ─pickup─> ai-wip ─> PR opened, labelled ai-review
-PR: ai-review ─> ai-reviewing-* ─┬─> ai-ok-code + ai-ok-sec ─┬─ issue PR  ─> merge-ready, assigned to you, ai-review dropped
+PR: ai-review ─> ai-reviewing-* ─┬─> ai-ok-code + ai-ok-sec ─┬─ issue PR  ─> merge-ready, assigned to you (ai-review + both ai-ok-* dropped)
                                  │        (± ai-notes)       │              ─> YOU merge ─> worktree removed
                                  │                           └─ dependabot ─┬─ no ai-notes ─> auto-merge ─> worktree removed
                                  │                                          └─ ai-notes ───> merge-ready, assigned to you
                                  └─> ai-changes (issue PRs only) ─> fix round (max 2) ─> ai-review
-                                                                               └─ round 3 ─> ai-blocked
+                                     ▲                                         └─ round 3 ─> ai-blocked
+                                     └─ Pass 1 sends back: not CLEAN, or a required check FAILED
 ```
 
 `ai-reviewing-code` / `ai-reviewing-sec` are the *claim* step: Pass 3 applies one
@@ -428,7 +429,8 @@ gh api repos/$OWNER_REPO/environments \
 ```
 
 Non-zero → a non-Dependabot PR may auto-merge, but only carrying **all** of: both
-`ai-ok-code` and `ai-ok-sec`, no `ai-notes`, no `ai-changes`, and
+`ai-ok-code` and `ai-ok-sec` — or `merge-ready`, which subsumes them once an
+earlier tick handed the PR over — no `ai-notes`, no `ai-changes`, and
 `mergeStateStatus: CLEAN`. Zero, or the call errors, or `gh` lacks access to that
 endpoint → hand the PR over exactly as below.
 
@@ -508,38 +510,59 @@ leads with what to do.
 
 **Hand a ready PR over properly.** "Merge it yourself" is only actionable if the user
 can find it, and a PR sitting in a list of open PRs looks identical to one still being
-worked. So for every non-Dependabot PR carrying both `ai-ok-code` and `ai-ok-sec` and
-not `ai-changes`, assign it, label it, and clear the stale review flag — **but only
+worked. So for every non-Dependabot PR carrying both `ai-ok-code` and `ai-ok-sec` —
+or `merge-ready` already, from an earlier tick — and not `ai-changes`, assign it,
+label it, and clear the labels the handoff supersedes — **but only
 after the `mergeStateStatus` probe below reports `CLEAN`**. That ordering is what
 makes `merge-ready` assert more than the `ai-ok-*` pair ever did: reviews passed
 *and* GitHub will accept the merge.
 
 ```bash
-gh pr edit <N> --add-assignee @me --add-label merge-ready --remove-label ai-review \
+gh pr edit <N> --add-assignee @me --add-label merge-ready \
+  --remove-label ai-review --remove-label ai-ok-code --remove-label ai-ok-sec \
   ${AGENT_USER:+--remove-assignee "$AGENT_USER"}
 ```
+
+**`merge-ready` replaces the pass pair — it does not join it.** A handed-off PR
+wearing `ai-ok-code`, `ai-ok-sec` *and* `merge-ready` says one thing three times,
+and the reader has to know which of the three is the strongest before they can
+act on any of them. `merge-ready` asserts strictly more than the pair (both
+reviews passed **and** `CLEAN`), so the pair carries no information once it is
+applied — a ready PR's whole vocabulary is the two-row table below.
+
+Consequently **`merge-ready` satisfies every later test for the `ai-ok-*` pair** —
+the gated-repo auto-merge arm above, the Dependabot arm below, and this pass's own
+selector on the next tick. The pair stays the in-flight signal Pass 3 writes and
+reads; it is only at the handoff that it stops being the thing anyone looks at.
 
 Dropping `AGENT_USER` is half the signal: leaving the agent assigned alongside
 you says you both owe it something, which is the one thing never true here.
 
 It lands in the user's *Assigned to you* view, and the labels then read as state rather
 than noise — `merge-ready` means **waiting on you**, filterable at a glance where an
-absence never was. Both
-halves matter: Pass 3 only ever *adds* the `ai-ok-*` labels, so without the removal a
-finished PR keeps wearing `ai-review` forever and looks mid-review. Idempotent, so
-re-running a tick is harmless.
+absence never was. Every removal
+matters: Pass 3 only ever *adds* its labels, so without them a finished PR keeps
+wearing `ai-review` forever and looks mid-review while three green-ish labels
+argue about who passed what. Idempotent, so re-running a tick is harmless.
 
-**`merge-ready` is derived state — reconcile it every tick.** The `ai-ok-*` pair
-plus `CLEAN` stays the source the loop computes from; the label only mirrors it.
-A PR carrying `merge-ready` while no longer `CLEAN`, or missing either pass
-label, gets it stripped (`gh pr edit <N> --remove-label merge-ready`). That is
+**`merge-ready` is derived state — reconcile it every tick.** `CLEAN` stays the
+source the loop computes from; the label only mirrors it. A PR carrying
+`merge-ready` while no longer `CLEAN`, or carrying `ai-changes`, gets it stripped
+(`gh pr edit <N> --remove-label merge-ready`) — and the two send-back blocks
+below strip it as part of the same edit. That is
 what keeps a stateless 15-minute loop from letting the label lie after `main`
 moves. Take no other action — do not merge, and **post no
-comment on a clean handoff**: nothing is wrong, so those three labels are the
+comment on a clean handoff**: nothing is wrong, so that one label is the
 whole message. A comment is how the loop records what a label cannot; a clean PR
 has nothing to record. An `ai-notes` handoff is the exception per the budget
 table — ≤10 lines through the marker upsert, linking the reviewer's
 `### Before merging` rather than restating it.
+
+**Reconcile on `CLEAN` only — never on a missing `ai-ok-*`.** The handoff strips
+that pair itself, so a rule that stripped `merge-ready` whenever a pass label was
+absent would undo the tick before it on every handed-off PR, leaving it with no
+labels at all, matching no selector in any pass, and assigned to a human with
+nothing saying why it is theirs.
 
 **Never strip `ai-notes` here.** It is the whole point of the handoff: it has to
 survive to the moment of merging, which is the moment it is for. A ready PR reads
@@ -547,8 +570,8 @@ one of two ways, and the difference must be legible without opening anything:
 
 | Labels | Means |
 |---|---|
-| `merge-ready` | Clean — merge freely. |
-| `merge-ready, ai-notes` | Passed, but open the comments first. |
+| `merge-ready` | Merge freely. |
+| `merge-ready`, `ai-notes` | Passed, but open the comments first. |
 
 **Check it can actually merge before calling it ready.** The `ai-ok-*` labels
 report the *agent review* verdict and nothing more — they say nothing about
@@ -595,8 +618,8 @@ gh pr edit <N> --add-assignee @me ${AGENT_USER:+--remove-assignee "$AGENT_USER"}
 Count it as `rev`. Idempotent, so it also picks up ones an earlier tick stranded.
 
 So: every open PR **authored by `dependabot[bot]`**, labelled both `ai-ok-code`
-and `ai-ok-sec`, **not** `ai-changes`, **not** `ai-notes`, that has no
-`autoMergeRequest` yet:
+and `ai-ok-sec` (or `merge-ready`), **not** `ai-changes`, **not** `ai-notes`, that
+has no `autoMergeRequest` yet:
 
 ```bash
 gh pr merge <N> --auto --squash --delete-branch
@@ -612,10 +635,69 @@ no human picks it up. Merging
 unattended when a reviewer flagged something for a human writes the note into the
 void, which is the one way this label can be worse than useless.
 
-**Also flag CI red here** — it is the one stall the loop cannot resolve itself.
-Any PR that already has `autoMergeRequest != null` and a `FAILURE` in its
-`statusCheckRollup` will sit queued forever. Count these as `ci-red` for Pass 5;
-take no other action (a human decides whether to fix or close).
+**CI red on an issue PR is a send-back, not a wait.** Reviewers are diff-scoped
+and never see CI, so both arms happily pass a PR whose `build` failed two minutes
+after it opened — and nothing else in the pipeline was ever going to dispatch a
+fix. Observed on #543 (2026-08-26): the human found it via the red ✗ on the PR
+page, which is precisely the noticing this loop exists to do. `ai-changes` **is**
+the send-back label; Pass 3 dispatches the fix-round implementer off it, under
+the same 2-round budget.
+
+So for every open **non-Dependabot** PR carrying any `ai-*` label, with a
+completed `FAILURE` on a **required** check:
+
+```bash
+gh pr checks <N> --required --json name,state,link 2>/dev/null \
+  | jq -r '.[] | select(.state == "FAILURE") | "\(.name)\t\(.link)"'
+```
+
+1. `gh pr edit <N> --add-label ai-changes --remove-label ai-review --remove-label ai-ok-code --remove-label ai-ok-sec --remove-label ai-notes --remove-label merge-ready`
+2. **Comment through the marker upsert** — ≤10 lines, naming the failing check
+   and pasting the relevant excerpt from `gh run view <run-id> --log-failed`
+   (the run id is in that check's `link`). This step is not optional: the
+   fix-round prompt reads the PR's comments *as its instructions*, so without it
+   the implementer arrives at a PR marked `ai-changes` with nothing telling it
+   what changed or why.
+3. Count it as `ci-red` for Pass 5, which carries the `⚠`.
+
+**Say in the comment that the fix may not be code.** #543's failure was the
+dogfood check finding a *bootstrap* gap — a label present in the canonical table
+and not yet on the repo — where the fix was `gh label create` / `fix labels`, or
+an `ACCEPTED` entry in `scripts/dogfood.mjs`, and never a branch edit. The
+implementer has repo-write, so leave that path open; a comment that assumes the
+branch is at fault steers it into editing code that is not wrong.
+
+Two carve-outs, both so the loop does not fight itself:
+
+- **An `ai-reviewing-code` / `ai-reviewing-sec` claim is active** — leave the PR
+  alone this tick. A reviewer is mid-run, and the fix round relabels `ai-review`
+  and re-spawns both arms anyway, so sending back now only throws away a review
+  in flight.
+- **`ai-changes` is already on the PR** — leave it. Re-applying is not free:
+  Pass 3 counts `ai-changes` applications off the timeline and stops at three, so
+  a stateless 15-minute loop re-adding it while CI stays red would exhaust the
+  round budget within the hour and mark the issue `ai-blocked` before any agent
+  had done anything.
+
+**`--required`, not the whole rollup.** `statusCheckRollup` also carries optional
+and third-party contexts, and an advisory check going red is not a broken PR —
+sending one back spends a fix round to change nothing. The required set is the
+actual merge gate, and `gh` already resolves which checks are in it. Dropping
+`ai-review` in step 1 is the mirror of what a `CHANGES` verdict does: leaving it
+on would have Pass 3 spawn reviewers *and* a fix round against one PR, reviewing
+a diff that is being rewritten underneath them. The implementer re-adds it when
+it pushes.
+
+No new label. `ai-changes` plus that comment already say "sent back, and why";
+if telling a review-rejected PR from a CI-rejected one in the list view ever
+matters, add a `ci-failing` rider on top of `ai-changes` then, not speculatively
+now.
+
+**A Dependabot PR is the exception — flag it, never send it back.** There is no
+fix round for one (Pass 3 treats `ai-changes` on a bot PR as terminal), so a red
+one that already armed auto-merge will sit queued forever and only a human can
+choose between a fix and a close. Count these as `ci-red` too; take no other
+action:
 
 ```bash
 gh pr list --state open --json number,autoMergeRequest,statusCheckRollup \
@@ -1347,49 +1429,73 @@ mkdir -p "$WT_ROOT"
 git -C "$ROOT" worktree add "$WT_ROOT/$SLUG" -b "$SLUG" origin/main
 ```
 
-**Then give it dependencies — and the choice matters.** Symlinking is the cheap
-path, but it is only correct for an issue confined to an app:
+**Then give it dependencies — from the repo's own symlink list.** `fix ai` writes
+`worktree.symlinkDirectories` into `.claude/settings.json`: the root
+`node_modules`, plus one entry per workspace package that has one, globbed from
+the repo's *own* `pnpm-workspace.yaml` / `package.json` `workspaces` (#406). That
+list is the single source of truth for what a worktree needs linked. Read it and
+do the linking here:
 
 ```bash
-# Only for app/docs-only issues — nothing under a workspace package.
-# Replaces worktree.symlinkDirectories. Link the workspace packages too, not just
-# the root — with only the root linked, `pnpm verify` ENOENTs at the treeshake step
-# because apps/*/node_modules is missing, and the agent cannot self-verify.
-ln -s "$ROOT/node_modules" "$WT_ROOT/$SLUG/node_modules"
-for app in "$ROOT"/apps/*/; do
-  [ -d "$app/node_modules" ] || continue
-  ln -s "$app/node_modules" "$WT_ROOT/$SLUG/apps/$(basename "$app")/node_modules"
+DIRS=$(jq -r '.worktree.symlinkDirectories[]? // empty' "$ROOT/.claude/settings.json" 2>/dev/null)
+for d in $DIRS; do
+  [ -d "$ROOT/$d" ] || continue          # an entry pointing at nothing links nothing
+  mkdir -p "$(dirname "$WT_ROOT/$SLUG/$d")"
+  ln -s "$ROOT/$d" "$WT_ROOT/$SLUG/$d"
 done
 ```
 
-**For anything touching a workspace package, do not symlink — install for real:**
+**Read the setting, do not rely on it.** `worktree.symlinkDirectories` is a
+**Claude Code** setting, honoured by `EnterWorktree` — which this pipeline
+forbids outright (see below) and replaces with a raw `git worktree add`. So the
+setting is *inert for exactly the worktrees this loop creates*: `doctor` can
+report `Claude worktree settings: ok` while every agent worktree gets its
+dependencies by some other path, which is how #511/PR #526 ended up hand-installed.
+Taking the list as data and doing the `ln -s` here is what makes that check mean
+something for loop worktrees too, without either subsystem owning the other.
+
+**No list, or no `.claude/settings.json` → install for real instead:**
 
 ```bash
-(cd "$WT_ROOT/$SLUG" && pnpm install)
+[ -z "$DIRS" ] && (cd "$WT_ROOT/$SLUG" && pnpm install)
 ```
 
-Those symlinks share the **root** and `apps/*`. pnpm workspaces keep the
-resolution that matters in each `packages/<name>/node_modules`, which is not
-symlinked and does not exist in a fresh worktree. Measured on `api-common`
-2026-08-20: the main checkout had per-package `node_modules` in **37 of 37**
-packages, the worktree had **1**. So `pnpm --filter <pkg> typecheck` there fails
-with `Cannot find module` rather than the real error — the agent cannot reproduce
-the bug, and the environment looks like the issue's fault. Issue #201 was handed
-back `ai-blocked` this way, well-diagnosed and untouched.
+That fallback is safe precisely because nothing was symlinked — the hazard below
+is `pnpm install` against a *symlinked* tree, not a real install in an isolated
+one. It costs a duplicate `node_modules` and about ten seconds, since pnpm
+hardlinks from the store. Run `npx @rtorcato/repo-tooling fix ai` in the repo to
+get the faster path back.
+
+Why the list has to come from that file rather than a hand-rolled glob: pnpm
+workspaces keep the resolution that matters in each
+`packages/<name>/node_modules`, and an earlier version of this pass linked the
+root and `apps/*` only — so it reproduced that gap on every repo that nests its
+packages anywhere else. Measured on `api-common` 2026-08-20: the main checkout
+had per-package `node_modules` in **37 of 37** packages, the worktree had **1**.
+So `pnpm --filter <pkg> typecheck` there fails with `Cannot find module` rather
+than the real error — the agent cannot reproduce the bug, and the environment
+looks like the issue's fault. Issue #201 was handed back `ai-blocked` this way,
+well-diagnosed and untouched. `workspaceSymlinkDirs` already globs the consuming
+repo's own layout, so deriving the list is both shorter here and correct on repos
+this file has never seen.
 
 **Never force `pnpm install` against a symlinked tree.** It wants to purge and
 rebuild the modules dir (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`), which
 mutates the **main checkout's** `node_modules` — shared by every other worktree
 and yanked out from under any agent mid-typecheck. `CI=true` and
 `--config.confirmModulesPurge=false` both silence that prompt; neither makes it
-safe. A real install in an unsymlinked worktree costs a duplicate `node_modules`
-and is the price of isolation. Pass 2's rebuild is the one sanctioned exception,
-and only because it is gated on no worktree surviving.
+safe. Now that the default path symlinks, this rule is **load-bearing rather than
+advisory** — the implementer prompt below states it, and `browser-common` #145 →
+PR #147 is what an implementer doing it anyway costs: the main checkout's `.bin`
+emptied, surfacing arbitrarily later in a human's `git push`. Pass 2's rebuild is
+the one sanctioned exception, and only because it is gated on no worktree
+surviving.
 
-**Once per repo, exclude the symlink from git.** Repos ignore `node_modules/`
-*with a trailing slash*, which does not match a symlink — so the link shows as
-untracked in every worktree and a `git add -A` commits it. `.git/info/exclude`
-is shared by all worktrees and never committed:
+**Once per repo, exclude the symlinks from git.** Repos ignore `node_modules/`
+*with a trailing slash*, which does not match a symlink — so every link shows as
+untracked in every worktree and a `git add -A` commits it. The pattern below has
+no slash, so it matches at any depth and covers the nested workspace links too.
+`.git/info/exclude` is shared by all worktrees and never committed:
 
 ```bash
 grep -qxF 'node_modules' "$ROOT/.git/info/exclude" || echo 'node_modules' >> "$ROOT/.git/info/exclude"
@@ -1403,9 +1509,9 @@ directory — the two rules are incompatible, so the call can only ever be refus
 five-plus times in one tick, each producing *"this session is isolated in the worktree
 …"* refusals on unrelated orchestrator commands. Implementers work via
 `git -C <absolute worktree path>` instead, which is what the prompt below says.
-Creating the worktree here also fixes the `worktree-` branch-prefix drift, and lets the
-`node_modules` symlink be explicit rather than depending on
-`worktree.symlinkDirectories` being configured.
+Creating the worktree here also fixes the `worktree-` branch-prefix drift, and it is
+why the symlinks above are created explicitly *from* `worktree.symlinkDirectories`
+rather than by `EnterWorktree` honouring it.
 
 **Spawn implementers one at a time — never two in the same message.** The worktree pin
 is a property of the session, not of an agent, so concurrent spawns cross-pin: the

--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -129,10 +129,11 @@ done
 ```
 
 **Then give each worktree dependencies** — the loop skill's Pass 4 rules apply
-verbatim: symlink `node_modules` (root *and* `apps/*`) only for an issue confined
-to an app; run a real `pnpm install` in the worktree for anything touching a
-workspace package; never force an install against a symlinked tree; and add
-`node_modules` to `$ROOT/.git/info/exclude` once per repo.
+verbatim: symlink every entry of `worktree.symlinkDirectories` from
+`$ROOT/.claude/settings.json` (the root `node_modules` plus each workspace
+package's, written by `fix ai`); run a real `pnpm install` in the worktree only
+when that list is missing or empty; never force an install against a symlinked
+tree; and add `node_modules` to `$ROOT/.git/info/exclude` once per repo.
 
 Stop here on `--label-only`. Report the picks and — briefly — what you skipped
 and why.
@@ -280,8 +281,8 @@ and still wearing a stale `ai-review`. Close that window here: once per PR
 whose two review arms both completed, apply the `ai-issue-loop` skill's Pass 1
 **by reference — execute what its text currently says, never a copy of it
 here**. A second copy of the handoff logic is drift with two files to keep
-honest; deferring means changes to Pass 1 (e.g. a future `merge-ready` label)
-take effect here without touching this file.
+honest; deferring means changes to Pass 1 (its `merge-ready` handoff, its CI-red
+send-back) take effect here without touching this file.
 
 - **Both arms passed** → run ai-issue-loop's Pass 1 handoff/send-back logic
   on this PR, per its current text — with one carve-out: `mergeStateStatus`

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -1105,6 +1105,12 @@ export async function checkTreeshakeSetup(dir: string, pkg: Pkg | null): Promise
  * one pays a full install before it can typecheck, lint or test — unless
  * `.claude/settings.json` tells Claude to symlink the directory from the main
  * checkout (#396). JS-only: the other language modules have nothing to symlink.
+ *
+ * Two consumers, one list (#527). Claude Code honours the setting only for
+ * worktrees it creates itself (`EnterWorktree`); the shipped `ai-issue-loop`
+ * skill creates its own with `git worktree add`, so it reads this same list and
+ * makes the symlinks itself. That is why the check is worth passing on a repo
+ * running the loop, where the setting alone would govern nothing.
  */
 export async function checkClaudeWorktreeSettings(dir: string): Promise<CheckResult> {
 	const check = 'Claude worktree settings'


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Three changes to `skills/ai-issue-loop/SKILL.md`, batched because they edit the same file and cannot be reverted independently.

## 1. CI-red send-back — Closes #545

Pass 1 only reacted to a non-`CLEAN` `mergeStateStatus` at handoff time, so a PR whose CI went red waited for a human to spot the ✗ (observed on #543). Reviewers are diff-scoped and never see CI, so nothing in the pipeline was going to dispatch a fix.

Pass 1 now sends back any open **non-Dependabot** PR carrying an `ai-*` label with a completed `FAILURE` on a **required** check: `ai-changes`, the superseded labels stripped, and a marker-upsert comment naming the check and pasting the `--log-failed` excerpt — including the issue's point that **the fix may not be code** (#543's red check was a bootstrap gap fixable with `gh label create`, not a branch edit). Counted `ci-red` for Pass 5, which already carries the `⚠`.

Two carve-outs: a live `ai-reviewing-*` claim (per the issue), and a PR **already** carrying `ai-changes` — re-applying is not free, since Pass 3 counts label applications off the timeline and stops at three, so a 15-minute loop would exhaust the fix-round budget within the hour and mark the issue `ai-blocked` with no agent having done anything.

**One deviation from the issue's spec:** step 1 also drops `ai-review`. Leaving it on has Pass 3 spawn reviewers *and* a fix round against one PR, reviewing a diff being rewritten underneath them. It mirrors what a `CHANGES` verdict already does, and the implementer re-adds it on push.

Dependabot PRs keep the old behaviour — flagged `ci-red`, never sent back, since Pass 3 treats `ai-changes` on a bot PR as terminal.

`--required` rather than the whole rollup: `statusCheckRollup` also carries optional and third-party contexts, and an advisory check going red should not spend a fix round.

## 2. Worktree dependency advice reconciled — Closes #527

**The issue's claim about #406 verified against the code and holds.** `workspaceSymlinkDirs` (`src/cli/generators/agent-rules.ts:100`) globs the repo's own `pnpm-workspace.yaml` / `package.json` `workspaces` and emits `<workspace>/node_modules` for each one that exists, so `worktree.symlinkDirectories` is complete. The skill's Pass 4 hand-rolled loop was the incomplete one — it linked the root and `apps/*` only, reproducing the exact `api-common` 37-of-37-vs-1 gap on any repo that nests packages elsewhere.

The issue's other point is the one that shapes the fix: `worktree.symlinkDirectories` is a **Claude Code** setting honoured by `EnterWorktree`, which the ai-* skills forbid — so it is inert for exactly the worktrees the loop creates. So neither Option A (honour the setting) nor C (always install) as written. Pass 4 now **reads the list as data** and does the `ln -s` itself: one source of truth for *what* to link, two mechanisms for *how*, and `doctor`'s *Claude worktree settings* check becomes meaningful for loop worktrees. No list, or no `.claude/settings.json` → a real `pnpm install` in the (unsymlinked, therefore safe) worktree.

That drops the app-confined carve-out — the branch is now keyed on data rather than on the implementer's judgement about which issue is "confined to an app", which is what got it wrong. The never-install-against-a-symlink rule becomes load-bearing rather than advisory, as the issue predicted, and says so.

`apps/docs/docs/guides/ai-setup.md` §Worktrees, `apps/docs/docs/guides/ai-issue-loop.md`, `skills/ai-workflow/SKILL.md` (which restated the old rule verbatim), and the `checkClaudeWorktreeSettings` doc comment all now say the same thing.

## 3. Collapse the ready-PR label set — no issue

Pass 1 added `merge-ready` without removing the two labels it supersedes, so a handed-off PR wore `ai-ok-code`, `ai-ok-sec` **and** `merge-ready` — one fact stated three times, with the reader having to know which is strongest. The handoff now strips both pass labels, leaving exactly:

| Labels | Means |
|---|---|
| `merge-ready` | Merge freely. |
| `merge-ready`, `ai-notes` | Passed, but open the comments first. |

`ai-notes` is never stripped; that rule stands untouched.

Checked every later reader of the pair, and adjusted three:

- **The reconcile rule** stripped `merge-ready` from a PR "missing either pass label" — which after this change would undo the previous tick on every handed-off PR, leaving it with no labels at all, matching no selector in any pass. It now keys on `CLEAN` (and `ai-changes`) only, and the file says why.
- **Pass 1's own handoff selector** and **the Dependabot auto-merge selector** now accept `merge-ready` in place of the pair, as does the gated-repo auto-merge arm. Stated once as a rule: `merge-ready` satisfies every later test for the pair.
- **Pass 3** is unaffected — it acts on `ai-review`, which the handoff drops — and the fix-round relabel already removed all four labels.

`src/base/labels.ts` and the SKILL.md bootstrap block are untouched, so `tests/base/labels.test.ts` stays green. `skills/ai-loop-status/SKILL.md` already read `merge-ready` first with the pair as a fallback.

## Verification

`pnpm run check` (0), `pnpm run typecheck` (0), `pnpm test --run` — 1073 passed, and `pnpm dogfood` clean (61 checks) after a build.

⚠ During this run the **main checkout flipped to `core.bare = true`** again (the #500 failure mode Pass 0 documents), staging 740 phantom deletions in the worktree index. Caught before any second commit; repaired with `git config core.bare false` + `git reset`, and this branch is one clean 5-file commit. Noting it as another datapoint — it happened right after `pnpm build-cli`, with no `worktree remove` involved.