### PR TITLE
feat(doctor): scan recent commit history for placeholder or generated author emails

### DIFF
--- a/src/base/git-identity.ts
+++ b/src/base/git-identity.ts
@@ -183,3 +183,79 @@ export async function checkGitIdentity(dir: string, exec?: GitExec): Promise<Che
 		hint: HINT,
 	}
 }
+
+const HISTORY_CHECK = 'Git author history'
+
+/**
+ * Bounded so doctor stays cheap on every invocation; the output always names
+ * how many commits were actually examined so "0 found" is never read as "all
+ * history is clean".
+ */
+export const HISTORY_SCAN_LIMIT = 200
+
+/** How many offending commits to name; the count carries the rest. */
+const HISTORY_SAMPLE = 3
+
+const HISTORY_HINT =
+	'These commits are already made: the address can never be verified as a secondary email, so they cannot be re-linked to a forge account without a history rewrite (#327). Fix the identity going forward (see the Git identity check) and treat the history as recorded loss.'
+
+/**
+ * The retrospective half of `checkGitIdentity` (#557): that check reads the
+ * identity the *next* commit will use, this one scans recent history for
+ * commits already made with a bad one. Same classifier — `classifyGitEmail` —
+ * so the two can never drift. Same STATUS reasoning too: history is not
+ * something the repo's author can fix by editing the repo, so a finding is
+ * `optional-missing`, never `drift`/`missing`, and the exit code is untouched.
+ * Detection only — there is deliberately no fixer, because the only "fix" is a
+ * history rewrite no tool should offer unprompted.
+ */
+export async function checkGitIdentityHistory(dir: string, exec?: GitExec): Promise<CheckResult> {
+	if (!(await fs.pathExists(path.join(dir, '.git')))) {
+		return { check: HISTORY_CHECK, status: 'ok', detail: 'not a git repository' }
+	}
+	if (process.env.CI) {
+		return { check: HISTORY_CHECK, status: 'ok', detail: 'skipped on CI' }
+	}
+
+	const git: GitExec = exec ?? ((args) => realGitExec(args, dir))
+	// A shallow clone has almost no history; scanning its stub and reporting
+	// "0 found" would be a false all-clear.
+	if ((await git(['rev-parse', '--is-shallow-repository'])) === 'true') {
+		return {
+			check: HISTORY_CHECK,
+			status: 'ok',
+			detail: 'shallow clone — commit history is not available to scan',
+		}
+	}
+	// %h %ae: abbreviated hash + author email, one commit per line.
+	const log = await git(['log', `-${HISTORY_SCAN_LIMIT}`, '--format=%h %ae'])
+	if (log === null || log === '') {
+		return { check: HISTORY_CHECK, status: 'ok', detail: 'no commits to scan' }
+	}
+	const commits = log.split('\n').map((line) => {
+		const sp = line.indexOf(' ')
+		return { hash: line.slice(0, sp), email: line.slice(sp + 1) }
+	})
+	const bad = commits.filter(({ email }) => {
+		const verdict = classifyGitEmail(email)
+		return verdict === 'placeholder' || verdict === 'generated'
+	})
+	const scanned = `the last ${commits.length} commit${commits.length === 1 ? '' : 's'}`
+	if (bad.length === 0) {
+		return {
+			check: HISTORY_CHECK,
+			status: 'ok',
+			detail: `no placeholder or machine-derived author emails in ${scanned}`,
+		}
+	}
+	const sample = bad
+		.slice(0, HISTORY_SAMPLE)
+		.map(({ hash, email }) => `${hash} (${email})`)
+		.join(', ')
+	return {
+		check: HISTORY_CHECK,
+		status: 'optional-missing',
+		detail: `${bad.length} of ${scanned} carry a placeholder or machine-derived author email — e.g. ${sample}`,
+		hint: HISTORY_HINT,
+	}
+}

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -16,7 +16,7 @@ import { checkAgentUser } from '../../base/agent-user.js'
 import { checkGitHubSettings } from '../../base/github-settings.js'
 import { checkLoopLabels } from '../../base/labels.js'
 import { checkMilestones } from '../../base/milestones.js'
-import { checkGitIdentity } from '../../base/git-identity.js'
+import { checkGitIdentity, checkGitIdentityHistory } from '../../base/git-identity.js'
 import { checkCopiedAssets } from '../utils/copied-assets.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
@@ -294,6 +294,8 @@ async function runBaseChecks(
 	results.push(await checkCopiedAssets(dir))
 	results.push(await checkNestedLanguages(dir, opts.language))
 	results.push(await checkGitIdentity(dir))
+	// The retrospective half (#557): commits already made with a bad identity.
+	results.push(await checkGitIdentityHistory(dir))
 	results.push(await checkEditorConfig(dir))
 	results.push(await checkFile(dir, COMMITLINT_FILE_CHECK))
 	if (opts.hooks) {

--- a/tests/base/git-identity.test.ts
+++ b/tests/base/git-identity.test.ts
@@ -1,7 +1,13 @@
 import { join } from 'node:path'
 import fs from 'fs-extra'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { checkGitIdentity, classifyGitEmail, type GitExec } from '../../src/base/git-identity.js'
+import {
+	checkGitIdentity,
+	checkGitIdentityHistory,
+	classifyGitEmail,
+	type GitExec,
+	HISTORY_SCAN_LIMIT,
+} from '../../src/base/git-identity.js'
 import { useTmpDir } from '../helpers/tmp-dir.js'
 
 const newTmpDir = useTmpDir()
@@ -102,5 +108,68 @@ describe('checkGitIdentity', () => {
 		const r = await checkGitIdentity(gitRepo(), emailIs('a@example.com'))
 		expect(r.status).toBe('ok')
 		expect(r.detail).toContain('CI')
+	})
+})
+
+describe('checkGitIdentityHistory', () => {
+	/** Fake git: answers the shallow probe and the bounded log, nothing else. */
+	const history = (opts: { shallow?: boolean; log?: string | null }): GitExec => {
+		return async (args) => {
+			if (args[0] === 'rev-parse') return opts.shallow ? 'true' : 'false'
+			if (args[0] === 'log') {
+				expect(args).toContain(`-${HISTORY_SCAN_LIMIT}`)
+				return opts.log ?? null
+			}
+			return null
+		}
+	}
+
+	it('passes a history of real addresses, naming what was scanned', async () => {
+		const r = await checkGitIdentityHistory(
+			gitRepo(),
+			history({ log: 'abc1234 rtorcato@me.com\ndef5678 1234+user@users.noreply.github.com' })
+		)
+		expect(r.status).toBe('ok')
+		// "0 found" must say how far it looked, or it reads as "all history clean".
+		expect(r.detail).toContain('last 2 commits')
+	})
+
+	it('reports a placeholder-authored commit in range without failing the run', async () => {
+		const r = await checkGitIdentityHistory(
+			gitRepo(),
+			history({
+				log: 'abc1234 rtorcato@me.com\ndef5678 test@example.com\n0123abc a@host.local',
+			})
+		)
+		// Never drift/missing: history is not fixable by editing the repo.
+		expect(r.status).toBe('optional-missing')
+		expect(r.detail).toContain('2 of the last 3 commits')
+		expect(r.detail).toContain('def5678 (test@example.com)')
+		// The hint must be honest that only a history rewrite could fix these.
+		expect(r.hint).toContain('history rewrite')
+	})
+
+	it('says so on a shallow clone rather than reporting a false all-clear', async () => {
+		const r = await checkGitIdentityHistory(gitRepo(), history({ shallow: true }))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('shallow clone')
+	})
+
+	it('handles a repo with no commits yet', async () => {
+		const r = await checkGitIdentityHistory(gitRepo(), history({ log: null }))
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('no commits')
+	})
+
+	it('skips on CI without consulting git', async () => {
+		process.env.CI = 'true'
+		let called = false
+		const spy: GitExec = async () => {
+			called = true
+			return null
+		}
+		const r = await checkGitIdentityHistory(gitRepo(), spy)
+		expect(r.status).toBe('ok')
+		expect(called).toBe(false)
 	})
 })

--- a/tests/languages/perl/fixers.test.ts
+++ b/tests/languages/perl/fixers.test.ts
@@ -75,6 +75,7 @@ describe('perl fixers', () => {
 			'lockfile',
 			'Monorepo',
 			'Git identity',
+			'Git author history',
 			'AI loop agent',
 			'README badges',
 			'Coverage upload',

--- a/tests/languages/python/fixers.test.ts
+++ b/tests/languages/python/fixers.test.ts
@@ -72,6 +72,7 @@ describe('python fixers', () => {
 			'lockfile',
 			'Monorepo',
 			'Git identity',
+			'Git author history',
 			'AI loop agent',
 			'README badges',
 			'Coverage upload',

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -76,6 +76,7 @@ describe('swift fixers', () => {
 			'language',
 			'Monorepo',
 			'Git identity',
+			'Git author history',
 			'AI loop agent',
 			'README badges',
 			'Coverage upload',


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Closes #557

`checkGitIdentity` reads only the identity the *next* commit will use; commits already made with a bad one were invisible to doctor. This adds the retrospective half as a new base check, **Git author history**:

- Scans the last 200 commits' author emails through the **same** exported `classifyGitEmail` — no second classifier to drift.
- A finding is `optional-missing`, never `drift`/`missing` — exit code untouched, and skipped on CI, matching the existing check's reasoning.
- The output always names how many commits were scanned, so "0 found" cannot be read as "all history clean".
- Reports the count plus a 3-commit sample; the hint is honest that these are unfixable without a history rewrite.
- A shallow clone is detected via `git rev-parse --is-shallow-repository` and reported as unscannable rather than a false all-clear.
- Detection only: no fixer, deliberately absent from `FIX_TARGETS`. Composes with #561's declared exceptions automatically via its check name.

Tests cover the issue's three reviewer-checkable cases (clean history, placeholder in range, shallow clone) plus empty-history and CI-skip.
