### PR TITLE
feat(lockfile): split .repo-tooling.json into record and rules subtrees (v4)

### DIFF
--- a/.repo-tooling.json
+++ b/.repo-tooling.json
@@ -1,39 +1,43 @@
 {
   "$schema": "https://rtorcato.github.io/repo-tooling/schemas/lockfile.json",
-  "version": 3,
-  "config": {
-    "language": "js",
-    "projectName": "@rtorcato/repo-tooling",
-    "projectType": "library",
-    "typescript": {
-      "enabled": true,
-      "config": "base"
+  "version": 4,
+  "record": {
+    "config": {
+      "language": "js",
+      "projectName": "@rtorcato/repo-tooling",
+      "projectType": "library",
+      "typescript": {
+        "enabled": true,
+        "config": "base"
+      },
+      "linting": {
+        "tool": "biome",
+        "eslintConfig": "base"
+      },
+      "formatting": {
+        "tool": "biome"
+      },
+      "testing": {
+        "framework": "vitest",
+        "environment": "node"
+      },
+      "gitHooks": true,
+      "commitLint": true,
+      "semanticRelease": true,
+      "securityAutomation": true,
+      "bundler": "none"
     },
-    "linting": {
-      "tool": "biome",
-      "eslintConfig": "base"
+    "assets": {
+      "docusaurus-sync-changelog": "de05aecb200657c2023dc3540dbdd2f9f2f17f1027e67a06266119d12cc05fea",
+      "docusaurus-theme": "3ead9ab407c2676bc404f7df552977a0fb0412b0f0d0bcde223c271a51860005"
     },
-    "formatting": {
-      "tool": "biome"
-    },
-    "testing": {
-      "framework": "vitest",
-      "environment": "node"
-    },
-    "gitHooks": true,
-    "commitLint": true,
-    "semanticRelease": true,
-    "securityAutomation": true,
-    "bundler": "none"
+    "writtenBy": "@rtorcato/repo-tooling@3.11.0",
+    "writtenAt": "2026-08-27T00:34:30.140Z"
   },
-  "assets": {
-    "docusaurus-sync-changelog": "de05aecb200657c2023dc3540dbdd2f9f2f17f1027e67a06266119d12cc05fea",
-    "docusaurus-theme": "3ead9ab407c2676bc404f7df552977a0fb0412b0f0d0bcde223c271a51860005"
-  },
-  "aiLoop": {
-    "agentUser": "rtorcato-bot"
-  },
-  "requiredSkills": ["ai-issue-loop", "ai-workflow", "ai-issue", "ai-loop-status"],
-  "writtenBy": "@rtorcato/repo-tooling@3.11.0",
-  "writtenAt": "2026-08-26T14:58:22.032Z"
+  "rules": {
+    "aiLoop": {
+      "agentUser": "rtorcato-bot"
+    },
+    "requiredSkills": ["ai-issue-loop", "ai-workflow", "ai-issue", "ai-loop-status"]
+  }
 }

--- a/apps/docs/docs/guides/ai-setup.md
+++ b/apps/docs/docs/guides/ai-setup.md
@@ -71,16 +71,19 @@ auto-writes this same install section into your `README.md` — one
 `package.json`'s `repository`. It's a merge-safe delimited block, so your own
 README content is never touched, and repos without a `skills/` dir get nothing.
 
-## `aiLoop`: the agent account for the issue loop
+## `rules.aiLoop`: the agent account for the issue loop
 
 If you run the `ai-issue-loop` / `ai-workflow` skills, `.repo-tooling.json` can
 name the account that in-flight work is assigned to, so `assignee` says whose
-turn it is:
+turn it is. Like everything under `rules`, it's yours to edit by hand — the
+tool carries the subtree forward verbatim and never stamps it:
 
 ```json
 {
-  "aiLoop": {
-    "agentUser": "your-bot-account"
+  "rules": {
+    "aiLoop": {
+      "agentUser": "your-bot-account"
+    }
   }
 }
 ```
@@ -98,13 +101,15 @@ against your repo's own remote (`gh api repos/{owner}/{repo}/assignees/<user>`)
 and reports drift when it isn't assignable. Absent field ⇒ `ok`, not
 applicable.
 
-## `requiredSkills`: catching a *stale* skill, not just a missing one
+## `rules.requiredSkills`: catching a *stale* skill, not just a missing one
 
 A repo whose workflows depend on the shipped skills can say so:
 
 ```json
 {
-  "requiredSkills": ["ai-issue-loop", "ai-workflow", "ai-issue", "ai-loop-status"]
+  "rules": {
+    "requiredSkills": ["ai-issue-loop", "ai-workflow", "ai-issue", "ai-loop-status"]
+  }
 }
 ```
 
@@ -121,22 +126,24 @@ Two rules keep the field safe to commit:
 - **It never fails your build.** The check probes your machine, not the repo, so
   it reports "not configured" and never `drift` or `missing` — a contributor
   without Claude installed doesn't fail this repo's `doctor`. It's also skipped
-  entirely unless the file has an `aiLoop` key.
+  entirely unless the file has a `rules.aiLoop` key.
 - **It only ever hints.** `doctor` names `fix claude-skills`; running it is
   yours. Committed repo config that directs writes into your home directory is
   the shape of a supply-chain attack even when the content is benign.
 
-## `mcp.recommended`: names and reasons, never an install directive
+## `rules.mcp.recommended`: names and reasons, never an install directive
 
 The same file can name the MCP servers a repo's workflow assumes — and only
 name them:
 
 ```json
 {
-  "mcp": {
-    "recommended": [
-      { "name": "some-server", "importance": "important", "why": "edits the design files under design/" }
-    ]
+  "rules": {
+    "mcp": {
+      "recommended": [
+        { "name": "some-server", "importance": "important", "why": "edits the design files under design/" }
+      ]
+    }
   }
 }
 ```

--- a/apps/docs/docs/guides/for-ai-agents.md
+++ b/apps/docs/docs/guides/for-ai-agents.md
@@ -82,7 +82,7 @@ npx @rtorcato/repo-tooling doctor --json -d ./existing-repo
 }
 ```
 
-Status values: `ok`, `drift` (file exists but doesn't extend the preset), `missing` (required file absent), `optional-missing` (optional convention absent), `declared` (a real deviation `.repo-tooling.json` `exceptions` records on purpose, with its reason — don't fix it).
+Status values: `ok`, `drift` (file exists but doesn't extend the preset), `missing` (required file absent), `optional-missing` (optional convention absent), `declared` (a real deviation `.repo-tooling.json` `rules.exceptions` records on purpose, with its reason — don't fix it).
 
 ### `fix` — apply fixers for items doctor flagged
 

--- a/apps/docs/docs/reference/repo-tooling-json.mdx
+++ b/apps/docs/docs/reference/repo-tooling-json.mdx
@@ -37,8 +37,16 @@ export const Fields = ({ schema }) => (
 
 <p>{lockfileSchema.description}</p>
 
-`setup` creates it, `fix` keeps it current, and `doctor` reads it to know what the repo opted into.
-Commit it — it is the repo's memory of its own tooling choices.
+The file is **two documents sharing one name**, split by who writes them:
+
+- **`record`** — the tool-written half. `setup` creates it, `fix` keeps it current, and its
+  `writtenBy`/`writtenAt` stamps are provenance claims about exactly this subtree.
+- **`rules`** — the human-written half: the repo's stated intent (`aiLoop`, `requiredSkills`,
+  `mcp`, `exceptions`), edited by hand and reviewed in PRs. The tool carries it forward
+  verbatim on every write and never stamps it.
+
+`doctor` reads both. Commit the file — it is the repo's memory of its own tooling choices
+*and* its standing rules.
 
 ## Editor validation
 
@@ -46,7 +54,7 @@ Every written file carries a `$schema` pointer, so editors that understand JSON 
 (VS Code out of the box) validate, autocomplete, and show these descriptions inline:
 
 <pre>
-<code>{JSON.stringify({ $schema: lockfileSchema.$id, version: 3 }, null, 2).replace('\n}', ',\n  ...\n}')}</code>
+<code>{JSON.stringify({ $schema: lockfileSchema.$id, version: 4 }, null, 2).replace('\n}', ',\n  ...\n}')}</code>
 </pre>
 
 The schema itself is published at <a href={lockfileSchema.$id}>{lockfileSchema.$id}</a>. It is
@@ -59,27 +67,38 @@ is what your editor enforces.
 <Fields schema={lockfileSchema} />
 
 Unknown fields are rejected (`additionalProperties: false`): the CLI rewrites the file from
-scratch on every save, so any key it doesn't know is a key it would silently drop.
+scratch on every save, so any key it doesn't know is a key it would silently drop — except
+`rules`, which is carried forward verbatim.
 
-## `config` — the ProjectConfig
+## `record` — what the tool wrote
+
+<Fields schema={lockfileSchema.properties.record} />
+
+### `record.config` — the ProjectConfig
 
 The full setup configuration, identical to what `setup --config` accepts
 (its standalone schema is published at
 <a href="https://rtorcato.github.io/repo-tooling/schemas/project-config.json">/schemas/project-config.json</a>,
 printable with `setup --config-schema`):
 
-<Fields schema={lockfileSchema.properties.config} />
+<Fields schema={lockfileSchema.properties.record.properties.config} />
 
 The `object`-typed fields above (`typescript`, `linting`, `formatting`, `testing`) are small
 enum-valued records — see the schema for their exact shapes.
 
-## `aiLoop` — ai-issue-loop settings
+## `rules` — what the humans wrote
 
-<Fields schema={lockfileSchema.properties.aiLoop} />
+Everything under `rules` is edited by hand and reviewed in PRs. It is deliberately outside
+the `writtenBy`/`writtenAt` stamps: the tool never writes here, so it never claims authorship
+of a rule — a hand edit to `rules` leaves the record's provenance true.
+
+### `rules.aiLoop` — ai-issue-loop settings
+
+<Fields schema={lockfileSchema.properties.rules.properties.aiLoop} />
 
 See the [AI issue loop guide](../guides/ai-issue-loop.md) for how this is used.
 
-## `requiredSkills` — agent skills this repo depends on
+### `rules.requiredSkills` — agent skills this repo depends on
 
 A list of the skills this package ships (`ai-issue-loop`, `ai-workflow`, `ai-issue`,
 `ai-loop-status`) that the repo's workflows assume. It exists for **staleness**, not absence:
@@ -87,7 +106,9 @@ a skill that isn't installed fails loudly the moment something reaches for it, w
 three releases behind runs to completion without complaint.
 
 ```json
-"requiredSkills": ["ai-issue-loop", "ai-workflow"]
+"rules": {
+  "requiredSkills": ["ai-issue-loop", "ai-workflow"]
+}
 ```
 
 `doctor` compares each listed skill's installed `SKILL.md` — its stamped `repo-tooling-hash`,
@@ -99,25 +120,27 @@ Two rules make it safe to commit:
 - **Never `drift`, never `missing`.** The check probes your machine, not the repo, so a
   contributor with no Claude installed must not fail its `doctor`. It only ever reports
   "not configured", which leaves the exit code alone. It is also skipped entirely unless the
-  file has an `aiLoop` key — that key is already the "this repo uses the pipeline" signal.
+  file has a `rules.aiLoop` key — that key is already the "this repo uses the pipeline" signal.
 - **Check and hint only.** `doctor` names `fix claude-skills`; it never runs it. Committed
   repo config that directs writes into your home directory is the shape of a supply-chain
   attack even when the content is benign, so that step stays a human's.
 
-## `mcp` — recommended MCP servers
+### `rules.mcp` — recommended MCP servers
 
 Advisory metadata about the MCP servers the repo's workflow assumes. **Never an install
 directive**: an entry may say *what* and *why*, and may not say *how*.
 
 ```json
-"mcp": {
-  "recommended": [
-    { "name": "some-server", "importance": "important", "why": "edits the design files under design/" }
-  ]
+"rules": {
+  "mcp": {
+    "recommended": [
+      { "name": "some-server", "importance": "important", "why": "edits the design files under design/" }
+    ]
+  }
 }
 ```
 
-<Fields schema={lockfileSchema.properties.mcp.properties.recommended.items} />
+<Fields schema={lockfileSchema.properties.rules.properties.mcp.properties.recommended.items} />
 
 `importance` is one of `nice-to-have`, `important`, `critical` — it signals how much of the
 workflow assumes the server, and nothing more. `why` is the one line that `.mcp.json`
@@ -130,15 +153,17 @@ carries Claude Code's own first-use consent prompt. The lockfile says *what and 
 `.mcp.json` says *how*, and you say *whether*. User-scoped MCP config is machine-private and
 is not probed at all.
 
-## `exceptions` — declared deviations
+### `rules.exceptions` — declared deviations
 
 A map from a `doctor` check name (the `check` string in `doctor --json` output) to the reason
 this repo deliberately deviates. The reason is **mandatory and non-empty** — the schema rejects
 an entry without one, so every deviation is argued in the PR that declares it.
 
 ```json
-"exceptions": {
-  "TypeScript": "this repo is the package; the tsconfig lives at src/cli/tsconfig.json"
+"rules": {
+  "exceptions": {
+    "TypeScript": "this repo is the package; the tsconfig lives at src/cli/tsconfig.json"
+  }
 }
 ```
 
@@ -163,6 +188,7 @@ since naming the fixer is an explicit override.
 | 1 | Initial format. |
 | 2 | Added `config.language` (multi-language seam). Older files migrate to `js` on read. |
 | 3 | Added `assets` — pristine hashes of copied presets, so `doctor` can tell a local fork from a stale copy. |
+| 4 | Split the file into `record` (tool-written, stamped) and `rules` (human-written, unstamped) subtrees. Nothing renamed or dropped — the flat v3 fields moved into them. |
 
 Older files are migrated in memory on read and rewritten at the current version on the next save.
 The pre-rename `.js-tooling.json` is still read as a fallback and replaced on the next write.

--- a/apps/docs/static/schemas/lockfile.json
+++ b/apps/docs/static/schemas/lockfile.json
@@ -2,14 +2,12 @@
 	"$schema": "https://json-schema.org/draft/2020-12/schema",
 	"$id": "https://rtorcato.github.io/repo-tooling/schemas/lockfile.json",
 	"title": "Lockfile",
-	"description": ".repo-tooling.json — the committed record of what @rtorcato/repo-tooling set up in this repo. Written by `setup` and `fix`, read by `doctor`.",
+	"description": ".repo-tooling.json — two documents sharing one file: `record` is written by @rtorcato/repo-tooling (`setup` and `fix`) and stamped with provenance; `rules` is written by humans, reviewed in PRs, and never stamped. Both are read by `doctor`.",
 	"type": "object",
 	"additionalProperties": false,
 	"required": [
 		"version",
-		"config",
-		"writtenBy",
-		"writtenAt"
+		"record"
 	],
 	"properties": {
 		"$schema": {
@@ -18,286 +16,305 @@
 		},
 		"version": {
 			"type": "integer",
-			"description": "Lockfile format version (current: 3). v2 added config.language, v3 added assets; older files are migrated on read."
+			"description": "Lockfile format version (current: 4). v2 added config.language, v3 added assets, v4 split the file into record/rules subtrees; older files are migrated on read."
 		},
-		"config": {
-			"title": "ProjectConfig",
-			"description": "The resolved setup configuration this repo was scaffolded or audited with.",
+		"record": {
 			"type": "object",
 			"additionalProperties": false,
 			"required": [
-				"projectName",
-				"projectType",
-				"typescript",
-				"linting",
-				"formatting",
-				"testing",
-				"gitHooks",
-				"commitLint",
-				"semanticRelease",
-				"securityAutomation",
-				"bundler"
+				"config",
+				"writtenBy",
+				"writtenAt"
 			],
+			"description": "The tool-written record of what setup/fix last did. Only the tool writes here — the writtenBy/writtenAt stamps are provenance claims about exactly this subtree.",
 			"properties": {
-				"projectName": {
-					"type": "string",
-					"minLength": 1
-				},
-				"language": {
-					"type": "string",
-					"enum": [
-						"js",
-						"swift",
-						"perl",
-						"python"
-					]
-				},
-				"projectType": {
-					"type": "string",
-					"enum": [
-						"library",
-						"web-app",
-						"node-api",
-						"nextjs-app",
-						"react-app"
-					]
-				},
-				"typescript": {
+				"config": {
+					"title": "ProjectConfig",
+					"description": "The resolved setup configuration this repo was scaffolded or audited with.",
 					"type": "object",
 					"additionalProperties": false,
 					"required": [
-						"enabled",
-						"config"
+						"projectName",
+						"projectType",
+						"typescript",
+						"linting",
+						"formatting",
+						"testing",
+						"gitHooks",
+						"commitLint",
+						"semanticRelease",
+						"securityAutomation",
+						"bundler"
 					],
 					"properties": {
-						"enabled": {
+						"projectName": {
+							"type": "string",
+							"minLength": 1
+						},
+						"language": {
+							"type": "string",
+							"enum": [
+								"js",
+								"swift",
+								"perl",
+								"python"
+							]
+						},
+						"projectType": {
+							"type": "string",
+							"enum": [
+								"library",
+								"web-app",
+								"node-api",
+								"nextjs-app",
+								"react-app"
+							]
+						},
+						"typescript": {
+							"type": "object",
+							"additionalProperties": false,
+							"required": [
+								"enabled",
+								"config"
+							],
+							"properties": {
+								"enabled": {
+									"type": "boolean"
+								},
+								"config": {
+									"type": "string",
+									"enum": [
+										"base",
+										"react",
+										"next",
+										"node",
+										"express"
+									]
+								}
+							}
+						},
+						"linting": {
+							"type": "object",
+							"additionalProperties": false,
+							"required": [
+								"tool"
+							],
+							"properties": {
+								"tool": {
+									"type": "string",
+									"enum": [
+										"biome",
+										"eslint",
+										"both",
+										"none"
+									]
+								},
+								"eslintConfig": {
+									"type": "string",
+									"enum": [
+										"base",
+										"nextjs"
+									]
+								}
+							}
+						},
+						"formatting": {
+							"type": "object",
+							"additionalProperties": false,
+							"required": [
+								"tool"
+							],
+							"properties": {
+								"tool": {
+									"type": "string",
+									"enum": [
+										"biome",
+										"prettier",
+										"none"
+									]
+								}
+							}
+						},
+						"testing": {
+							"type": "object",
+							"additionalProperties": false,
+							"required": [
+								"framework"
+							],
+							"properties": {
+								"framework": {
+									"type": "string",
+									"enum": [
+										"vitest",
+										"jest",
+										"playwright",
+										"cypress",
+										"none"
+									]
+								},
+								"environment": {
+									"type": "string",
+									"enum": [
+										"node",
+										"browser",
+										"both"
+									]
+								}
+							}
+						},
+						"gitHooks": {
 							"type": "boolean"
 						},
-						"config": {
+						"commitLint": {
+							"type": "boolean"
+						},
+						"semanticRelease": {
+							"type": "boolean"
+						},
+						"changesets": {
+							"type": "boolean"
+						},
+						"releasePlease": {
+							"type": "boolean"
+						},
+						"oxlint": {
+							"type": "boolean"
+						},
+						"securityAutomation": {
+							"type": "boolean"
+						},
+						"bundler": {
 							"type": "string",
 							"enum": [
-								"base",
-								"react",
-								"next",
-								"node",
-								"express"
-							]
-						}
-					}
-				},
-				"linting": {
-					"type": "object",
-					"additionalProperties": false,
-					"required": [
-						"tool"
-					],
-					"properties": {
-						"tool": {
-							"type": "string",
-							"enum": [
-								"biome",
-								"eslint",
-								"both",
+								"tsup",
+								"esbuild",
+								"rollup",
+								"rolldown",
+								"vite",
 								"none"
 							]
 						},
-						"eslintConfig": {
-							"type": "string",
-							"enum": [
-								"base",
-								"nextjs"
-							]
-						}
-					}
-				},
-				"formatting": {
-					"type": "object",
-					"additionalProperties": false,
-					"required": [
-						"tool"
-					],
-					"properties": {
-						"tool": {
-							"type": "string",
-							"enum": [
-								"biome",
-								"prettier",
-								"none"
-							]
-						}
-					}
-				},
-				"testing": {
-					"type": "object",
-					"additionalProperties": false,
-					"required": [
-						"framework"
-					],
-					"properties": {
-						"framework": {
-							"type": "string",
-							"enum": [
-								"vitest",
-								"jest",
-								"playwright",
-								"cypress",
-								"none"
-							]
+						"treeshakeCheck": {
+							"type": "boolean"
 						},
-						"environment": {
-							"type": "string",
-							"enum": [
-								"node",
-								"browser",
-								"both"
-							]
+						"publint": {
+							"type": "boolean"
+						},
+						"badges": {
+							"type": "boolean"
+						},
+						"aiSetup": {
+							"type": "boolean"
+						},
+						"turborepo": {
+							"type": "boolean"
+						},
+						"nx": {
+							"type": "boolean"
+						},
+						"tailwind": {
+							"type": "boolean"
+						},
+						"bun": {
+							"type": "boolean"
 						}
 					}
 				},
-				"gitHooks": {
-					"type": "boolean"
+				"assets": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string"
+					},
+					"description": "Preset name → sha256 of the asset's pristine content at copy time. Lets doctor tell a deliberate local fork (file differs from this hash) from a copy the package has since moved past (file still matches, shipped asset doesn't). A preset with no entry is untracked, never drifted."
 				},
-				"commitLint": {
-					"type": "boolean"
-				},
-				"semanticRelease": {
-					"type": "boolean"
-				},
-				"changesets": {
-					"type": "boolean"
-				},
-				"releasePlease": {
-					"type": "boolean"
-				},
-				"oxlint": {
-					"type": "boolean"
-				},
-				"securityAutomation": {
-					"type": "boolean"
-				},
-				"bundler": {
+				"writtenBy": {
 					"type": "string",
-					"enum": [
-						"tsup",
-						"esbuild",
-						"rollup",
-						"rolldown",
-						"vite",
-						"none"
-					]
+					"description": "Package name and version that last wrote the record subtree."
 				},
-				"treeshakeCheck": {
-					"type": "boolean"
-				},
-				"publint": {
-					"type": "boolean"
-				},
-				"badges": {
-					"type": "boolean"
-				},
-				"aiSetup": {
-					"type": "boolean"
-				},
-				"turborepo": {
-					"type": "boolean"
-				},
-				"nx": {
-					"type": "boolean"
-				},
-				"tailwind": {
-					"type": "boolean"
-				},
-				"bun": {
-					"type": "boolean"
+				"writtenAt": {
+					"type": "string",
+					"format": "date-time",
+					"description": "ISO 8601 timestamp of the last record write."
 				}
 			}
 		},
-		"assets": {
-			"type": "object",
-			"additionalProperties": {
-				"type": "string"
-			},
-			"description": "Preset name → sha256 of the asset's pristine content at copy time. Lets doctor tell a deliberate local fork (file differs from this hash) from a copy the package has since moved past (file still matches, shipped asset doesn't). A preset with no entry is untracked, never drifted."
-		},
-		"aiLoop": {
+		"rules": {
 			"type": "object",
 			"additionalProperties": false,
-			"description": "Settings for the ai-issue-loop skills. Repo-scoped on purpose: committed here they travel with the repo and survive a new laptop.",
+			"description": "The human-written ruleset: the repo's stated intent, edited by hand and reviewed in PRs. The tool carries it forward verbatim on every write and never stamps it.",
 			"properties": {
-				"agentUser": {
-					"type": "string",
-					"description": "Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime."
-				}
-			}
-		},
-		"requiredSkills": {
-			"type": "array",
-			"items": {
-				"type": "string",
-				"enum": [
-					"ai-issue-loop",
-					"ai-workflow",
-					"ai-issue",
-					"ai-loop-status"
-				]
-			},
-			"description": "Agent skills this repo's workflows depend on. doctor compares each installed copy's stamped hash against the shipped one and reports a missing or stale skill — always as \"not configured\", never drift, because it probes the machine rather than the repo. It never runs the fixer for you."
-		},
-		"mcp": {
-			"type": "object",
-			"additionalProperties": false,
-			"description": "Advisory MCP metadata: names, importance and reasons only, never an install directive. Executable server config belongs in the native .mcp.json, which carries Claude Code's own first-use consent prompt.",
-			"properties": {
-				"recommended": {
+				"aiLoop": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "Settings for the ai-issue-loop skills. Repo-scoped on purpose: committed here they travel with the repo and survive a new laptop.",
+					"properties": {
+						"agentUser": {
+							"type": "string",
+							"description": "Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime."
+						}
+					}
+				},
+				"requiredSkills": {
 					"type": "array",
-					"description": "MCP servers this repo's workflow assumes. doctor reports which of them .mcp.json does not declare, informationally — it never installs or enables one.",
 					"items": {
-						"type": "object",
-						"additionalProperties": false,
-						"required": [
-							"name",
-							"importance",
-							"why"
-						],
-						"properties": {
-							"name": {
-								"type": "string",
-								"description": "The server name as it would appear in .mcp.json."
-							},
-							"importance": {
-								"type": "string",
-								"enum": [
-									"nice-to-have",
-									"important",
-									"critical"
+						"type": "string",
+						"enum": [
+							"ai-issue-loop",
+							"ai-workflow",
+							"ai-issue",
+							"ai-loop-status"
+						]
+					},
+					"description": "Agent skills this repo's workflows depend on. doctor compares each installed copy's stamped hash against the shipped one and reports a missing or stale skill — always as \"not configured\", never drift, because it probes the machine rather than the repo. It never runs the fixer for you."
+				},
+				"mcp": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "Advisory MCP metadata: names, importance and reasons only, never an install directive. Executable server config belongs in the native .mcp.json, which carries Claude Code's own first-use consent prompt.",
+					"properties": {
+						"recommended": {
+							"type": "array",
+							"description": "MCP servers this repo's workflow assumes. doctor reports which of them .mcp.json does not declare, informationally — it never installs or enables one.",
+							"items": {
+								"type": "object",
+								"additionalProperties": false,
+								"required": [
+									"name",
+									"importance",
+									"why"
 								],
-								"description": "How much of the repo's workflow assumes the server."
-							},
-							"why": {
-								"type": "string",
-								"description": "One line on what the server is for — the thing .mcp.json structurally cannot say."
+								"properties": {
+									"name": {
+										"type": "string",
+										"description": "The server name as it would appear in .mcp.json."
+									},
+									"importance": {
+										"type": "string",
+										"enum": [
+											"nice-to-have",
+											"important",
+											"critical"
+										],
+										"description": "How much of the repo's workflow assumes the server."
+									},
+									"why": {
+										"type": "string",
+										"description": "One line on what the server is for — the thing .mcp.json structurally cannot say."
+									}
+								}
 							}
 						}
 					}
+				},
+				"exceptions": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "string",
+						"minLength": 1
+					},
+					"description": "Declared exceptions: doctor check name → the reason this repo deliberately deviates. The reason is mandatory and non-empty — doctor shows the check as `declared` with it (never hidden) and stops failing the run for it. An entry naming a check doctor does not run is itself reported as drift."
 				}
 			}
-		},
-		"exceptions": {
-			"type": "object",
-			"additionalProperties": {
-				"type": "string",
-				"minLength": 1
-			},
-			"description": "Declared exceptions: doctor check name → the reason this repo deliberately deviates. The reason is mandatory and non-empty — doctor shows the check as `declared` with it (never hidden) and stops failing the run for it. An entry naming a check doctor does not run is itself reported as drift."
-		},
-		"writtenBy": {
-			"type": "string",
-			"description": "Package name and version that last wrote this file."
-		},
-		"writtenAt": {
-			"type": "string",
-			"format": "date-time",
-			"description": "ISO 8601 timestamp of the last write."
 		}
 	}
 }

--- a/skills/ai-issue-loop/SKILL.md
+++ b/skills/ai-issue-loop/SKILL.md
@@ -219,8 +219,9 @@ behaves exactly as it did before this existed.
 
 ```bash
 # Repo config first — committed, so it travels with the repo and survives a new
-# machine. `AI_LOOP_AGENT` overrides it for a repo with no lockfile.
-AGENT_USER="${AI_LOOP_AGENT:-$(jq -r '.aiLoop.agentUser // empty' "$ROOT/.repo-tooling.json" 2>/dev/null)}"
+# machine. `AI_LOOP_AGENT` overrides it for a repo with no lockfile. The flat
+# `.aiLoop` fallback reads a pre-v4 lockfile that hasn't migrated yet (#559).
+AGENT_USER="${AI_LOOP_AGENT:-$(jq -r '.rules.aiLoop.agentUser // .aiLoop.agentUser // empty' "$ROOT/.repo-tooling.json" 2>/dev/null)}"
 # A typo would fail every `gh` edit for the whole tick, so prove it is assignable
 # once, here. 204 = yes, 404 = no; push access is what qualifies an account.
 [ -n "$AGENT_USER" ] && { gh api "repos/$OWNER_REPO/assignees/$AGENT_USER" --silent 2>/dev/null || {
@@ -235,7 +236,7 @@ being that assignment quietly stops. In `.repo-tooling.json` it is committed,
 reviewable, and carried forward by `fix lockfile`:
 
 ```json
-{ "aiLoop": { "agentUser": "your-bot-account" } }
+{ "rules": { "aiLoop": { "agentUser": "your-bot-account" } } }
 ```
 
 Every later use is `${AGENT_USER:+--add-assignee "$AGENT_USER"}`, which expands

--- a/skills/ai-workflow/SKILL.md
+++ b/skills/ai-workflow/SKILL.md
@@ -53,7 +53,7 @@ git -C "$ROOT" fetch --prune
 # Optional: the account in-flight work is assigned to, so `assignee` says whose
 # turn it is. Unset → nothing below assigns, exactly as before. See the
 # ai-issue-loop skill's Pass 0 for why this is repo config rather than an env var.
-AGENT_USER="${AI_LOOP_AGENT:-$(jq -r '.aiLoop.agentUser // empty' "$ROOT/.repo-tooling.json" 2>/dev/null)}"
+AGENT_USER="${AI_LOOP_AGENT:-$(jq -r '.rules.aiLoop.agentUser // .aiLoop.agentUser // empty' "$ROOT/.repo-tooling.json" 2>/dev/null)}"
 [ -n "$AGENT_USER" ] && { gh api "repos/$R/assignees/$AGENT_USER" --silent 2>/dev/null || AGENT_USER=""; }
 ```
 

--- a/skills/repo-tooling/SKILL.md
+++ b/skills/repo-tooling/SKILL.md
@@ -30,7 +30,7 @@ npx @rtorcato/repo-tooling doctor --json                 # confirm clean
   prompt to **No**; `--yes` is required to overwrite. Show `fix <target> --diff` first.
 - `missing` — required and absent → fix it.
 - `optional-missing` — opt-in tool not configured. Only fix if the user wants that tool.
-- `declared` — a real deviation the repo's `.repo-tooling.json` `exceptions` records on
+- `declared` — a real deviation the repo's `.repo-tooling.json` `rules.exceptions` records on
   purpose, with its reason. Leave it alone; it doesn't fail the run.
 
 `fix` returns `FixActionRecord[]` with `status: applied | dry-run | skipped | already-ok | unsupported`.

--- a/src/base/agent-user.ts
+++ b/src/base/agent-user.ts
@@ -41,15 +41,15 @@ export async function checkAgentUser(
 		return {
 			check: CHECK,
 			status: 'ok',
-			detail: 'not applicable — no aiLoop.agentUser in .repo-tooling.json',
+			detail: 'not applicable — no rules.aiLoop.agentUser in .repo-tooling.json',
 		}
 	}
 	if (!LOGIN.test(agentUser)) {
 		return {
 			check: CHECK,
 			status: 'drift',
-			detail: `aiLoop.agentUser "${agentUser}" is not a valid GitHub login`,
-			hint: 'Fix or remove aiLoop.agentUser in .repo-tooling.json',
+			detail: `rules.aiLoop.agentUser "${agentUser}" is not a valid GitHub login`,
+			hint: 'Fix or remove rules.aiLoop.agentUser in .repo-tooling.json',
 		}
 	}
 	// Cheap gate first: no .git → never spawn (keeps tmp-dir doctor runs offline).
@@ -61,15 +61,15 @@ export async function checkAgentUser(
 		return {
 			check: CHECK,
 			status: 'ok',
-			detail: `aiLoop.agentUser "${agentUser}" is an assignable collaborator`,
+			detail: `rules.aiLoop.agentUser "${agentUser}" is an assignable collaborator`,
 		}
 	}
 	if (/HTTP 404/.test(r.stderr)) {
 		return {
 			check: CHECK,
 			status: 'drift',
-			detail: `aiLoop.agentUser "${agentUser}" is not an assignable collaborator — the loop skills will silently assign nothing`,
-			hint: `Add the account as a collaborator (\`gh api -X PUT repos/{owner}/{repo}/collaborators/${agentUser}\`) or remove aiLoop.agentUser from .repo-tooling.json`,
+			detail: `rules.aiLoop.agentUser "${agentUser}" is not an assignable collaborator — the loop skills will silently assign nothing`,
+			hint: `Add the account as a collaborator (\`gh api -X PUT repos/{owner}/{repo}/collaborators/${agentUser}\`) or remove rules.aiLoop.agentUser from .repo-tooling.json`,
 		}
 	}
 	// Offline, unauthenticated, or gh missing — not evidence of drift.

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -199,7 +199,9 @@ function checkLockfile(lock: Lockfile | null): CheckResult {
 	return {
 		check: 'lockfile',
 		status: 'ok',
-		detail: `.repo-tooling.json v${lock.version} (written by ${lock.writtenBy})`,
+		// The stamp only ever describes the tool-written `record` subtree — the
+		// human-written `rules` half is deliberately unstamped (#559).
+		detail: `.repo-tooling.json v${lock.version} (record written by ${lock.record.writtenBy})`,
 	}
 }
 
@@ -224,7 +226,7 @@ function demoteDeclined(results: CheckResult[], lock: Lockfile | null): CheckRes
 // otherwise a typo silently does nothing and a check rename silently
 // un-suppresses a finding, and both are invisible.
 function applyExceptions(results: CheckResult[], lock: Lockfile | null): CheckResult[] {
-	const exceptions = lock?.exceptions
+	const exceptions = lock?.rules?.exceptions
 	if (!exceptions) return results
 	const known = new Set(results.map((r) => r.check))
 	const overlaid: CheckResult[] = results.map((r) => {
@@ -313,7 +315,7 @@ async function runBaseChecks(
 	// ai-issue-loop label colours/descriptions (#446) — same seam, same self-skip.
 	results.push(await checkLoopLabels(dir))
 	// aiLoop.agentUser assignability (#530) — same seam, same self-skip.
-	results.push(await checkAgentUser(dir, lock?.aiLoop?.agentUser))
+	results.push(await checkAgentUser(dir, lock?.rules?.aiLoop?.agentUser))
 	results.push(await checkGitLabCI(dir))
 	results.push(await checkCodeowners(dir))
 	results.push(await checkCommunityHealth(dir))
@@ -323,13 +325,13 @@ async function runBaseChecks(
 	results.push(await checkClaudeSkills(opts.skillsDir))
 	// #533: gated on `aiLoop`, which is already the "this repo uses the pipeline"
 	// signal, so a repo that doesn't gets no line at all rather than an empty one.
-	if (lock?.aiLoop && lock.requiredSkills?.length) {
-		results.push(await checkRequiredSkills(lock.requiredSkills, opts.skillsDir))
+	if (lock?.rules?.aiLoop && lock.rules.requiredSkills?.length) {
+		results.push(await checkRequiredSkills(lock.rules.requiredSkills, opts.skillsDir))
 	}
 	// #534: advisory. Absent `mcp.recommended` means the repo has nothing to say
 	// about MCP, which is not a finding.
-	if (lock?.mcp?.recommended?.length) {
-		results.push(await checkRecommendedMcp(dir, lock.mcp.recommended))
+	if (lock?.rules?.mcp?.recommended?.length) {
+		results.push(await checkRecommendedMcp(dir, lock.rules.mcp.recommended))
 	}
 	results.push(await checkReadmeBadges(dir, opts.badges.audience, opts.badges.fixTarget))
 	results.push(await checkCoverageUpload(dir))

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -132,7 +132,7 @@ export function getFixTargetForCheck(checkName: string, language?: string): stri
  */
 export function declinedInLock(lock: Lockfile | null, checkName: string): boolean {
 	if (!lock) return false
-	const c = lock.config
+	const c = lock.record.config
 	switch (checkName) {
 		case 'TypeScript':
 			return c.typescript?.enabled === false
@@ -200,7 +200,7 @@ export function lockfilePatchForTarget(
 	target: string,
 	lock: Lockfile
 ): Partial<ProjectConfig> | null {
-	const c = lock.config
+	const c = lock.record.config
 	switch (target) {
 		case 'biome':
 			if (c.linting.tool === 'biome' || c.linting.tool === 'both') return null

--- a/src/cli/commands/fix.ts
+++ b/src/cli/commands/fix.ts
@@ -401,7 +401,7 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 			}
 			process.exit(1)
 		}
-		const files = computeFileList(resyncLock.config)
+		const files = computeFileList(resyncLock.record.config)
 		if (!silent) {
 			console.log(
 				chalk.cyan(`\n🔄 Resync from ${LOCKFILE_NAME} (${files.length} files in scope)\n`)
@@ -432,8 +432,8 @@ export async function fixCommand(target: string | undefined, options: FixOptions
 				return
 			}
 		}
-		await generateConfigs(resyncLock.config, targetDir)
-		await writeLockfile(targetDir, resyncLock.config)
+		await generateConfigs(resyncLock.record.config, targetDir)
+		await writeLockfile(targetDir, resyncLock.record.config)
 		if (json) {
 			console.log(
 				JSON.stringify({ directory: targetDir, mode: 'resync', dryRun: false, files }, null, 2)

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -153,11 +153,13 @@ async function resolveConfig(options: SetupOptions): Promise<ProjectConfig | nul
 		const raw = await fs.readJson(configPath)
 		// Accept the `.repo-tooling.json` lockfile itself as the config source, so a
 		// repo needs only one file: the lockfile already embeds the full
-		// ProjectConfig under `config`. Unwrap it here rather than requiring a
-		// separate hand-authored config file (#271).
+		// ProjectConfig — under `record.config` since v4, top-level `config` before
+		// (#559). Unwrap it here rather than requiring a separate config file (#271).
 		const candidate =
-			typeof raw === 'object' && raw !== null && 'config' in raw && 'version' in raw
-				? (raw as { config: unknown }).config
+			typeof raw === 'object' && raw !== null && 'version' in raw
+				? ((raw as { record?: { config?: unknown } }).record?.config ??
+					(raw as { config?: unknown }).config ??
+					raw)
 				: raw
 		const { valid, errors } = validateProjectConfig(candidate)
 		if (!valid) {

--- a/src/cli/utils/copied-assets.ts
+++ b/src/cli/utils/copied-assets.ts
@@ -44,7 +44,7 @@ export async function classifyCopiedAssets(dir: string): Promise<CopiedAssetStat
 		const current = await hashFile(path.join(dir, preset.target))
 		if (current === null) continue
 
-		const recorded = lock?.assets?.[name]
+		const recorded = lock?.record.assets?.[name]
 		// Unmodified since the copy, so whether it's stale is purely a question of
 		// what this package ships now. A source we can't read (shouldn't happen)
 		// falls back to the recorded hash — "no news", not drift.

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -18,7 +18,10 @@ export const LEGACY_LOCKFILE_NAME = `.${LEGACY_TOOL_NAME}.json`
 // migrated to v2 on read, defaulting language to 'js'.
 // v3 added `assets` — the pristine hash of each copied preset (#428). Older
 // files carry no hashes, which reads as "not tracked", never as drift.
-export const LOCKFILE_VERSION = 3
+// v4 split the file into two subtrees with documented ownership (#559):
+// `record` (tool-written, stamped) and `rules` (human-written, unstamped).
+// Nothing was renamed or dropped — the flat v3 fields just moved into them.
+export const LOCKFILE_VERSION = 4
 const LOCKFILE_SCHEMA_URL = 'https://rtorcato.github.io/repo-tooling/schemas/lockfile.json'
 
 /**
@@ -43,9 +46,13 @@ export interface McpRecommendation {
 	why: string
 }
 
-export interface Lockfile {
-	$schema?: string
-	version: number
+/**
+ * The tool-written half (#559): what `setup`/`fix` last did, stamped with the
+ * version that did it. Only the tool writes here, so `writtenBy`/`writtenAt`
+ * are provenance claims about exactly this subtree and nothing else — a hand
+ * edit to `rules` no longer makes the stamp a lie.
+ */
+export interface LockfileRecord {
 	config: ProjectConfig
 	/**
 	 * Preset name → sha256 of the asset's *pristine* content at copy time (#428).
@@ -55,6 +62,16 @@ export interface Lockfile {
 	 * entry here is simply untracked; absence is not evidence of drift.
 	 */
 	assets?: Record<string, string>
+	writtenBy: string
+	writtenAt: string
+}
+
+/**
+ * The human-written half (#559): the repo's stated rules, edited by hand and
+ * reviewed in PRs. Deliberately unstamped — the tool carries this subtree
+ * forward verbatim on every write and never claims authorship of it.
+ */
+export interface LockfileRules {
 	/**
 	 * Settings for the `ai-issue-loop` skills (#524). Repo-scoped on purpose: the
 	 * agent account is a collaborator on *this* repo, so a machine-wide env var
@@ -95,8 +112,13 @@ export interface Lockfile {
 	 * so a typo or a renamed check can't silently mute (or un-mute) anything.
 	 */
 	exceptions?: Record<string, string>
-	writtenBy: string
-	writtenAt: string
+}
+
+export interface Lockfile {
+	$schema?: string
+	version: number
+	record: LockfileRecord
+	rules?: LockfileRules
 }
 
 /**
@@ -123,10 +145,10 @@ export function lockfileSchema() {
 		$schema: 'https://json-schema.org/draft/2020-12/schema',
 		$id: LOCKFILE_SCHEMA_URL,
 		title: 'Lockfile',
-		description: `${LOCKFILE_NAME} — the committed record of what @rtorcato/repo-tooling set up in this repo. Written by \`setup\` and \`fix\`, read by \`doctor\`.`,
+		description: `${LOCKFILE_NAME} — two documents sharing one file: \`record\` is written by @rtorcato/repo-tooling (\`setup\` and \`fix\`) and stamped with provenance; \`rules\` is written by humans, reviewed in PRs, and never stamped. Both are read by \`doctor\`.`,
 		type: 'object',
 		additionalProperties: false,
-		required: ['version', 'config', 'writtenBy', 'writtenAt'],
+		required: ['version', 'record'],
 		properties: {
 			$schema: {
 				type: 'string',
@@ -134,88 +156,120 @@ export function lockfileSchema() {
 			},
 			version: {
 				type: 'integer',
-				description: `Lockfile format version (current: ${LOCKFILE_VERSION}). v2 added config.language, v3 added assets; older files are migrated on read.`,
+				description: `Lockfile format version (current: ${LOCKFILE_VERSION}). v2 added config.language, v3 added assets, v4 split the file into record/rules subtrees; older files are migrated on read.`,
 			},
-			config: {
-				...projectConfigSchema,
-				description: 'The resolved setup configuration this repo was scaffolded or audited with.',
-			},
-			assets: {
-				type: 'object',
-				additionalProperties: { type: 'string' },
-				description:
-					"Preset name → sha256 of the asset's pristine content at copy time. Lets doctor tell a deliberate local fork (file differs from this hash) from a copy the package has since moved past (file still matches, shipped asset doesn't). A preset with no entry is untracked, never drifted.",
-			},
-			aiLoop: {
+			record: {
 				type: 'object',
 				additionalProperties: false,
+				required: ['config', 'writtenBy', 'writtenAt'],
 				description:
-					'Settings for the ai-issue-loop skills. Repo-scoped on purpose: committed here they travel with the repo and survive a new laptop.',
+					'The tool-written record of what setup/fix last did. Only the tool writes here — the writtenBy/writtenAt stamps are provenance claims about exactly this subtree.',
 				properties: {
-					agentUser: {
+					config: {
+						...projectConfigSchema,
+						description:
+							'The resolved setup configuration this repo was scaffolded or audited with.',
+					},
+					assets: {
+						type: 'object',
+						additionalProperties: { type: 'string' },
+						description:
+							"Preset name → sha256 of the asset's pristine content at copy time. Lets doctor tell a deliberate local fork (file differs from this hash) from a copy the package has since moved past (file still matches, shipped asset doesn't). A preset with no entry is untracked, never drifted.",
+					},
+					writtenBy: {
 						type: 'string',
-						description:
-							'Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime.',
+						description: 'Package name and version that last wrote the record subtree.',
 					},
-				} satisfies Record<keyof NonNullable<Lockfile['aiLoop']>, object>,
+					writtenAt: {
+						type: 'string',
+						format: 'date-time',
+						description: 'ISO 8601 timestamp of the last record write.',
+					},
+				} satisfies Record<keyof LockfileRecord, object>,
 			},
-			requiredSkills: {
-				type: 'array',
-				items: { type: 'string', enum: SHIPPED_SKILLS },
-				description:
-					'Agent skills this repo\'s workflows depend on. doctor compares each installed copy\'s stamped hash against the shipped one and reports a missing or stale skill — always as "not configured", never drift, because it probes the machine rather than the repo. It never runs the fixer for you.',
-			},
-			mcp: {
+			rules: {
 				type: 'object',
 				additionalProperties: false,
 				description:
-					"Advisory MCP metadata: names, importance and reasons only, never an install directive. Executable server config belongs in the native .mcp.json, which carries Claude Code's own first-use consent prompt.",
+					"The human-written ruleset: the repo's stated intent, edited by hand and reviewed in PRs. The tool carries it forward verbatim on every write and never stamps it.",
 				properties: {
-					recommended: {
-						type: 'array',
+					aiLoop: {
+						type: 'object',
+						additionalProperties: false,
 						description:
-							"MCP servers this repo's workflow assumes. doctor reports which of them .mcp.json does not declare, informationally — it never installs or enables one.",
-						items: {
-							type: 'object',
-							additionalProperties: false,
-							required: ['name', 'importance', 'why'],
-							properties: {
-								name: {
-									type: 'string',
-									description: 'The server name as it would appear in .mcp.json.',
-								},
-								importance: {
-									type: 'string',
-									enum: MCP_IMPORTANCE,
-									description: "How much of the repo's workflow assumes the server.",
-								},
-								why: {
-									type: 'string',
-									description:
-										'One line on what the server is for — the thing .mcp.json structurally cannot say.',
-								},
-							} satisfies Record<keyof McpRecommendation, object>,
-						},
+							'Settings for the ai-issue-loop skills. Repo-scoped on purpose: committed here they travel with the repo and survive a new laptop.',
+						properties: {
+							agentUser: {
+								type: 'string',
+								description:
+									'Login that in-flight work is assigned to, so `assignee` says whose turn it is. Must be an assignable collaborator; the skills verify that at runtime.',
+							},
+						} satisfies Record<keyof NonNullable<LockfileRules['aiLoop']>, object>,
 					},
-				} satisfies Record<keyof NonNullable<Lockfile['mcp']>, object>,
-			},
-			exceptions: {
-				type: 'object',
-				additionalProperties: { type: 'string', minLength: 1 },
-				description:
-					'Declared exceptions: doctor check name → the reason this repo deliberately deviates. The reason is mandatory and non-empty — doctor shows the check as `declared` with it (never hidden) and stops failing the run for it. An entry naming a check doctor does not run is itself reported as drift.',
-			},
-			writtenBy: {
-				type: 'string',
-				description: 'Package name and version that last wrote this file.',
-			},
-			writtenAt: {
-				type: 'string',
-				format: 'date-time',
-				description: 'ISO 8601 timestamp of the last write.',
+					requiredSkills: {
+						type: 'array',
+						items: { type: 'string', enum: SHIPPED_SKILLS },
+						description:
+							'Agent skills this repo\'s workflows depend on. doctor compares each installed copy\'s stamped hash against the shipped one and reports a missing or stale skill — always as "not configured", never drift, because it probes the machine rather than the repo. It never runs the fixer for you.',
+					},
+					mcp: {
+						type: 'object',
+						additionalProperties: false,
+						description:
+							"Advisory MCP metadata: names, importance and reasons only, never an install directive. Executable server config belongs in the native .mcp.json, which carries Claude Code's own first-use consent prompt.",
+						properties: {
+							recommended: {
+								type: 'array',
+								description:
+									"MCP servers this repo's workflow assumes. doctor reports which of them .mcp.json does not declare, informationally — it never installs or enables one.",
+								items: {
+									type: 'object',
+									additionalProperties: false,
+									required: ['name', 'importance', 'why'],
+									properties: {
+										name: {
+											type: 'string',
+											description: 'The server name as it would appear in .mcp.json.',
+										},
+										importance: {
+											type: 'string',
+											enum: MCP_IMPORTANCE,
+											description: "How much of the repo's workflow assumes the server.",
+										},
+										why: {
+											type: 'string',
+											description:
+												'One line on what the server is for — the thing .mcp.json structurally cannot say.',
+										},
+									} satisfies Record<keyof McpRecommendation, object>,
+								},
+							},
+						} satisfies Record<keyof NonNullable<LockfileRules['mcp']>, object>,
+					},
+					exceptions: {
+						type: 'object',
+						additionalProperties: { type: 'string', minLength: 1 },
+						description:
+							'Declared exceptions: doctor check name → the reason this repo deliberately deviates. The reason is mandatory and non-empty — doctor shows the check as `declared` with it (never hidden) and stops failing the run for it. An entry naming a check doctor does not run is itself reported as drift.',
+					},
+				} satisfies Record<keyof LockfileRules, object>,
 			},
 		} satisfies Record<keyof Lockfile, object>,
 	}
+}
+
+/** The flat v1–v3 layout: every field at the top level, no subtrees (#559). */
+interface FlatLockfile {
+	$schema?: string
+	version: number
+	config: ProjectConfig
+	assets?: Record<string, string>
+	aiLoop?: LockfileRules['aiLoop']
+	requiredSkills?: string[]
+	mcp?: LockfileRules['mcp']
+	exceptions?: Record<string, string>
+	writtenBy: string
+	writtenAt: string
 }
 
 /**
@@ -223,14 +277,30 @@ export function lockfileSchema() {
  * current version, so a newer-than-supported file is left as-is for
  * checkLockfile to flag. `version` stays at the on-disk value — bumping it here
  * hid every older file from doctor's older-than-current check (#531); the write
- * path stamps LOCKFILE_VERSION anyway, so the file is v3 next time it's saved.
+ * path stamps LOCKFILE_VERSION anyway, so the file is v4 next time it's saved.
+ *
+ * v1–v3 are flat: nest the fields into record/rules (#559), default language
+ * to 'js' (v1, #140) and assets to {} (pre-v3, #428). Nothing is renamed.
  */
-function migrate(lock: Lockfile): Lockfile {
-	if (lock.version >= LOCKFILE_VERSION) return lock
+function migrate(raw: Record<string, unknown>): Lockfile {
+	if ((raw.version as number) >= LOCKFILE_VERSION) return raw as unknown as Lockfile
+	const flat = raw as unknown as FlatLockfile
+	const rules: LockfileRules = {
+		...(flat.aiLoop ? { aiLoop: flat.aiLoop } : {}),
+		...(flat.requiredSkills ? { requiredSkills: flat.requiredSkills } : {}),
+		...(flat.mcp ? { mcp: flat.mcp } : {}),
+		...(flat.exceptions ? { exceptions: flat.exceptions } : {}),
+	}
 	return {
-		...lock,
-		config: { language: 'js', ...lock.config },
-		assets: lock.assets ?? {},
+		...(flat.$schema ? { $schema: flat.$schema } : {}),
+		version: flat.version,
+		record: {
+			config: { language: 'js', ...flat.config },
+			assets: flat.assets ?? {},
+			writtenBy: flat.writtenBy,
+			writtenAt: flat.writtenAt,
+		},
+		...(Object.keys(rules).length > 0 ? { rules } : {}),
 	}
 }
 
@@ -247,8 +317,13 @@ export async function readLockfile(dir: string): Promise<Lockfile | null> {
 		if (typeof raw !== 'object' || raw === null) return null
 		const obj = raw as Record<string, unknown>
 		if (typeof obj.version !== 'number') return null
-		if (typeof obj.config !== 'object' || obj.config === null) return null
-		return migrate(obj as unknown as Lockfile)
+		// v4+ keeps config under `record`; v1–v3 keep it at the top level (#559).
+		const config =
+			obj.version >= LOCKFILE_VERSION
+				? (obj.record as Record<string, unknown> | undefined)?.config
+				: obj.config
+		if (typeof config !== 'object' || config === null) return null
+		return migrate(obj)
 	} catch {
 		return null
 	}
@@ -270,21 +345,21 @@ export async function writeLockfile(
 	}
 	// One read, because everything not rebuilt from `config` has to be carried
 	// forward explicitly — this object is constructed from scratch, so any key
-	// not named here is dropped by the next `fix lockfile`.
+	// not named here is dropped by the next `fix lockfile`. `rules` rides along
+	// verbatim: it is the human's subtree, and the stamp says nothing about it.
 	const existing = await readLockfile(dir)
-	const carried = assets ?? existing?.assets
+	const carried = assets ?? existing?.record.assets
 	const filepath = path.join(dir, LOCKFILE_NAME)
 	const lockfile: Lockfile = {
 		$schema: LOCKFILE_SCHEMA_URL,
 		version: LOCKFILE_VERSION,
-		config,
-		...(carried && Object.keys(carried).length > 0 ? { assets: carried } : {}),
-		...(existing?.aiLoop ? { aiLoop: existing.aiLoop } : {}),
-		...(existing?.requiredSkills ? { requiredSkills: existing.requiredSkills } : {}),
-		...(existing?.mcp ? { mcp: existing.mcp } : {}),
-		...(existing?.exceptions ? { exceptions: existing.exceptions } : {}),
-		writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
-		writtenAt: new Date().toISOString(),
+		record: {
+			config,
+			...(carried && Object.keys(carried).length > 0 ? { assets: carried } : {}),
+			writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
+			writtenAt: new Date().toISOString(),
+		},
+		...(existing?.rules ? { rules: existing.rules } : {}),
 	}
 	await fs.writeJson(filepath, lockfile, { spaces: 2 })
 	// Migrate a pre-rename repo to the new name: now that the canonical file is
@@ -304,7 +379,7 @@ export async function updateLockfileConfig(
 ): Promise<boolean> {
 	const existing = await readLockfile(dir)
 	if (!existing) return false
-	const merged: ProjectConfig = { ...existing.config, ...patch }
+	const merged: ProjectConfig = { ...existing.record.config, ...patch }
 	await writeLockfile(dir, merged)
 	return true
 }
@@ -318,6 +393,6 @@ export async function updateLockfileConfig(
 export async function recordAssetHash(dir: string, preset: string, hash: string): Promise<boolean> {
 	const existing = await readLockfile(dir)
 	if (!existing) return false
-	await writeLockfile(dir, existing.config, { ...existing.assets, [preset]: hash })
+	await writeLockfile(dir, existing.record.config, { ...existing.record.assets, [preset]: hash })
 	return true
 }

--- a/src/languages/js/fixers.ts
+++ b/src/languages/js/fixers.ts
@@ -939,10 +939,10 @@ export const FIXERS: Fixer[] = [
 				console.error(chalk.yellow('   no package.json found — skipping'))
 				return { filesWritten: [] }
 			}
-			const config = lock ? lock.config : inferProjectConfig(pkg as Record<string, unknown>)
+			const config = lock ? lock.record.config : inferProjectConfig(pkg as Record<string, unknown>)
 			// Recorded hashes win: they capture the pristine content at copy time,
 			// which a byte-match against today's shipped asset can only approximate.
-			const assets = { ...(await identifiablePresetHashes(targetDir)), ...lock?.assets }
+			const assets = { ...(await identifiablePresetHashes(targetDir)), ...lock?.record.assets }
 			await writeLockfile(targetDir, config, assets)
 			return { filesWritten: [LOCKFILE_NAME] }
 		},

--- a/tests/cli/commands/doctor.test.ts
+++ b/tests/cli/commands/doctor.test.ts
@@ -1146,7 +1146,7 @@ describe('doctor + lockfile', () => {
 	async function writeLock(
 		dir: string,
 		configPatch: Record<string, unknown> = {},
-		extra: Record<string, unknown> = {}
+		rules: Record<string, unknown> = {}
 	): Promise<void> {
 		const config = {
 			projectName: 'demo',
@@ -1164,10 +1164,12 @@ describe('doctor + lockfile', () => {
 		}
 		await fs.writeJson(join(dir, '.repo-tooling.json'), {
 			version: LOCKFILE_VERSION,
-			config,
-			...extra,
-			writtenBy: '@rtorcato/repo-tooling@test',
-			writtenAt: new Date().toISOString(),
+			record: {
+				config,
+				writtenBy: '@rtorcato/repo-tooling@test',
+				writtenAt: new Date().toISOString(),
+			},
+			...(Object.keys(rules).length > 0 ? { rules } : {}),
 		})
 	}
 
@@ -1222,21 +1224,23 @@ describe('doctor + lockfile', () => {
 		await seedPackageJson(dir)
 		await fs.writeJson(join(dir, '.repo-tooling.json'), {
 			version: 99,
-			config: {
-				projectName: 'demo',
-				projectType: 'library',
-				typescript: { enabled: true, config: 'base' },
-				linting: { tool: 'biome' },
-				formatting: { tool: 'biome' },
-				testing: { framework: 'vitest' },
-				gitHooks: true,
-				commitLint: true,
-				semanticRelease: true,
-				securityAutomation: true,
-				bundler: 'tsup',
+			record: {
+				config: {
+					projectName: 'demo',
+					projectType: 'library',
+					typescript: { enabled: true, config: 'base' },
+					linting: { tool: 'biome' },
+					formatting: { tool: 'biome' },
+					testing: { framework: 'vitest' },
+					gitHooks: true,
+					commitLint: true,
+					semanticRelease: true,
+					securityAutomation: true,
+					bundler: 'tsup',
+				},
+				writtenBy: 'future',
+				writtenAt: new Date().toISOString(),
 			},
-			writtenBy: 'future',
-			writtenAt: new Date().toISOString(),
 		})
 		const results = await runDoctor(dir)
 		expect(results.find((r) => r.check === 'lockfile')?.status).toBe('drift')

--- a/tests/cli/commands/fix.test.ts
+++ b/tests/cli/commands/fix.test.ts
@@ -1160,8 +1160,8 @@ describe('fix + lockfile', () => {
 		await fixCommand('lockfile', { directory: dir, yes: true })
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
 		expect(lock.version).toBe(LOCKFILE_VERSION)
-		expect(lock.config.projectName).toBe('demo')
-		expect(lock.config.linting.tool).toBe('biome')
+		expect(lock.record.config.projectName).toBe('demo')
+		expect(lock.record.config.linting.tool).toBe('biome')
 	})
 
 	it('fix lockfile --yes migrates an older lockfile in place, keeping its config (#531)', async () => {
@@ -1177,8 +1177,8 @@ describe('fix + lockfile', () => {
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
 		expect(lock.version).toBe(LOCKFILE_VERSION)
 		// Recorded choices survive — no re-inference over an existing lockfile.
-		expect(lock.config.testing.framework).toBe('jest')
-		expect(lock.assets.biome).toMatch(/^[0-9a-f]{64}$/)
+		expect(lock.record.config.testing.framework).toBe('jest')
+		expect(lock.record.assets.biome).toMatch(/^[0-9a-f]{64}$/)
 	})
 
 	it('fix vitest --yes regenerates the config but keeps an existing vitest.setup.ts', async () => {
@@ -1197,7 +1197,7 @@ describe('fix + lockfile', () => {
 		await writeLock(dir, { testing: { framework: 'jest', environment: 'node' } })
 		await fixCommand('vitest', { directory: dir, yes: true })
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.config.testing.framework).toBe('vitest')
+		expect(lock.record.config.testing.framework).toBe('vitest')
 	})
 
 	it('fix biome --yes on an eslint-locked project flips the recorded linting choice', async () => {
@@ -1209,8 +1209,8 @@ describe('fix + lockfile', () => {
 		})
 		await fixCommand('biome', { directory: dir, yes: true })
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.config.linting.tool).toBe('biome')
-		expect(lock.config.formatting.tool).toBe('biome')
+		expect(lock.record.config.linting.tool).toBe('biome')
+		expect(lock.record.config.formatting.tool).toBe('biome')
 	})
 
 	it('does not touch the lockfile when no lockfile exists', async () => {

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -270,7 +270,7 @@ describe('setup --preset', () => {
 		expect(await fs.pathExists(join(dir, 'package.json'))).toBe(false)
 
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.config.language).toBe('swift')
+		expect(lock.record.config.language).toBe('swift')
 	})
 
 	it('rejects unknown preset names', async () => {
@@ -464,9 +464,9 @@ describe('setup --preset review prompt', () => {
 		expect(await fs.pathExists(join(dir, 'release.config.mjs'))).toBe(true)
 
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.config.gitHooks).toBe(false)
-		expect(lock.config.aiSetup).toBe(false)
-		expect(lock.config.semanticRelease).toBe(true)
+		expect(lock.record.config.gitHooks).toBe(false)
+		expect(lock.record.config.aiSetup).toBe(false)
+		expect(lock.record.config.semanticRelease).toBe(true)
 	})
 
 	it('prints the resolved file list before asking', async () => {
@@ -723,7 +723,7 @@ describe('setup language prompt', () => {
 
 		expect(await fs.pathExists(join(dir, 'Sources/MySwiftLib/MySwiftLib.swift'))).toBe(true)
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.config.language).toBe('swift')
+		expect(lock.record.config.language).toBe('swift')
 	})
 
 	it('records the chosen language in the lockfile instead of a hardcoded js', async () => {
@@ -736,7 +736,7 @@ describe('setup language prompt', () => {
 			logSpy.mockRestore()
 		}
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
-		expect(lock.config.language).toBe('js')
+		expect(lock.record.config.language).toBe('js')
 	})
 
 	// #463: every test above spies on `inquirer.prompt`, which replaces the

--- a/tests/cli/utils/copied-assets.test.ts
+++ b/tests/cli/utils/copied-assets.test.ts
@@ -43,7 +43,7 @@ describe('classifyCopiedAssets', () => {
 
 		// The hash landed in the lockfile rather than nowhere.
 		const lock = await readLockfile(dir)
-		expect(lock?.assets?.oxlint).toMatch(/^[0-9a-f]{64}$/)
+		expect(lock?.record.assets?.oxlint).toMatch(/^[0-9a-f]{64}$/)
 
 		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('ok')
 	})
@@ -74,7 +74,7 @@ describe('classifyCopiedAssets', () => {
 		// Strip the record, leaving the pre-#428 shape: the file is there, its
 		// provenance isn't.
 		const lock = await readLockfile(dir)
-		await writeLockfile(dir, lock?.config as ProjectConfig, {})
+		await writeLockfile(dir, lock?.record.config as ProjectConfig, {})
 
 		expect(stateOf(await classifyCopiedAssets(dir), 'oxlint')).toBe('unknown')
 	})

--- a/tests/cli/utils/lockfile-schema.test.ts
+++ b/tests/cli/utils/lockfile-schema.test.ts
@@ -125,20 +125,28 @@ describe("this repo's own lockfile", () => {
 	})
 
 	// Proves the assertion above is real: each mutation is a way the file could
-	// drift, and each must produce at least one error.
+	// drift, and each must produce at least one error. `record`/`rules` since #559.
+	const record = lockfile.record as Record<string, unknown>
+	const withRules = (rules: unknown) => ({ ...lockfile, rules })
+
 	it('rejects a drifted lockfile', () => {
-		const missingRequired = { ...lockfile }
-		delete missingRequired.writtenBy
+		const missingRequired = { ...lockfile, record: { ...record } }
+		delete missingRequired.record.writtenBy
 		expect(validate(missingRequired, schema)).not.toEqual([])
 		expect(validate({ ...lockfile, strayKey: true }, schema)).not.toEqual([])
-		expect(validate({ ...lockfile, version: '3' }, schema)).not.toEqual([])
-		expect(validate({ ...lockfile, aiLoop: { agentUsr: 'typo' } }, schema)).not.toEqual([])
+		expect(validate({ ...lockfile, version: '4' }, schema)).not.toEqual([])
+		// The flat pre-#559 layout no longer validates as v4.
+		expect(validate({ ...lockfile, aiLoop: { agentUser: 'flat' } }, schema)).not.toEqual([])
+		expect(validate(withRules({ aiLoop: { agentUsr: 'typo' } }), schema)).not.toEqual([])
 		// #533: only skills this package ships, and only as an array.
-		expect(validate({ ...lockfile, requiredSkills: ['not-a-skill'] }, schema)).not.toEqual([])
-		expect(validate({ ...lockfile, requiredSkills: 'ai-issue-loop' }, schema)).not.toEqual([])
+		expect(validate(withRules({ requiredSkills: ['not-a-skill'] }), schema)).not.toEqual([])
+		expect(validate(withRules({ requiredSkills: 'ai-issue-loop' }), schema)).not.toEqual([])
 		expect(
 			validate(
-				{ ...lockfile, config: { ...(lockfile.config as object), bundler: 'webpack' } },
+				{
+					...lockfile,
+					record: { ...record, config: { ...(record.config as object), bundler: 'webpack' } },
+				},
 				schema
 			)
 		).not.toEqual([])
@@ -147,7 +155,7 @@ describe("this repo's own lockfile", () => {
 	// #534: the schema is the whole enforcement of "advisory metadata, never an
 	// install directive" — an entry may say what and why, and may not say how.
 	it('accepts an advisory mcp.recommended entry and rejects executable config', () => {
-		const mcp = (recommended: unknown) => validate({ ...lockfile, mcp: { recommended } }, schema)
+		const mcp = (recommended: unknown) => validate(withRules({ mcp: { recommended } }), schema)
 		expect(
 			mcp([{ name: 'some-server', importance: 'important', why: 'edits the design files' }])
 		).toEqual([])
@@ -161,7 +169,7 @@ describe("this repo's own lockfile", () => {
 	// #558: an exception's reason is mandatory and non-empty — the schema is what
 	// enforces "every deviation is argued", so an empty reason must not validate.
 	it('accepts a declared exception with a reason and rejects one without', () => {
-		const exceptions = (value: unknown) => validate({ ...lockfile, exceptions: value }, schema)
+		const exceptions = (value: unknown) => validate(withRules({ exceptions: value }), schema)
 		expect(exceptions({ TypeScript: 'this repo is the package itself' })).toEqual([])
 		expect(exceptions({ TypeScript: '' })).not.toEqual([])
 		expect(exceptions({ TypeScript: true })).not.toEqual([])

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -53,13 +53,13 @@ describe('readLockfile', () => {
 	it('falls back to the pre-rename .js-tooling.json name (#272)', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, LEGACY_LOCKFILE_NAME), {
-			version: LOCKFILE_VERSION,
+			version: 3,
 			config: baseConfig({ language: 'js' }),
 			writtenBy: 'old',
 			writtenAt: '2024-01-01T00:00:00.000Z',
 		})
 		const lock = await readLockfile(dir)
-		expect(lock?.config.projectName).toBe('demo')
+		expect(lock?.record.config.projectName).toBe('demo')
 	})
 
 	it('migrates a v1 file, defaulting language to js', async () => {
@@ -74,9 +74,9 @@ describe('readLockfile', () => {
 		const lock = await readLockfile(dir)
 		// The on-disk version is preserved so doctor can flag it as older (#531).
 		expect(lock?.version).toBe(1)
-		expect(lock?.config.language).toBe('js')
+		expect(lock?.record.config.language).toBe('js')
 		// Existing fields survive the migration untouched.
-		expect(lock?.config.projectName).toBe('demo')
+		expect(lock?.record.config.projectName).toBe('demo')
 	})
 
 	it('migrates a v2 file in memory with no recorded asset hashes (#428)', async () => {
@@ -91,8 +91,50 @@ describe('readLockfile', () => {
 		const lock = await readLockfile(dir)
 		// The on-disk version is preserved so doctor can flag it as older (#531).
 		expect(lock?.version).toBe(2)
-		expect(lock?.assets).toEqual({})
-		expect(lock?.config.projectName).toBe('demo')
+		expect(lock?.record.assets).toEqual({})
+		expect(lock?.record.config.projectName).toBe('demo')
+	})
+
+	// #559: v4 split the file into record (tool-written) and rules (human-written).
+	it('migrates a flat v3 file into the record/rules subtrees, field for field', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, LOCKFILE_NAME), {
+			version: 3,
+			config: baseConfig({ language: 'js' }),
+			assets: { biome: 'abc123' },
+			aiLoop: { agentUser: 'some-bot' },
+			requiredSkills: ['ai-issue-loop'],
+			mcp: { recommended: [{ name: 's', importance: 'critical', why: 'because' }] },
+			exceptions: { TypeScript: 'reason' },
+			writtenBy: 'old',
+			writtenAt: '2024-01-01T00:00:00.000Z',
+		})
+
+		const lock = await readLockfile(dir)
+		// The on-disk version is preserved so doctor can flag it as older (#531).
+		expect(lock?.version).toBe(3)
+		expect(lock?.record.config.projectName).toBe('demo')
+		expect(lock?.record.assets).toEqual({ biome: 'abc123' })
+		expect(lock?.record.writtenBy).toBe('old')
+		expect(lock?.record.writtenAt).toBe('2024-01-01T00:00:00.000Z')
+		expect(lock?.rules).toEqual({
+			aiLoop: { agentUser: 'some-bot' },
+			requiredSkills: ['ai-issue-loop'],
+			mcp: { recommended: [{ name: 's', importance: 'critical', why: 'because' }] },
+			exceptions: { TypeScript: 'reason' },
+		})
+	})
+
+	it('omits rules entirely when a v3 file set none of its fields', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, LOCKFILE_NAME), {
+			version: 3,
+			config: baseConfig({ language: 'js' }),
+			writtenBy: 'old',
+			writtenAt: '2024-01-01T00:00:00.000Z',
+		})
+		const lock = await readLockfile(dir)
+		expect(lock?.rules).toBeUndefined()
 	})
 })
 
@@ -105,16 +147,16 @@ describe('writeLockfile', () => {
 		const lock = await readLockfile(dir)
 		expect(lock).not.toBeNull()
 		expect(lock?.version).toBe(LOCKFILE_VERSION)
-		expect(lock?.config.projectName).toBe('demo')
-		expect(lock?.config.testing.framework).toBe('vitest')
-		expect(lock?.writtenBy).toMatch(/@rtorcato\/repo-tooling@/)
-		expect(lock?.writtenAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+		expect(lock?.record.config.projectName).toBe('demo')
+		expect(lock?.record.config.testing.framework).toBe('vitest')
+		expect(lock?.record.writtenBy).toMatch(/@rtorcato\/repo-tooling@/)
+		expect(lock?.record.writtenAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
 	})
 
 	it('migrates a pre-rename repo: writes the new name and removes the legacy file (#272)', async () => {
 		const dir = newTmpDir()
 		await fs.writeJson(join(dir, LEGACY_LOCKFILE_NAME), {
-			version: LOCKFILE_VERSION,
+			version: 3,
 			config: baseConfig({ language: 'js' }),
 			writtenBy: 'old',
 			writtenAt: '2024-01-01T00:00:00.000Z',
@@ -140,10 +182,10 @@ describe('updateLockfileConfig', () => {
 		})
 		expect(updated).toBe(true)
 		const lock = await readLockfile(dir)
-		expect(lock?.config.testing.framework).toBe('jest')
+		expect(lock?.record.config.testing.framework).toBe('jest')
 		// Other fields preserved
-		expect(lock?.config.linting.tool).toBe('biome')
-		expect(lock?.config.gitHooks).toBe(true)
+		expect(lock?.record.config.linting.tool).toBe('biome')
+		expect(lock?.record.config.gitHooks).toBe(true)
 	})
 
 	it('returns false when no lockfile exists', async () => {
@@ -160,8 +202,8 @@ describe('updateLockfileConfig', () => {
 		await updateLockfileConfig(dir, { gitHooks: false })
 
 		const lock = await readLockfile(dir)
-		expect(lock?.assets).toEqual({ oxlint: 'abc123' })
-		expect(lock?.config.gitHooks).toBe(false)
+		expect(lock?.record.assets).toEqual({ oxlint: 'abc123' })
+		expect(lock?.record.config.gitHooks).toBe(false)
 	})
 })
 
@@ -175,45 +217,52 @@ describe('recordAssetHash', () => {
 
 // #524: writeLockfile rebuilds the object from scratch, so any key it does not
 // name is silently dropped — the same trap the `assets` carry-forward exists for.
-describe('aiLoop settings survive a rewrite', () => {
-	it('carries aiLoop forward when only config is rewritten', async () => {
+// Since #559 every hand-edited field lives under `rules`, carried verbatim.
+describe('rules survive a rewrite', () => {
+	it('carries rules forward when only config is rewritten', async () => {
 		const dir = newTmpDir()
 		await writeLockfile(dir, baseConfig())
 		const file = join(dir, '.repo-tooling.json')
 		const lock = await fs.readJson(file)
-		await fs.writeJson(file, { ...lock, aiLoop: { agentUser: 'some-bot' } }, { spaces: 2 })
+		const mcp = { recommended: [{ name: 's', importance: 'critical', why: 'because' }] }
+		const rules = { aiLoop: { agentUser: 'some-bot' }, requiredSkills: ['ai-issue-loop'], mcp }
+		await fs.writeJson(file, { ...lock, rules }, { spaces: 2 })
 
 		await writeLockfile(dir, { ...baseConfig(), projectName: 'renamed' })
 
 		const after = await fs.readJson(file)
-		expect(after.aiLoop).toEqual({ agentUser: 'some-bot' })
-		expect(after.config.projectName).toBe('renamed')
+		expect(after.rules).toEqual(rules)
+		expect(after.record.config.projectName).toBe('renamed')
 	})
 
 	it('omits the key entirely when nothing set it', async () => {
 		const dir = newTmpDir()
 		await writeLockfile(dir, baseConfig())
-		expect(await fs.readJson(join(dir, '.repo-tooling.json'))).not.toHaveProperty('aiLoop')
+		expect(await fs.readJson(join(dir, '.repo-tooling.json'))).not.toHaveProperty('rules')
 	})
 
-	// #533 / #534: same trap, two more hand-edited-only keys.
-	it('carries requiredSkills and mcp forward, and omits them when unset', async () => {
+	// #559: rewriting a flat v3 file migrates it on disk — the hand-edited fields
+	// land under `rules`, nothing is lost, and the file is v4 from then on.
+	it('nests flat v3 hand-edited fields under rules on the next write', async () => {
 		const dir = newTmpDir()
-		await writeLockfile(dir, baseConfig())
-		const file = join(dir, '.repo-tooling.json')
-		expect(await fs.readJson(file)).not.toHaveProperty('requiredSkills')
-		expect(await fs.readJson(file)).not.toHaveProperty('mcp')
+		await fs.writeJson(join(dir, '.repo-tooling.json'), {
+			version: 3,
+			config: baseConfig({ language: 'js' }),
+			aiLoop: { agentUser: 'some-bot' },
+			exceptions: { TypeScript: 'reason' },
+			writtenBy: 'old',
+			writtenAt: '2024-01-01T00:00:00.000Z',
+		})
 
-		const mcp = { recommended: [{ name: 's', importance: 'critical', why: 'because' }] }
-		await fs.writeJson(
-			file,
-			{ ...(await fs.readJson(file)), requiredSkills: ['ai-issue-loop'], mcp },
-			{ spaces: 2 }
-		)
-		await writeLockfile(dir, { ...baseConfig(), projectName: 'renamed' })
+		await writeLockfile(dir, baseConfig({ language: 'js' }))
 
-		const after = await fs.readJson(file)
-		expect(after.requiredSkills).toEqual(['ai-issue-loop'])
-		expect(after.mcp).toEqual(mcp)
+		const after = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(after.version).toBe(LOCKFILE_VERSION)
+		expect(after.rules).toEqual({
+			aiLoop: { agentUser: 'some-bot' },
+			exceptions: { TypeScript: 'reason' },
+		})
+		expect(after).not.toHaveProperty('aiLoop')
+		expect(after).not.toHaveProperty('config')
 	})
 })


### PR DESCRIPTION
🤖 *Opened by Claude (AI agent) on the owner's behalf.*

Implements Option C from the decision on #559: `.repo-tooling.json` becomes two documents sharing one file — a tool-written **`record`** subtree (`config`, `assets`, `writtenBy`, `writtenAt`) and a human-written **`rules`** subtree (`aiLoop`, `requiredSkills`, `mcp`, `exceptions`).

Closes #559

## What changed

- **v4 lockfile migration** on the #544 machinery: flat v1–v3 files are nested in memory on read (on-disk `version` preserved so the older-than-current check still fires, per #531) and rewritten as v4 on the next save. Field for field — nothing renamed or dropped.
- **`doctor`'s lockfile line scopes its claim**: `.repo-tooling.json v4 (record written by …)`. The `AI loop agent` check's messages now say `rules.aiLoop.agentUser`.
- **Every reader updated**: `doctor` (agentUser / requiredSkills / mcp / exceptions gates), `declinedInLock` / `lockfilePatchForTarget`, `fix --resync`, the `lockfile` fixer, copied-assets classification, and setup's #271 lockfile-as-config unwrap (which now accepts both shapes).
- **Skills' jq paths**: `ai-issue-loop` and `ai-workflow` read `.rules.aiLoop.agentUser // .aiLoop.agentUser // empty` — the flat fallback keeps a not-yet-migrated repo's loop assignment working.
- **Schema + docs move together**: `pnpm schema:generate` output committed, `repo-tooling-json.mdx` restructured around the two subtrees, `ai-setup.md` examples nested, #552 self-validation test updated (its drift mutations now exercise the nested shape, including rejecting the flat pre-v4 layout).
- **This repo's own file migrated** in this PR via `writeLockfile` (the CLI's self-guard blocks `fix lockfile` here). Its `writtenBy` now reads `@rtorcato/repo-tooling@3.11.0` — honestly the package.json version of the dev tree that ran the migration; semantic-release will stamp the real version on the next tool write after release.

## Tests

- v3→v4 migration field-for-field, rules omitted when empty, flat hand-edited fields nested on the next write.
- `rules` carried forward verbatim across rewrites (the #524 carry-forward trap, re-pinned for the new shape).
- Self-validation of the repo's own v4 file against the regenerated schema.
- Full suite: 1145 passed, 1 expected fail (pre-existing).
