### PR TITLE
feat(lockfile): add requiredSkills and mcp.recommended with advisory doctor checks

### DIFF
--- a/.repo-tooling.json
+++ b/.repo-tooling.json
@@ -33,6 +33,7 @@
   "aiLoop": {
     "agentUser": "rtorcato-bot"
   },
+  "requiredSkills": ["ai-issue-loop", "ai-workflow", "ai-issue", "ai-loop-status"],
   "writtenBy": "@rtorcato/repo-tooling@3.11.0",
   "writtenAt": "2026-08-26T14:58:22.032Z"
 }

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -98,6 +98,58 @@ against your repo's own remote (`gh api repos/{owner}/{repo}/assignees/<user>`)
 and reports drift when it isn't assignable. Absent field ⇒ `ok`, not
 applicable.
 
+## `requiredSkills`: catching a *stale* skill, not just a missing one
+
+A repo whose workflows depend on the shipped skills can say so:
+
+```json
+{
+  "requiredSkills": ["ai-issue-loop", "ai-workflow", "ai-issue", "ai-loop-status"]
+}
+```
+
+Absence isn't the interesting failure — a skill that isn't installed fails loudly
+the moment something reaches for it. Staleness is. An installed copy several
+releases behind runs happily to completion while missing whatever the newer
+releases added, and nothing complains. So `doctor` compares each listed skill's
+installed `SKILL.md` — its stamped `repo-tooling-hash`, under `~/.claude/skills`
+or wherever `--skills-dir` points — against the copy this package ships, and
+reports anything missing, stale, or matching no shipped version at all.
+
+Two rules keep the field safe to commit:
+
+- **It never fails your build.** The check probes your machine, not the repo, so
+  it reports "not configured" and never `drift` or `missing` — a contributor
+  without Claude installed doesn't fail this repo's `doctor`. It's also skipped
+  entirely unless the file has an `aiLoop` key.
+- **It only ever hints.** `doctor` names `fix claude-skills`; running it is
+  yours. Committed repo config that directs writes into your home directory is
+  the shape of a supply-chain attack even when the content is benign.
+
+## `mcp.recommended`: names and reasons, never an install directive
+
+The same file can name the MCP servers a repo's workflow assumes — and only
+name them:
+
+```json
+{
+  "mcp": {
+    "recommended": [
+      { "name": "some-server", "importance": "important", "why": "edits the design files under design/" }
+    ]
+  }
+}
+```
+
+`importance` is `nice-to-have`, `important` or `critical`; `why` is the one line
+`.mcp.json` structurally cannot carry. `doctor` reports which of these names
+`.mcp.json` doesn't declare, informationally, and stops there.
+
+There's deliberately no `command`, `args` or `env`, and no fixer. MCP servers
+execute code, so real config belongs in `.mcp.json` — the file below, which
+carries Claude Code's own first-use consent prompt. The lockfile says *what and
+why*, `.mcp.json` says *how*, and you say *whether*.
+
 ## Worktrees: symlink `node_modules` instead of reinstalling it
 
 A Claude Code worktree starts empty, so an agent working one pays a full

--- a/apps/docs/docs/reference/repo-tooling-json.mdx
+++ b/apps/docs/docs/reference/repo-tooling-json.mdx
@@ -79,6 +79,57 @@ enum-valued records — see the schema for their exact shapes.
 
 See the [AI issue loop guide](../guides/ai-issue-loop.md) for how this is used.
 
+## `requiredSkills` — agent skills this repo depends on
+
+A list of the skills this package ships (`ai-issue-loop`, `ai-workflow`, `ai-issue`,
+`ai-loop-status`) that the repo's workflows assume. It exists for **staleness**, not absence:
+a skill that isn't installed fails loudly the moment something reaches for it, while a copy
+three releases behind runs to completion without complaint.
+
+```json
+"requiredSkills": ["ai-issue-loop", "ai-workflow"]
+```
+
+`doctor` compares each listed skill's installed `SKILL.md` — its stamped `repo-tooling-hash`,
+under `~/.claude/skills` or wherever `--skills-dir` points — against the hash of the copy this
+package ships, and reports anything missing, stale, or matching no shipped version at all.
+
+Two rules make it safe to commit:
+
+- **Never `drift`, never `missing`.** The check probes your machine, not the repo, so a
+  contributor with no Claude installed must not fail its `doctor`. It only ever reports
+  "not configured", which leaves the exit code alone. It is also skipped entirely unless the
+  file has an `aiLoop` key — that key is already the "this repo uses the pipeline" signal.
+- **Check and hint only.** `doctor` names `fix claude-skills`; it never runs it. Committed
+  repo config that directs writes into your home directory is the shape of a supply-chain
+  attack even when the content is benign, so that step stays a human's.
+
+## `mcp` — recommended MCP servers
+
+Advisory metadata about the MCP servers the repo's workflow assumes. **Never an install
+directive**: an entry may say *what* and *why*, and may not say *how*.
+
+```json
+"mcp": {
+  "recommended": [
+    { "name": "some-server", "importance": "important", "why": "edits the design files under design/" }
+  ]
+}
+```
+
+<Fields schema={lockfileSchema.properties.mcp.properties.recommended.items} />
+
+`importance` is one of `nice-to-have`, `important`, `critical` — it signals how much of the
+workflow assumes the server, and nothing more. `why` is the one line that `.mcp.json`
+structurally cannot carry.
+
+`doctor` reports, informationally, which recommended names the repo-scoped `.mcp.json` does not
+declare. It never installs or enables a server, and there is deliberately no `command`, `args`
+or `env` here: MCP servers execute code, so the real config belongs in `.mcp.json`, which
+carries Claude Code's own first-use consent prompt. The lockfile says *what and why*,
+`.mcp.json` says *how*, and you say *whether*. User-scoped MCP config is machine-private and
+is not probed at all.
+
 ## Version history
 
 | Version | Change |

--- a/apps/docs/static/schemas/lockfile.json
+++ b/apps/docs/static/schemas/lockfile.json
@@ -230,6 +230,58 @@
 				}
 			}
 		},
+		"requiredSkills": {
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": [
+					"ai-issue-loop",
+					"ai-workflow",
+					"ai-issue",
+					"ai-loop-status"
+				]
+			},
+			"description": "Agent skills this repo's workflows depend on. doctor compares each installed copy's stamped hash against the shipped one and reports a missing or stale skill — always as \"not configured\", never drift, because it probes the machine rather than the repo. It never runs the fixer for you."
+		},
+		"mcp": {
+			"type": "object",
+			"additionalProperties": false,
+			"description": "Advisory MCP metadata: names, importance and reasons only, never an install directive. Executable server config belongs in the native .mcp.json, which carries Claude Code's own first-use consent prompt.",
+			"properties": {
+				"recommended": {
+					"type": "array",
+					"description": "MCP servers this repo's workflow assumes. doctor reports which of them .mcp.json does not declare, informationally — it never installs or enables one.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": [
+							"name",
+							"importance",
+							"why"
+						],
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "The server name as it would appear in .mcp.json."
+							},
+							"importance": {
+								"type": "string",
+								"enum": [
+									"nice-to-have",
+									"important",
+									"critical"
+								],
+								"description": "How much of the repo's workflow assumes the server."
+							},
+							"why": {
+								"type": "string",
+								"description": "One line on what the server is for — the thing .mcp.json structurally cannot say."
+							}
+						}
+					}
+				}
+			}
+		},
 		"writtenBy": {
 			"type": "string",
 			"description": "Package name and version that last wrote this file."

--- a/src/base/checks.ts
+++ b/src/base/checks.ts
@@ -10,6 +10,7 @@ import {
 } from '../cli/generators/claude-skills.js'
 import { DEPENDABOT_CONFIG_PATHS, dependabotIgnoreRules } from '../cli/generators/security.js'
 import { type DetectedLanguage, detectNestedLanguages } from '../cli/utils/detect-language.js'
+import type { McpRecommendation } from '../cli/utils/lockfile.js'
 import type { CheckResult } from './types.js'
 
 /**
@@ -598,6 +599,118 @@ export async function checkClaudeSkills(skillsDir?: string): Promise<CheckResult
 		check,
 		status: 'ok',
 		detail: `${SHIPPED_SKILLS.length} skills installed at ${[...versions].join(', ')}`,
+	}
+}
+
+/**
+ * The skills *this repo* declares it depends on — `requiredSkills` in
+ * `.repo-tooling.json` (#533). Where `checkClaudeSkills` above reports on the
+ * package's whole skill set as a machine-level nicety, this one is the repo
+ * asserting a dependency, so it names the skills the repo actually runs on and
+ * reports a stale installed copy against them.
+ *
+ * Staleness is the failure mode it exists for. Absence fails loudly the moment
+ * something reaches for the skill; a copy three releases behind runs to
+ * completion without complaint — observed 2026-08-26, an `ai-issue-loop` missing
+ * both its decision-comment security gate and its decay rule.
+ *
+ * Same severity rule as `checkClaudeSkills`, for the same reason: it probes the
+ * machine, not the repo, so it never returns `drift` or `missing`. A contributor
+ * with no Claude installed must not fail this repo's `doctor`.
+ *
+ * **Check and hint only.** The fixer writes into `~/`, and repo config that
+ * triggers writes outside the repo is the shape of a supply-chain attack even
+ * when the content is benign. doctor says stale; the human runs the fixer.
+ */
+export async function checkRequiredSkills(
+	names: string[],
+	skillsDir?: string
+): Promise<CheckResult> {
+	const check = 'Required skills'
+	const hint =
+		'Run `npx @rtorcato/repo-tooling fix claude-skills` yourself to install or refresh them — add `--force-skills` to overwrite a locally modified copy. It writes to `~/.claude`, outside this repo, so nothing runs it for you.'
+	// A name outside SHIPPED_SKILLS has no shipped asset to hash against, and
+	// reading one would throw rather than report. The published schema rejects it
+	// in an editor; this is the runtime half of the same validation.
+	const unknown = names.filter((name) => !SHIPPED_SKILLS.includes(name))
+	if (unknown.length > 0) {
+		return {
+			check,
+			status: 'optional-missing',
+			detail: `.repo-tooling.json lists ${unknown.join(', ')}, which this package does not ship`,
+			hint: `requiredSkills accepts ${SHIPPED_SKILLS.join(', ')}`,
+		}
+	}
+
+	const statuses: [string, SkillStatus][] = []
+	for (const name of names) statuses.push([name, await claudeSkillStatus(name, skillsDir)])
+
+	const missing = statuses.filter(([, s]) => !s.installed).map(([name]) => name)
+	// `needsInstall` is `behind && pristine`, so these two partitions are disjoint:
+	// a copy matching no shipped version is a fork, not something to update.
+	const stale = statuses.filter(([, s]) => s.installed && s.needsInstall)
+	const modified = statuses.filter(([, s]) => s.contentState && s.contentState !== 'pristine')
+
+	const parts = [
+		missing.length > 0 ? `not installed: ${missing.join(', ')}` : null,
+		...stale.map(
+			([name, s]) =>
+				`${name} is stale — installed ${s.installedVersion ?? 'unstamped'}, this package ships ${s.shippedVersion}`
+		),
+		...modified.map(
+			([name, s]) => `${name} at ${s.file} matches no version this package has shipped`
+		),
+	].filter((part) => part !== null)
+
+	if (parts.length === 0) {
+		return {
+			check,
+			status: 'ok',
+			detail: `${names.length} required skill(s) installed and current: ${names.join(', ')}`,
+		}
+	}
+	return { check, status: 'optional-missing', detail: parts.join('; '), hint }
+}
+
+/**
+ * The MCP servers this repo's workflow assumes — `mcp.recommended` in
+ * `.repo-tooling.json` (#534). Informational in the strongest sense: it reports
+ * which recommended names the repo-scoped `.mcp.json` does not declare, and
+ * stops there.
+ *
+ * Never `drift`, never a CI failure, and deliberately no fixer — MCP servers
+ * execute code, so installing one from committed repo config would be an install
+ * directive rather than a recommendation. `.mcp.json` carries Claude Code's own
+ * first-use consent prompt; that is where the decision belongs.
+ *
+ * User-scoped MCP config is not probed at all. It is machine-private, and a
+ * server configured there is none of this repo's business.
+ */
+export async function checkRecommendedMcp(
+	dir: string,
+	recommended: McpRecommendation[]
+): Promise<CheckResult> {
+	const check = 'Recommended MCP'
+	// Absent, malformed or unreadable all mean the same thing here — nothing is
+	// declared — and none of them is worth its own finding on an advisory check.
+	const declared = await fs
+		.readJson(path.join(dir, '.mcp.json'))
+		.then((raw: { mcpServers?: Record<string, unknown> }) => Object.keys(raw?.mcpServers ?? {}))
+		.catch(() => [] as string[])
+
+	const absent = recommended.filter((entry) => !declared.includes(entry.name))
+	if (absent.length === 0) {
+		return {
+			check,
+			status: 'ok',
+			detail: `.mcp.json declares all ${recommended.length} recommended server(s): ${recommended.map((e) => e.name).join(', ')}`,
+		}
+	}
+	return {
+		check,
+		status: 'optional-missing',
+		detail: absent.map((e) => `${e.name} (${e.importance}) — ${e.why}`).join('; '),
+		hint: 'Advisory only. Add what you want to `.mcp.json` by hand; nothing here installs or enables an MCP server.',
 	}
 }
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -38,6 +38,8 @@ import {
 	checkNestedLanguages,
 	checkPrePushHook,
 	checkReadmeBadges,
+	checkRecommendedMcp,
+	checkRequiredSkills,
 	COMMITLINT_FILE_CHECK,
 	type GitHooksProfile,
 } from '../../base/checks.js'
@@ -285,6 +287,16 @@ async function runBaseChecks(
 	results.push(await checkAiSetup(dir))
 	// User-global, not repo state — see checkClaudeSkills on why it never returns drift.
 	results.push(await checkClaudeSkills(opts.skillsDir))
+	// #533: gated on `aiLoop`, which is already the "this repo uses the pipeline"
+	// signal, so a repo that doesn't gets no line at all rather than an empty one.
+	if (lock?.aiLoop && lock.requiredSkills?.length) {
+		results.push(await checkRequiredSkills(lock.requiredSkills, opts.skillsDir))
+	}
+	// #534: advisory. Absent `mcp.recommended` means the repo has nothing to say
+	// about MCP, which is not a finding.
+	if (lock?.mcp?.recommended?.length) {
+		results.push(await checkRecommendedMcp(dir, lock.mcp.recommended))
+	}
 	results.push(await checkReadmeBadges(dir, opts.badges.audience, opts.badges.fixTarget))
 	results.push(await checkCoverageUpload(dir))
 	return results

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -52,6 +52,12 @@ export const FIX_TARGETS: Record<string, string> = {
 	'Claude worktree settings': 'ai',
 	'Claude skills': 'claude-skills',
 	'Copied assets': 'copied-assets',
+	// `Required skills` (#533) and `Recommended MCP` (#534) are deliberately
+	// absent. Both are driven by committed repo config and both would act outside
+	// the repo — installing into `~/.claude`, enabling a code-executing MCP
+	// server. Staying out of this map keeps them out of `fix`'s footer suggestions
+	// and out of every lookup a fixer path makes; their own hints name the command
+	// a human runs by hand.
 }
 
 /**

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import packageJson from '../../../package.json' with { type: 'json' }
 import { CONFIG_SCHEMA, validateProjectConfig } from '../commands/setup-presets.js'
 import type { ProjectConfig } from '../commands/setup.js'
+import { SHIPPED_SKILLS } from '../generators/claude-skills.js'
 
 export const LOCKFILE_NAME = '.repo-tooling.json'
 // Package and bin name used before the js-tooling→repo-tooling rename (#272).
@@ -19,6 +20,28 @@ export const LEGACY_LOCKFILE_NAME = `.${LEGACY_TOOL_NAME}.json`
 // files carry no hashes, which reads as "not tracked", never as drift.
 export const LOCKFILE_VERSION = 3
 const LOCKFILE_SCHEMA_URL = 'https://rtorcato.github.io/repo-tooling/schemas/lockfile.json'
+
+/**
+ * How much of the repo's workflow assumes a recommended MCP server (#534).
+ * Signals priority to a human reading the file, and nothing more — no code
+ * branches on it beyond printing it.
+ */
+export const MCP_IMPORTANCE = ['nice-to-have', 'important', 'critical'] as const
+export type McpImportance = (typeof MCP_IMPORTANCE)[number]
+
+/**
+ * One advisory MCP entry. Deliberately has no `command`, `args` or `env`: the
+ * lockfile says *what and why*, the native `.mcp.json` says *how*, and the human
+ * says *whether*. Executable server config committed here would be an install
+ * directive, and MCP servers run code.
+ */
+export interface McpRecommendation {
+	/** The server name as it would appear in `.mcp.json`. */
+	name: string
+	importance: McpImportance
+	/** One line of free text — the thing `.mcp.json` structurally cannot say. */
+	why: string
+}
 
 export interface Lockfile {
 	$schema?: string
@@ -46,6 +69,24 @@ export interface Lockfile {
 		 */
 		agentUser?: string
 	}
+	/**
+	 * Agent skills this repo's workflows depend on (#533), from `SHIPPED_SKILLS`.
+	 * Absence of a skill fails loudly; a stale installed copy fails silently, and
+	 * staleness is the one that hurts — so `doctor` compares each listed skill's
+	 * stamped hash against what this package ships.
+	 *
+	 * Check and hint only. A committed file that directs writes into `~/` is the
+	 * shape of a supply-chain attack even when the content is benign, so nothing
+	 * here ever runs `fix claude-skills`; doctor says stale, the human runs it.
+	 */
+	requiredSkills?: string[]
+	/**
+	 * Advisory MCP metadata (#534) — never an install directive. See
+	 * `McpRecommendation`.
+	 */
+	mcp?: {
+		recommended?: McpRecommendation[]
+	}
 	writtenBy: string
 	writtenAt: string
 }
@@ -59,8 +100,9 @@ export interface Lockfile {
  * `pnpm schema:generate` and gated by tests/cli/utils/lockfile-schema.test.ts.
  *
  * A function, not a const: lockfile.ts sits in an import cycle with
- * setup-presets.ts (via the swift scaffolder), so CONFIG_SCHEMA is in its TDZ
- * while this module evaluates.
+ * setup-presets.ts (via the swift scaffolder) and with claude-skills.ts (via
+ * copy-preset.ts), so CONFIG_SCHEMA and SHIPPED_SKILLS are both in their TDZ
+ * while this module evaluates. Reading them here, at call time, is safe.
  */
 // ponytail: key sets are compiler-checked against the type; a changed field
 // *type* (string → number) still needs both lines edited by hand.
@@ -108,6 +150,46 @@ export function lockfileSchema() {
 							'Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime.',
 					},
 				} satisfies Record<keyof NonNullable<Lockfile['aiLoop']>, object>,
+			},
+			requiredSkills: {
+				type: 'array',
+				items: { type: 'string', enum: SHIPPED_SKILLS },
+				description:
+					'Agent skills this repo\'s workflows depend on. doctor compares each installed copy\'s stamped hash against the shipped one and reports a missing or stale skill — always as "not configured", never drift, because it probes the machine rather than the repo. It never runs the fixer for you.',
+			},
+			mcp: {
+				type: 'object',
+				additionalProperties: false,
+				description:
+					"Advisory MCP metadata: names, importance and reasons only, never an install directive. Executable server config belongs in the native .mcp.json, which carries Claude Code's own first-use consent prompt.",
+				properties: {
+					recommended: {
+						type: 'array',
+						description:
+							"MCP servers this repo's workflow assumes. doctor reports which of them .mcp.json does not declare, informationally — it never installs or enables one.",
+						items: {
+							type: 'object',
+							additionalProperties: false,
+							required: ['name', 'importance', 'why'],
+							properties: {
+								name: {
+									type: 'string',
+									description: 'The server name as it would appear in .mcp.json.',
+								},
+								importance: {
+									type: 'string',
+									enum: MCP_IMPORTANCE,
+									description: "How much of the repo's workflow assumes the server.",
+								},
+								why: {
+									type: 'string',
+									description:
+										'One line on what the server is for — the thing .mcp.json structurally cannot say.',
+								},
+							} satisfies Record<keyof McpRecommendation, object>,
+						},
+					},
+				} satisfies Record<keyof NonNullable<Lockfile['mcp']>, object>,
 			},
 			writtenBy: {
 				type: 'string',
@@ -184,6 +266,8 @@ export async function writeLockfile(
 		config,
 		...(carried && Object.keys(carried).length > 0 ? { assets: carried } : {}),
 		...(existing?.aiLoop ? { aiLoop: existing.aiLoop } : {}),
+		...(existing?.requiredSkills ? { requiredSkills: existing.requiredSkills } : {}),
+		...(existing?.mcp ? { mcp: existing.mcp } : {}),
 		writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
 		writtenAt: new Date().toISOString(),
 	}

--- a/tests/base/required-skills.test.ts
+++ b/tests/base/required-skills.test.ts
@@ -1,0 +1,121 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import { checkRecommendedMcp, checkRequiredSkills } from '../../src/base/checks.js'
+import { readShippedSkill, stampSkill } from '../../src/cli/generators/claude-skills.js'
+import type { McpRecommendation } from '../../src/cli/utils/lockfile.js'
+import { useTmpDir } from '../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+/** Write `content` where `claudeSkillStatus(name, dir)` will look for it. */
+async function install(dir: string, name: string, content: string): Promise<void> {
+	await fs.outputFile(join(dir, name, 'SKILL.md'), content)
+}
+
+describe('checkRequiredSkills (#533)', () => {
+	it('reports a skill that is not installed, without ever failing the exit code', async () => {
+		const r = await checkRequiredSkills(['ai-issue-loop', 'ai-workflow'], newTmpDir())
+		// The whole point of the severity rule: a contributor with no Claude
+		// installed must not fail this repo's doctor.
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('not installed: ai-issue-loop, ai-workflow')
+		expect(r.hint).toContain('fix claude-skills')
+	})
+
+	it('is ok when the installed copy is what this package ships', async () => {
+		const dir = newTmpDir()
+		const shipped = await readShippedSkill('ai-issue-loop')
+		await install(dir, 'ai-issue-loop', stampSkill(shipped.content, shipped.version))
+
+		const r = await checkRequiredSkills(['ai-issue-loop'], dir)
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('ai-issue-loop')
+	})
+
+	// The failure this check exists for: an older copy runs to completion without
+	// complaint, so nothing but a version comparison ever notices.
+	it('reports a stale copy — pristine content, older stamp', async () => {
+		const dir = newTmpDir()
+		const shipped = await readShippedSkill('ai-issue-loop')
+		await install(dir, 'ai-issue-loop', stampSkill(shipped.content, '0.0.1'))
+
+		const r = await checkRequiredSkills(['ai-issue-loop'], dir)
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('ai-issue-loop is stale')
+		expect(r.detail).toContain('0.0.1')
+		expect(r.detail).toContain(shipped.version)
+	})
+
+	// Mirrors the assets model (#428): content matching no shipped version is
+	// somebody's fork, and `fix claude-skills` refuses it without --force-skills.
+	it('reports a copy whose hash matches no shipped version as modified', async () => {
+		const dir = newTmpDir()
+		const shipped = await readShippedSkill('ai-issue-loop')
+		await install(
+			dir,
+			'ai-issue-loop',
+			`${stampSkill(shipped.content, shipped.version)}\nlocal edit\n`
+		)
+
+		const r = await checkRequiredSkills(['ai-issue-loop'], dir)
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('matches no version this package has shipped')
+		expect(r.hint).toContain('--force-skills')
+	})
+
+	it('names a skill this package does not ship instead of throwing on the missing asset', async () => {
+		const r = await checkRequiredSkills(['ai-issue-loop', 'not-a-skill'], newTmpDir())
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('not-a-skill')
+		expect(r.hint).toContain('ai-issue-loop')
+	})
+})
+
+describe('checkRecommendedMcp (#534)', () => {
+	const pencil: McpRecommendation = {
+		name: 'some-server',
+		importance: 'important',
+		why: 'edits the design files under design/',
+	}
+
+	it('quotes importance and why for a server .mcp.json does not declare', async () => {
+		const r = await checkRecommendedMcp(newTmpDir(), [pencil])
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('some-server (important) — edits the design files under design/')
+		// Advisory: the hint must not point at a fixer, because there isn't one.
+		expect(r.hint).toContain('by hand')
+		expect(r.hint).not.toContain('fix ')
+	})
+
+	it('is ok once .mcp.json declares every recommended server', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, '.mcp.json'), {
+			mcpServers: { 'some-server': { command: 'whatever' } },
+		})
+
+		const r = await checkRecommendedMcp(dir, [pencil])
+		expect(r.status).toBe('ok')
+	})
+
+	it('reports only the servers that are absent', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, '.mcp.json'), { mcpServers: { 'some-server': {} } })
+
+		const r = await checkRecommendedMcp(dir, [
+			pencil,
+			{ name: 'other-server', importance: 'critical', why: 'runs the thing' },
+		])
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('other-server (critical)')
+		expect(r.detail).not.toContain('some-server')
+	})
+
+	it('treats a malformed .mcp.json as declaring nothing rather than erroring', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, '.mcp.json'), '{ not json')
+
+		const r = await checkRecommendedMcp(dir, [pencil])
+		expect(r.status).toBe('optional-missing')
+	})
+})

--- a/tests/cli/utils/lockfile-schema.test.ts
+++ b/tests/cli/utils/lockfile-schema.test.ts
@@ -46,23 +46,34 @@ interface JsonSchema {
 	required?: readonly string[]
 	properties?: Record<string, JsonSchema>
 	additionalProperties?: boolean | JsonSchema
+	items?: JsonSchema
 }
 
 /**
  * Validate against the keyword subset lockfileSchema() actually uses: type
- * (object/string/integer/boolean), enum, minLength, required, properties and
- * additionalProperties (`false` or a schema). Returns one message per problem.
+ * (object/array/string/integer/boolean), enum, minLength, required, properties,
+ * additionalProperties (`false` or a schema) and items. Returns one message per
+ * problem.
  *
  * Hand-rolled because the repo has no JSON Schema validator, and the schema
- * leans on six keywords — not enough to justify an ajv devDependency.
+ * leans on seven keywords — not enough to justify an ajv devDependency.
  */
 // ponytail: `format: date-time` on writtenAt is not checked, and neither are
-// arrays or composition keywords — none appear in the schema. Reach for ajv the
-// day one does.
+// composition keywords — none appear in the schema. Reach for ajv the day one
+// does.
 function validate(value: unknown, schema: JsonSchema, path = '$'): string[] {
 	const errors: string[] = []
 	if (schema.enum && !schema.enum.includes(value as string)) {
 		errors.push(`${path}: ${JSON.stringify(value)} is not one of ${schema.enum.join(', ')}`)
+	}
+	if (schema.type === 'array') {
+		if (!Array.isArray(value)) return [`${path}: expected array`]
+		if (schema.items) {
+			for (const [i, item] of value.entries()) {
+				errors.push(...validate(item, schema.items, `${path}[${i}]`))
+			}
+		}
+		return errors
 	}
 	if (schema.type === 'object') {
 		if (typeof value !== 'object' || value === null || Array.isArray(value)) {
@@ -122,11 +133,28 @@ describe("this repo's own lockfile", () => {
 		expect(validate({ ...lockfile, strayKey: true }, schema)).not.toEqual([])
 		expect(validate({ ...lockfile, version: '3' }, schema)).not.toEqual([])
 		expect(validate({ ...lockfile, aiLoop: { agentUsr: 'typo' } }, schema)).not.toEqual([])
+		// #533: only skills this package ships, and only as an array.
+		expect(validate({ ...lockfile, requiredSkills: ['not-a-skill'] }, schema)).not.toEqual([])
+		expect(validate({ ...lockfile, requiredSkills: 'ai-issue-loop' }, schema)).not.toEqual([])
 		expect(
 			validate(
 				{ ...lockfile, config: { ...(lockfile.config as object), bundler: 'webpack' } },
 				schema
 			)
+		).not.toEqual([])
+	})
+
+	// #534: the schema is the whole enforcement of "advisory metadata, never an
+	// install directive" — an entry may say what and why, and may not say how.
+	it('accepts an advisory mcp.recommended entry and rejects executable config', () => {
+		const mcp = (recommended: unknown) => validate({ ...lockfile, mcp: { recommended } }, schema)
+		expect(
+			mcp([{ name: 'some-server', importance: 'important', why: 'edits the design files' }])
+		).toEqual([])
+		expect(mcp([{ name: 'some-server', importance: 'vital', why: 'x' }])).not.toEqual([])
+		expect(mcp([{ name: 'some-server', importance: 'important' }])).not.toEqual([])
+		expect(
+			mcp([{ name: 'some-server', importance: 'important', why: 'x', command: 'npx anything' }])
 		).not.toEqual([])
 	})
 })

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -195,4 +195,25 @@ describe('aiLoop settings survive a rewrite', () => {
 		await writeLockfile(dir, baseConfig())
 		expect(await fs.readJson(join(dir, '.repo-tooling.json'))).not.toHaveProperty('aiLoop')
 	})
+
+	// #533 / #534: same trap, two more hand-edited-only keys.
+	it('carries requiredSkills and mcp forward, and omits them when unset', async () => {
+		const dir = newTmpDir()
+		await writeLockfile(dir, baseConfig())
+		const file = join(dir, '.repo-tooling.json')
+		expect(await fs.readJson(file)).not.toHaveProperty('requiredSkills')
+		expect(await fs.readJson(file)).not.toHaveProperty('mcp')
+
+		const mcp = { recommended: [{ name: 's', importance: 'critical', why: 'because' }] }
+		await fs.writeJson(
+			file,
+			{ ...(await fs.readJson(file)), requiredSkills: ['ai-issue-loop'], mcp },
+			{ spaces: 2 }
+		)
+		await writeLockfile(dir, { ...baseConfig(), projectName: 'renamed' })
+
+		const after = await fs.readJson(file)
+		expect(after.requiredSkills).toEqual(['ai-issue-loop'])
+		expect(after.mcp).toEqual(mcp)
+	})
 })


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Two new `.repo-tooling.json` fields, batched because they add to the same schema block and #534 is an explicit follow-on to #533. Both are facts the repo states about itself, never instructions anything acts on.

## `requiredSkills` (#533)

Lists the shipped agent skills a repo's workflows depend on, validated against `SHIPPED_SKILLS` by the published schema and again at runtime.

It exists for **staleness**, not absence. A missing skill fails loudly the moment something reaches for it; a copy several releases behind runs to completion without complaint. The new `Required skills` check compares each listed skill's installed `SKILL.md` — its stamped `repo-tooling-hash`, honouring `--skills-dir` — against the shipped asset's, and reports missing, stale, or (mirroring the assets model) matching no shipped version at all.

Gated on `aiLoop`: that key is already the "this repo uses the pipeline" signal, so a repo without it gets no line rather than an empty one.

## `mcp.recommended` (#534)

`{ name, importance, why }` per entry, `importance` an enum of `nice-to-have | important | critical`. The `Recommended MCP` check reports which of those names the repo-scoped `.mcp.json` does not declare, and stops there. User-scoped MCP config is machine-private and is not probed.

## The line that holds for both

Neither check ever returns `drift` or `missing` — they probe the *machine*, not the repo, so a contributor without Claude installed does not fail `doctor`, and neither can fail CI.

Neither has a fixer, and neither is in `FIX_TARGETS` (there's a comment there saying why). Committed repo config that directs writes into `~/`, or that installs a code-executing MCP server, is the shape of a supply-chain attack even when the content is benign. So the MCP entry shape carries no `command`/`args`/`env`, `doctor` only ever *names* `fix claude-skills`, and the human runs it. `.mcp.json` keeps Claude Code's own first-use consent prompt.

## Dogfood

This repo now declares all four shipped skills. Running `doctor` against it immediately caught the real thing:

```
Required skills | optional-missing | ai-issue-loop is stale — installed 3.22.1, this package ships 3.25.0; ...
```

No `mcp` block is set here — the issue's `pencil` entry is an example, not a default, and this is a public library.

## Notes for review

- `lockfile.ts` now imports `SHIPPED_SKILLS`, which closes a second import cycle (via `copy-preset.ts`). Safe for the same reason the existing `CONFIG_SCHEMA` one is: it's read inside `lockfileSchema()` at call time, not at module eval. The comment there says so.
- The hand-rolled validator in `lockfile-schema.test.ts` gained `type: 'array'` + `items` — the `ponytail:` note said to reach for ajv the day arrays appeared; six lines is still cheaper than the dependency.
- `apps/docs/static/schemas/lockfile.json` is regenerated with `pnpm schema:generate`, not hand-edited.
- Verified: `check`, `typecheck`, and the full suite (67 files, 1130 passed) all green.

Closes #533
Closes #534
