### PR TITLE
feat(doctor): record deliberate deviations as declared exceptions in .repo-tooling.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Every command supports `--json` and a non-interactive mode. Combine with `--yes`
 | `setup --config <path>` | ✅ | `--dry-run` only | Scaffold with a full `ProjectConfig` JSON file. See `setup --config-schema`. |
 | `setup --config-schema` | ✅ | ✅ (JSON Schema) | Print the JSON Schema for `ProjectConfig`. Use to validate configs before scaffolding. |
 | `setup --dry-run` | ✅ | ✅ | Print resolved config + file list without writing. Pair with `--preset` or `--config`. |
-| `doctor --json` | ✅ | ✅ | Audit a project. Returns `{ directory, results: [{ check, status, detail, hint? }] }`. Status: `ok` / `drift` / `missing` / `optional-missing`. |
+| `doctor --json` | ✅ | ✅ | Audit a project. Returns `{ directory, results: [{ check, status, detail, hint? }] }`. Status: `ok` / `drift` / `missing` / `optional-missing` / `declared`. |
 | `fix --json --yes` | ✅ | ✅ | Walk every doctor finding, apply fixers. Returns `FixActionRecord[]` with `status: applied | dry-run | skipped | already-ok | unsupported`. |
 | `fix <target> --json --yes` | ✅ | ✅ | Apply one fixer. Targets from `list --json`. |
 | `fix --dry-run` | ✅ | ✅ | Print what each fixer would write without writing. Combine with `--json`. |

--- a/apps/docs/docs/guides/for-ai-agents.md
+++ b/apps/docs/docs/guides/for-ai-agents.md
@@ -82,7 +82,7 @@ npx @rtorcato/repo-tooling doctor --json -d ./existing-repo
 }
 ```
 
-Status values: `ok`, `drift` (file exists but doesn't extend the preset), `missing` (required file absent), `optional-missing` (optional convention absent).
+Status values: `ok`, `drift` (file exists but doesn't extend the preset), `missing` (required file absent), `optional-missing` (optional convention absent), `declared` (a real deviation `.repo-tooling.json` `exceptions` records on purpose, with its reason — don't fix it).
 
 ### `fix` — apply fixers for items doctor flagged
 
@@ -174,7 +174,7 @@ pnpm install
 DOCTOR=$(npx @rtorcato/repo-tooling doctor --json -d .)
 
 # 2. Parse, decide whether to fix everything or specific items
-#    (For agents: filter results where status !== "ok" && status !== "optional-missing")
+#    (For agents: filter results where status !== "ok" && status !== "optional-missing" && status !== "declared")
 
 # 3. Apply all fixable findings
 npx @rtorcato/repo-tooling fix --yes --json -d .
@@ -192,7 +192,7 @@ npx @rtorcato/repo-tooling fix dependabot --yes --json -d .
 ## Exit codes
 
 - `setup` — `0` on success, `1` on failure (validation error, write failure).
-- `doctor` — `0` if every check is `ok` or `optional-missing`; `1` if any `drift` or `missing`.
+- `doctor` — `0` if every check is `ok`, `optional-missing`, or `declared`; `1` if any `drift` or `missing`.
 - `fix` — always `0` (intent expressed; rerun `doctor` to confirm state). Unknown target → `1` with a JSON error payload.
 - `list` — `0`.
 - `copy` — `0` on success, `1` on unknown config name.

--- a/apps/docs/docs/reference/repo-tooling-json.mdx
+++ b/apps/docs/docs/reference/repo-tooling-json.mdx
@@ -130,6 +130,32 @@ carries Claude Code's own first-use consent prompt. The lockfile says *what and 
 `.mcp.json` says *how*, and you say *whether*. User-scoped MCP config is machine-private and
 is not probed at all.
 
+## `exceptions` — declared deviations
+
+A map from a `doctor` check name (the `check` string in `doctor --json` output) to the reason
+this repo deliberately deviates. The reason is **mandatory and non-empty** — the schema rejects
+an entry without one, so every deviation is argued in the PR that declares it.
+
+```json
+"exceptions": {
+  "TypeScript": "this repo is the package; the tsconfig lives at src/cli/tsconfig.json"
+}
+```
+
+Three rules keep it from becoming a mute button:
+
+- **Shown, never hidden.** The check still appears in every report, as `declared` with its
+  reason, and the summary carries a `declared: N` count. Only the exit code changes: a declared
+  exception no longer fails the run.
+- **A stale exception is itself a finding.** An entry naming a check `doctor` does not run —
+  a typo, or a check that was renamed or removed — is reported as `drift`, so it can't silently
+  do nothing (or silently stop suppressing).
+- **Per-repo by construction.** The file lives in the repo it excuses, so an exception that is
+  legitimate here cannot leak into a repo where the same finding is real.
+
+A bulk `fix` / `fix --yes` skips declared checks; a targeted `fix <target>` still applies,
+since naming the fixer is an explicit override.
+
 ## Version history
 
 | Version | Change |

--- a/apps/docs/static/schemas/lockfile.json
+++ b/apps/docs/static/schemas/lockfile.json
@@ -282,6 +282,14 @@
 				}
 			}
 		},
+		"exceptions": {
+			"type": "object",
+			"additionalProperties": {
+				"type": "string",
+				"minLength": 1
+			},
+			"description": "Declared exceptions: doctor check name → the reason this repo deliberately deviates. The reason is mandatory and non-empty — doctor shows the check as `declared` with it (never hidden) and stops failing the run for it. An entry naming a check doctor does not run is itself reported as drift."
+		},
 		"writtenBy": {
 			"type": "string",
 			"description": "Package name and version that last wrote this file."

--- a/skills/repo-tooling/SKILL.md
+++ b/skills/repo-tooling/SKILL.md
@@ -30,6 +30,8 @@ npx @rtorcato/repo-tooling doctor --json                 # confirm clean
   prompt to **No**; `--yes` is required to overwrite. Show `fix <target> --diff` first.
 - `missing` — required and absent → fix it.
 - `optional-missing` — opt-in tool not configured. Only fix if the user wants that tool.
+- `declared` — a real deviation the repo's `.repo-tooling.json` `exceptions` records on
+  purpose, with its reason. Leave it alone; it doesn't fail the run.
 
 `fix` returns `FixActionRecord[]` with `status: applied | dry-run | skipped | already-ok | unsupported`.
 

--- a/src/base/types.ts
+++ b/src/base/types.ts
@@ -1,4 +1,7 @@
-export type CheckStatus = 'ok' | 'drift' | 'missing' | 'optional-missing'
+// 'declared': the finding is real but the repo's lockfile records it as a
+// deliberate deviation with a reason (#558). Shown, never hidden — and never
+// counted toward the failing exit code.
+export type CheckStatus = 'ok' | 'drift' | 'missing' | 'optional-missing' | 'declared'
 
 export interface CheckResult {
 	check: string

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -218,6 +218,38 @@ function demoteDeclined(results: CheckResult[], lock: Lockfile | null): CheckRes
 	})
 }
 
+// Declared exceptions (#558): a failing check the lock names is reported as
+// `declared` with its reason — shown, never hidden, but no longer failing the
+// run. An exception naming a check this run doesn't know is itself drift:
+// otherwise a typo silently does nothing and a check rename silently
+// un-suppresses a finding, and both are invisible.
+function applyExceptions(results: CheckResult[], lock: Lockfile | null): CheckResult[] {
+	const exceptions = lock?.exceptions
+	if (!exceptions) return results
+	const known = new Set(results.map((r) => r.check))
+	const overlaid: CheckResult[] = results.map((r) => {
+		const reason = exceptions[r.check]
+		if (!reason || r.status === 'ok') return r
+		// Hint deliberately dropped: the deviation is declared, so "how to fix it"
+		// is exactly the noise the exception exists to retire.
+		return {
+			check: r.check,
+			status: 'declared',
+			detail: `${r.detail} — declared exception: ${reason}`,
+		}
+	})
+	for (const name of Object.keys(exceptions)) {
+		if (known.has(name)) continue
+		overlaid.push({
+			check: 'Declared exceptions',
+			status: 'drift',
+			detail: `.repo-tooling.json declares an exception for "${name}", which is not a check this run knows`,
+			hint: 'A typo, or a check that was renamed or removed — fix or delete the entry in `exceptions`',
+		})
+	}
+	return overlaid
+}
+
 /**
  * The per-language inputs the base suite needs. Git hooks, commit linting and
  * README badges are repo concerns whose *evidence* is language-shaped (#309), so
@@ -335,7 +367,7 @@ export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckR
 				skillsDir,
 			})),
 		]
-		return demoteDeclined(results, lock)
+		return applyExceptions(demoteDeclined(results, lock), lock)
 	}
 
 	// Swift suite (#286): base checks plus the module's own. Swift repos have no
@@ -360,7 +392,7 @@ export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckR
 			})),
 			...(await runSwiftChecks(targetDir)),
 		]
-		return demoteDeclined(results, lock)
+		return applyExceptions(demoteDeclined(results, lock), lock)
 	}
 
 	// Python suite (#290): same shape as Swift — base checks plus the module's
@@ -385,7 +417,7 @@ export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckR
 			})),
 			...(await runPythonChecks(targetDir)),
 		]
-		return demoteDeclined(results, lock)
+		return applyExceptions(demoteDeclined(results, lock), lock)
 	}
 
 	// Perl suite (#289): same shape as Swift and Python — base checks plus the
@@ -412,7 +444,7 @@ export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckR
 			})),
 			...(await runPerlChecks(targetDir)),
 		]
-		return demoteDeclined(results, lock)
+		return applyExceptions(demoteDeclined(results, lock), lock)
 	}
 
 	// JS suite: the module's own checks, then the shared base ones. Only the
@@ -481,7 +513,7 @@ export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckR
 		}))
 	)
 
-	return demoteDeclined(results, lock)
+	return applyExceptions(demoteDeclined(results, lock), lock)
 }
 
 const STATUS_ICONS: Record<CheckStatus, string> = {
@@ -489,6 +521,7 @@ const STATUS_ICONS: Record<CheckStatus, string> = {
 	drift: chalk.yellow('⚠️ '),
 	missing: chalk.red('❌'),
 	'optional-missing': chalk.gray('➖'),
+	declared: chalk.blue('📝'),
 }
 
 function statusLabel(status: CheckStatus): string {
@@ -501,6 +534,8 @@ function statusLabel(status: CheckStatus): string {
 			return chalk.red('missing')
 		case 'optional-missing':
 			return chalk.gray('not configured')
+		case 'declared':
+			return chalk.blue('declared')
 	}
 }
 
@@ -537,12 +572,14 @@ export function summarize(results: CheckResult[]): {
 	drift: number
 	missing: number
 	optionalMissing: number
+	declared: number
 } {
 	return {
 		ok: results.filter((r) => r.status === 'ok').length,
 		drift: results.filter((r) => r.status === 'drift').length,
 		missing: results.filter((r) => r.status === 'missing').length,
 		optionalMissing: results.filter((r) => r.status === 'optional-missing').length,
+		declared: results.filter((r) => r.status === 'declared').length,
 	}
 }
 
@@ -564,7 +601,7 @@ export async function doctorCommand(options: DoctorOptions = {}) {
 		const summary = summarize(results)
 		console.log()
 		console.log(
-			`  Summary: ${chalk.green(`${summary.ok} ok`)}, ${chalk.yellow(`${summary.drift} drift`)}, ${chalk.red(`${summary.missing} missing`)}, ${chalk.gray(`${summary.optionalMissing} not configured`)}\n`
+			`  Summary: ${chalk.green(`${summary.ok} ok`)}, ${chalk.yellow(`${summary.drift} drift`)}, ${chalk.red(`${summary.missing} missing`)}, ${chalk.gray(`${summary.optionalMissing} not configured`)}, ${chalk.blue(`${summary.declared} declared`)}\n`
 		)
 		const suggestions = nextStepSuggestions(results, await detectLanguage(dir))
 		if (suggestions.length > 0) {

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -580,7 +580,10 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 		return
 	}
 
-	const fixable = results.filter((r) => r.status !== 'ok')
+	// `declared` is a deviation the lockfile records on purpose (#558) — a bulk
+	// fix must not "repair" it. A targeted `fix <target>` still can: naming the
+	// fixer is the same explicit override the declined-in-lock path gets.
+	const fixable = results.filter((r) => r.status !== 'ok' && r.status !== 'declared')
 	if (fixable.length === 0) {
 		if (json) return emitJson(null)
 		console.log(chalk.green('\n✅ All checks pass — nothing to fix\n'))

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -87,6 +87,14 @@ export interface Lockfile {
 	mcp?: {
 		recommended?: McpRecommendation[]
 	}
+	/**
+	 * Declared exceptions (#558): doctor check name (`CheckResult.check`) → the
+	 * mandatory reason this repo deliberately deviates. doctor reports the check
+	 * as `declared` (reason shown, never hidden) and it stops failing the run.
+	 * An entry naming a check the run doesn't know is itself reported as drift,
+	 * so a typo or a renamed check can't silently mute (or un-mute) anything.
+	 */
+	exceptions?: Record<string, string>
 	writtenBy: string
 	writtenAt: string
 }
@@ -191,6 +199,12 @@ export function lockfileSchema() {
 					},
 				} satisfies Record<keyof NonNullable<Lockfile['mcp']>, object>,
 			},
+			exceptions: {
+				type: 'object',
+				additionalProperties: { type: 'string', minLength: 1 },
+				description:
+					'Declared exceptions: doctor check name → the reason this repo deliberately deviates. The reason is mandatory and non-empty — doctor shows the check as `declared` with it (never hidden) and stops failing the run for it. An entry naming a check doctor does not run is itself reported as drift.',
+			},
 			writtenBy: {
 				type: 'string',
 				description: 'Package name and version that last wrote this file.',
@@ -268,6 +282,7 @@ export async function writeLockfile(
 		...(existing?.aiLoop ? { aiLoop: existing.aiLoop } : {}),
 		...(existing?.requiredSkills ? { requiredSkills: existing.requiredSkills } : {}),
 		...(existing?.mcp ? { mcp: existing.mcp } : {}),
+		...(existing?.exceptions ? { exceptions: existing.exceptions } : {}),
 		writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
 		writtenAt: new Date().toISOString(),
 	}

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1143,7 +1143,11 @@ describe('doctor CODEOWNERS', () => {
 })
 
 describe('doctor + lockfile', () => {
-	async function writeLock(dir: string, configPatch: Record<string, unknown> = {}): Promise<void> {
+	async function writeLock(
+		dir: string,
+		configPatch: Record<string, unknown> = {},
+		extra: Record<string, unknown> = {}
+	): Promise<void> {
 		const config = {
 			projectName: 'demo',
 			projectType: 'library',
@@ -1161,6 +1165,7 @@ describe('doctor + lockfile', () => {
 		await fs.writeJson(join(dir, '.repo-tooling.json'), {
 			version: LOCKFILE_VERSION,
 			config,
+			...extra,
 			writtenBy: '@rtorcato/repo-tooling@test',
 			writtenAt: new Date().toISOString(),
 		})
@@ -1311,6 +1316,45 @@ describe('doctor + lockfile', () => {
 			expect(previous).toBe('optional-missing')
 			expect(r.status).toBe('ok')
 		}
+	})
+
+	// Declared exceptions (#558): shown with their reason, never hidden, and no
+	// longer counted toward the failing exit code.
+	it('reports an excepted failing check as declared, with its reason', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await writeLock(
+			dir,
+			{},
+			{ exceptions: { TypeScript: 'this repo is the package; tsconfig lives elsewhere' } }
+		)
+		const results = await runDoctor(dir)
+		const ts = results.find((r) => r.check === 'TypeScript')
+		expect(ts?.status).toBe('declared')
+		expect(ts?.detail).toMatch(/declared exception: this repo is the package/)
+		// The whole point: declared feeds neither `drift` nor `missing`, the two
+		// counts doctorCommand derives its exit code from.
+		expect(summarize(results).declared).toBe(1)
+		expect(results.filter((r) => r.check === 'Declared exceptions')).toEqual([])
+	})
+
+	it('leaves a passing check ok even when an exception names it', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await writeLock(dir, {}, { exceptions: { lockfile: 'not actually needed' } })
+		const results = await runDoctor(dir)
+		expect(results.find((r) => r.check === 'lockfile')?.status).toBe('ok')
+	})
+
+	it('reports an exception naming an unknown check as drift', async () => {
+		const dir = newTmpDir()
+		await seedPackageJson(dir)
+		await writeLock(dir, {}, { exceptions: { 'Type Script': 'typo of a real check' } })
+		const results = await runDoctor(dir)
+		const stale = results.find((r) => r.check === 'Declared exceptions')
+		expect(stale?.status).toBe('drift')
+		expect(stale?.detail).toMatch(/"Type Script"/)
+		expect(stale?.hint).toMatch(/renamed or removed/)
 	})
 })
 

--- a/tests/cli/utils/lockfile-schema.test.ts
+++ b/tests/cli/utils/lockfile-schema.test.ts
@@ -157,4 +157,14 @@ describe("this repo's own lockfile", () => {
 			mcp([{ name: 'some-server', importance: 'important', why: 'x', command: 'npx anything' }])
 		).not.toEqual([])
 	})
+
+	// #558: an exception's reason is mandatory and non-empty — the schema is what
+	// enforces "every deviation is argued", so an empty reason must not validate.
+	it('accepts a declared exception with a reason and rejects one without', () => {
+		const exceptions = (value: unknown) => validate({ ...lockfile, exceptions: value }, schema)
+		expect(exceptions({ TypeScript: 'this repo is the package itself' })).toEqual([])
+		expect(exceptions({ TypeScript: '' })).not.toEqual([])
+		expect(exceptions({ TypeScript: true })).not.toEqual([])
+		expect(exceptions(['TypeScript'])).not.toEqual([])
+	})
 })


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Closes #558

## What

A repo can now declare a deliberate deviation in `.repo-tooling.json`:

```json
"exceptions": {
  "TypeScript": "this repo is the package; the tsconfig lives at src/cli/tsconfig.json"
}
```

Keyed by the doctor check name (`CheckResult.check`), with a mandatory non-empty reason enforced by the published JSON Schema (`minLength: 1`).

## Behaviour

- **Shown, never hidden**: the check reports as a new `declared` status with its reason appended to the detail, and the summary line carries a `declared: N` count.
- **Exit code**: `declared` feeds neither `drift` nor `missing`, so a declared exception no longer fails the run.
- **A stale exception is itself a finding**: an entry naming a check the run doesn't know (typo, renamed, removed) is reported as `drift` under a `Declared exceptions` check, so it can't silently do nothing or silently un-suppress.
- **Bulk `fix` skips declared checks**; a targeted `fix <target>` still applies (naming the fixer is the same explicit override the declined-in-lock path gets).
- Published lockfile schema regenerated (`pnpm schema:generate`); the #552 self-validation test stays green.

## Reviewer's four cases (all tested)

1. No exception → behaves exactly as today (existing suite, unchanged).
2. Exception on a failing check → `declared` with reason, not counted toward the failing exit code.
3. Exception naming an unknown check → reported as drift.
4. Schema rejects a missing/empty/non-string reason.

Deliberately out of scope per the issue: expiry, and dogfooding exceptions into this repo's own `.repo-tooling.json` (a one-line follow-up once this lands).
