### PR TITLE
feat(rules): compare repo rules against a reference repo, and seed setup from one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ Every command supports `--json` and a non-interactive mode. Combine with `--yes`
 | `setup --config-schema` | ✅ | ✅ (JSON Schema) | Print the JSON Schema for `ProjectConfig`. Use to validate configs before scaffolding. |
 | `setup --dry-run` | ✅ | ✅ | Print resolved config + file list without writing. Pair with `--preset` or `--config`. |
 | `doctor --json` | ✅ | ✅ | Audit a project. Returns `{ directory, results: [{ check, status, detail, hint? }] }`. Status: `ok` / `drift` / `missing` / `optional-missing` / `declared`. |
+| `doctor --rules-from <owner/repo>` | ✅ | ✅ | Report how this repo's `config`/`rules` differ from a reference repo's `.repo-tooling.json` (read over `gh`). Informational only — adds a `rulesReference` key to the JSON, never a check result, never affects the exit code. |
+| `setup --from <owner/repo>` | ❌ (seeds the wizard) | `--dry-run` only | Seed the wizard's defaults from a reference repo's recorded config. Seeded, not skipped — every question is still asked. |
 | `fix --json --yes` | ✅ | ✅ | Walk every doctor finding, apply fixers. Returns `FixActionRecord[]` with `status: applied | dry-run | skipped | already-ok | unsupported`. |
 | `fix <target> --json --yes` | ✅ | ✅ | Apply one fixer. Targets from `list --json`. |
 | `fix --dry-run` | ✅ | ✅ | Print what each fixer would write without writing. Combine with `--json`. |

--- a/apps/docs/docs/reference/repo-tooling-json.mdx
+++ b/apps/docs/docs/reference/repo-tooling-json.mdx
@@ -181,6 +181,60 @@ Three rules keep it from becoming a mute button:
 A bulk `fix` / `fix --yes` skips declared checks; a targeted `fix <target>` still applies,
 since naming the fixer is an explicit override.
 
+## Comparing against another repo
+
+There is **no guideline package**, and there never will be: the rules are unique to each repo,
+and a rule that travels as a dependency stops being the repo's own. Sharing a guideline means
+pointing at a **reference repo** — one whose `.repo-tooling.json` you consider exemplary.
+
+```bash
+# Report how this repo's config and rules differ from another repo's
+npx @rtorcato/repo-tooling doctor --rules-from owner/repo
+```
+
+The reference is read over `gh` (`repos/owner/repo/contents/.repo-tooling.json`), so it works
+for any repo your `gh` login can see, public or private.
+
+Three properties make this safe to point at a repo you do not control:
+
+- **Informational, always.** Differences are printed in their own section, never as check
+  results — they are not `drift`, they do not appear in the summary counts, and they cannot
+  change the exit code. Two repos legitimately differ; the point is seeing where.
+- **Read and report, never apply.** There is no fixer, and nothing from the reference is ever
+  written into your repo.
+- **The reference is untrusted input.** The `owner/repo` string is shape-checked before it
+  reaches an API path, the response is size-capped, and the JSON is validated against the
+  published schema before a single field is read. A missing, malformed, oversized or
+  schema-invalid reference is reported plainly and the comparison is skipped — never as a
+  finding about your repo.
+
+Only the comparable half is diffed: `record.config` and everything under `rules`. The `assets`
+hashes and the `writtenBy`/`writtenAt` stamps are excluded — they differ between any two repos
+by construction, so including them would bury every difference that means something.
+
+With `--json`, the comparison rides alongside the results under `rulesReference`, and only when
+the flag is given.
+
+## Starting a new repo from another one
+
+The same reference, the other direction:
+
+```bash
+npx @rtorcato/repo-tooling setup --from owner/repo -d ./my-new-lib
+```
+
+The wizard is **seeded, not skipped**: every question is still asked, with that repo's answers
+as the defaults instead of the built-in ones. Nothing is written that you did not see.
+
+Only `record.config` crosses over. `projectName` is never seeded (a new repo is not the
+reference repo), the record-side stamps are not copied (the new repo writes its own `writtenBy`
+and starts with no `assets`), and `rules` stays behind — an `exceptions` entry excuses a
+deviation in the repo that argued for it, so copying one would mute a check somewhere it is
+still a real finding.
+
+`--from` seeds the wizard, so it is ignored (with a warning) alongside `--preset` or `--config`,
+which skip the wizard entirely.
+
 ## Version history
 
 | Version | Change |

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -19,6 +19,7 @@ import { checkMilestones } from '../../base/milestones.js'
 import { checkGitIdentity, checkGitIdentityHistory } from '../../base/git-identity.js'
 import { checkCopiedAssets } from '../utils/copied-assets.js'
 import { type Lockfile, LOCKFILE_VERSION, readLockfile } from '../utils/lockfile.js'
+import { compareRulesWithReference, type RulesComparison } from '../utils/reference-rules.js'
 import { declinedInLock, getFixTargetForCheck } from './fix-targets.js'
 import {
 	type BadgeAudience,
@@ -87,6 +88,8 @@ export interface DoctorOptions {
 	json?: boolean
 	/** `--skills-dir`, mirroring `fix` — the read side of the same flag (#485). */
 	skillsDir?: string
+	/** `--rules-from <owner/repo>`: report how this repo's rules differ from that repo's (#563). */
+	rulesFrom?: string
 }
 
 const PACKAGE = '@rtorcato/repo-tooling'
@@ -587,12 +590,54 @@ export function summarize(results: CheckResult[]): {
 	}
 }
 
+/**
+ * Print the `--rules-from` comparison (#563). Deliberately not a CheckResult:
+ * two repos legitimately differ, so a difference is never a finding about either
+ * one, and keeping it out of `results` is what makes "never affects the exit
+ * code" structural rather than a promise the next check has to remember.
+ */
+function printRulesComparison(comparison: RulesComparison) {
+	console.log(
+		chalk.cyan(`\n📐 Rules vs ${comparison.reference}`),
+		chalk.gray('(informational — differences are not drift and do not affect the exit code)\n')
+	)
+	if (!comparison.compared) {
+		console.log(`  ${chalk.gray('➖')} ${chalk.gray(`not compared — ${comparison.reason}`)}\n`)
+		return
+	}
+	const differences = comparison.differences ?? []
+	if (differences.length === 0) {
+		console.log(`  ${chalk.green('✅')} ${chalk.gray('identical — no differences to report')}\n`)
+		return
+	}
+	const show = (v: unknown) => (v === undefined ? chalk.dim('(absent)') : JSON.stringify(v))
+	for (const d of differences) {
+		console.log(`  ${chalk.bold(d.path)}`)
+		console.log(`     ${chalk.gray('here:')} ${show(d.local)}`)
+		console.log(`     ${chalk.gray(`${comparison.reference}:`)} ${show(d.reference)}`)
+	}
+	console.log(chalk.gray(`\n  ${differences.length} difference(s).\n`))
+}
+
 export async function doctorCommand(options: DoctorOptions = {}) {
 	const dir = options.directory ?? process.cwd()
 	const results = await runDoctor(dir, options.skillsDir)
+	const comparison = options.rulesFrom
+		? await compareRulesWithReference(dir, options.rulesFrom)
+		: null
 
 	if (options.json) {
-		console.log(JSON.stringify({ directory: path.resolve(dir), results }, null, 2))
+		console.log(
+			JSON.stringify(
+				{
+					directory: path.resolve(dir),
+					results,
+					...(comparison ? { rulesReference: comparison } : {}),
+				},
+				null,
+				2
+			)
+		)
 	} else {
 		console.log(chalk.cyan(`\n🩺 Diagnosing ${path.resolve(dir)} against ${PACKAGE} presets...\n`))
 		for (const r of results) {
@@ -615,6 +660,7 @@ export async function doctorCommand(options: DoctorOptions = {}) {
 			}
 			console.log()
 		}
+		if (comparison) printRulesComparison(comparison)
 	}
 
 	const summary = summarize(results)

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -8,6 +8,7 @@ import { detectLanguage } from '../utils/detect-language.js'
 import { formatGeneratedFiles } from '../utils/format.js'
 import { installDependencies } from '../utils/install.js'
 import { LOCKFILE_NAME, writeLockfile } from '../utils/lockfile.js'
+import { fetchReferenceLockfile } from '../utils/reference-rules.js'
 import {
 	buildPresetConfig,
 	computeFileList,
@@ -81,6 +82,8 @@ export interface SetupOptions {
 	configSchema?: boolean
 	/** Accept a `--preset` as-is instead of reviewing it in an interactive terminal. */
 	yes?: boolean
+	/** `--from <owner/repo>`: seed the wizard's defaults from that repo's lockfile (#563). */
+	from?: string
 }
 
 /**
@@ -140,10 +143,31 @@ async function reviewPresetConfig(config: ProjectConfig): Promise<ProjectConfig>
 	return reviewed
 }
 
+/**
+ * Read a reference repo's recorded config to seed the wizard (#563). Only
+ * `record.config` — the answers — crosses over: `assets` and the
+ * `writtenBy`/`writtenAt` stamps describe the reference's own history, and this
+ * repo's lockfile gets its own on the first write. `rules` is left behind too,
+ * since an `exceptions` entry excuses a deviation in the repo that wrote it.
+ */
+async function seedFromReference(reference: string): Promise<ProjectConfig> {
+	const result = await fetchReferenceLockfile(reference)
+	if (!result.ok) throw new Error(`Cannot seed from ${reference}: ${result.reason}`)
+	console.log(
+		chalk.cyan(`\n🌱 Seeding defaults from ${reference} — every answer is still yours to change.\n`)
+	)
+	return result.lockfile.record.config
+}
+
 /** `null` means the run was declined, not that it failed — see promptForConfig. */
 async function resolveConfig(options: SetupOptions): Promise<ProjectConfig | null> {
 	if (options.config && options.preset) {
 		console.warn(chalk.yellow('⚠️  Both --config and --preset given; --config wins.\n'))
+	}
+	if (options.from && (options.config || options.preset)) {
+		console.warn(
+			chalk.yellow('⚠️  --from seeds the wizard, which --config/--preset skip; ignoring --from.\n')
+		)
 	}
 	if (options.config) {
 		const configPath = path.resolve(options.config)
@@ -176,7 +200,8 @@ async function resolveConfig(options: SetupOptions): Promise<ProjectConfig | nul
 		if (options.dryRun || options.yes || !isInteractiveTerminal()) return config
 		return reviewPresetConfig(config)
 	}
-	return promptForConfig(path.resolve(options.directory))
+	const seed = options.from ? await seedFromReference(options.from) : undefined
+	return promptForConfig(path.resolve(options.directory), seed)
 }
 
 export async function setupProject(options: SetupOptions) {
@@ -251,7 +276,7 @@ const SCAFFOLDABLE: ReadonlyArray<LanguageModule['id']> = ['js', 'swift']
  * like. Languages setup can't scaffold yet are still offered — hiding them reads
  * as "repo-tooling is JS-only" when the honest answer is "not yet" (#139).
  */
-async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
+async function promptForLanguage(targetDir: string, seed?: ProjectConfig): Promise<LanguageModule> {
 	const detected = await detectLanguage(targetDir)
 	const { language } = await inquirer.prompt([
 		{
@@ -264,8 +289,10 @@ async function promptForLanguage(targetDir: string): Promise<LanguageModule> {
 					: `${module.label} (${module.supported ? 'doctor/fix only — no setup preset yet' : 'setup lands with its module'})`,
 				value: module.id,
 			})),
+			// What this dir already looks like beats the reference's language: the
+			// files on disk are evidence, the reference is only a suggestion.
 			// 'unknown' is a bare dir mid-setup — JS is the historical default.
-			default: detected === 'unknown' ? 'js' : detected,
+			default: detected !== 'unknown' ? detected : (seed?.language ?? 'js'),
 		},
 	])
 	return LANGUAGES[language as LanguageModule['id']]
@@ -292,9 +319,19 @@ function explainNotScaffoldable(module: LanguageModule) {
 	)
 }
 
-/** `null` when the chosen language has no scaffolding yet; nothing is written. */
-async function promptForConfig(targetDir: string): Promise<ProjectConfig | null> {
-	const language = await promptForLanguage(targetDir)
+/**
+ * `null` when the chosen language has no scaffolding yet; nothing is written.
+ *
+ * @param seed A reference repo's recorded config (#563). It moves the *defaults*
+ *   only — every question is still asked, so seeding can never write an answer
+ *   the user did not see. `projectName` is deliberately never seeded: a new repo
+ *   is not the reference repo.
+ */
+async function promptForConfig(
+	targetDir: string,
+	seed?: ProjectConfig
+): Promise<ProjectConfig | null> {
+	const language = await promptForLanguage(targetDir, seed)
 
 	// Gate on SCAFFOLDABLE, not `module.supported` — Swift is supported (#286)
 	// but has no preset yet (#288), and falling through here would write a
@@ -327,6 +364,18 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 	// Turborepo only makes sense in a pnpm-workspace monorepo, so the prompt is
 	// only offered when one is already present in the target dir.
 	const hasWorkspace = await fs.pathExists(path.join(targetDir, 'pnpm-workspace.yaml'))
+	// Two questions ask for something the config stores as a set of booleans, so
+	// their seeded default has to be derived rather than read.
+	const seededReleaseTool = !seed
+		? 'semantic-release'
+		: seed.semanticRelease
+			? 'semantic-release'
+			: seed.changesets
+				? 'changesets'
+				: seed.releasePlease
+					? 'release-please'
+					: 'none'
+	const seededOrchestrator = !seed ? 'turbo' : seed.turborepo ? 'turbo' : seed.nx ? 'nx' : 'none'
 	const answers = await inquirer.prompt([
 		{
 			type: 'input',
@@ -339,6 +388,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			type: 'select',
 			name: 'projectType',
 			message: '🏗️  What type of project are you building?',
+			default: seed?.projectType,
 			choices: [
 				{ name: '📚 Library/Package', value: 'library' },
 				{ name: '🌐 Web Application', value: 'web-app' },
@@ -351,7 +401,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 			type: 'confirm',
 			name: 'useTypeScript',
 			message: '📘 Do you want to use TypeScript?',
-			default: true,
+			default: seed?.typescript.enabled ?? true,
 		},
 		{
 			type: 'select',
@@ -378,6 +428,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 
 				return baseChoices
 			},
+			default: seed?.typescript.config,
 			when: (answers: any) => answers.useTypeScript,
 		},
 		{
@@ -390,7 +441,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				{ name: '🔥 Both Biome + ESLint', value: 'both' },
 				{ name: '❌ None', value: 'none' },
 			],
-			default: 'biome',
+			default: seed?.linting.tool ?? 'biome',
 		},
 		{
 			type: 'select',
@@ -403,13 +454,14 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				}
 				return choices
 			},
+			default: seed?.linting.eslintConfig,
 			when: (answers: any) => answers.lintingTool === 'eslint' || answers.lintingTool === 'both',
 		},
 		{
 			type: 'confirm',
 			name: 'oxlint',
 			message: '🦀 Also run Oxlint alongside (50–100× faster than ESLint)?',
-			default: false,
+			default: seed?.oxlint ?? false,
 			when: (answers: any) => answers.lintingTool !== 'none',
 		},
 		{
@@ -423,7 +475,7 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				{ name: '🌲 Cypress (E2E)', value: 'cypress' },
 				{ name: '❌ None', value: 'none' },
 			],
-			default: 'vitest',
+			default: seed?.testing.framework ?? 'vitest',
 		},
 		{
 			type: 'select',
@@ -435,19 +487,19 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				{ name: '🔄 Both', value: 'both' },
 			],
 			when: (answers: any) => answers.testingFramework === 'jest',
-			default: 'node',
+			default: seed?.testing.environment ?? 'node',
 		},
 		{
 			type: 'confirm',
 			name: 'gitHooks',
 			message: '🪝 Set up Git hooks (Husky + lint-staged)?',
-			default: true,
+			default: seed?.gitHooks ?? true,
 		},
 		{
 			type: 'confirm',
 			name: 'commitLint',
 			message: '📝 Set up conventional commit linting?',
-			default: true,
+			default: seed?.commitLint ?? true,
 			when: (answers: any) => answers.gitHooks,
 		},
 		{
@@ -460,40 +512,40 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				{ name: '🙏 Release Please (Google, release-PR-driven)', value: 'release-please' },
 				{ name: '❌ None', value: 'none' },
 			],
-			default: 'semantic-release',
+			default: seededReleaseTool,
 			when: (answers: any) => answers.projectType === 'library',
 		},
 		{
 			type: 'confirm',
 			name: 'treeshakeCheck',
 			message: '🌳 Add a tree-shake verification check (apps/treeshake-check)?',
-			default: false,
+			default: seed?.treeshakeCheck ?? false,
 			when: (answers: any) => answers.projectType === 'library',
 		},
 		{
 			type: 'confirm',
 			name: 'publint',
 			message: '📦 Add publint to lint your package before publishing?',
-			default: true,
+			default: seed?.publint ?? true,
 			when: (answers: any) => answers.projectType === 'library',
 		},
 		{
 			type: 'confirm',
 			name: 'badges',
 			message: '🔖 Add status badges (CI, npm, coverage, license) to the README?',
-			default: true,
+			default: seed?.badges ?? true,
 		},
 		{
 			type: 'confirm',
 			name: 'securityAutomation',
 			message: '🛡️  Include security automation (Dependabot + CodeQL)?',
-			default: true,
+			default: seed?.securityAutomation ?? true,
 		},
 		{
 			type: 'confirm',
 			name: 'aiSetup',
 			message: '🤖 Add AI agent rules (AGENTS.md, CLAUDE.md, Cursor, Copilot, Claude skill)?',
-			default: true,
+			default: seed?.aiSetup ?? true,
 		},
 		{
 			type: 'select',
@@ -504,14 +556,14 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 				{ name: '🔷 Nx (nx.json)', value: 'nx' },
 				{ name: '❌ None', value: 'none' },
 			],
-			default: 'turbo',
+			default: seededOrchestrator,
 			when: () => hasWorkspace,
 		},
 		{
 			type: 'confirm',
 			name: 'tailwind',
 			message: '🎨 Add Tailwind CSS v4 (PostCSS plugin + globals.css)?',
-			default: true,
+			default: seed?.tailwind ?? true,
 			// Only meaningful for frontend project types.
 			when: (answers: any) =>
 				answers.projectType === 'web-app' ||
@@ -537,13 +589,14 @@ async function promptForConfig(targetDir: string): Promise<ProjectConfig | null>
 
 				return choices
 			},
+			default: seed?.bundler,
 			when: (answers: any) => answers.projectType !== 'nextjs-app', // Next.js has its own bundler
 		},
 		{
 			type: 'confirm',
 			name: 'bun',
 			message: '🥟 Target the Bun runtime (bunfig.toml + Bun-typed tsconfig)?',
-			default: false,
+			default: seed?.bun ?? false,
 			// A runtime flag, not a project type — offer it for Node-compatible
 			// library/API targets, not the browser-framework types.
 			when: (answers: any) =>

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -149,10 +149,19 @@ async function reviewPresetConfig(config: ProjectConfig): Promise<ProjectConfig>
  * `writtenBy`/`writtenAt` stamps describe the reference's own history, and this
  * repo's lockfile gets its own on the first write. `rules` is left behind too,
  * since an `exceptions` entry excuses a deviation in the repo that wrote it.
+ *
+ * `null` means the reference could not be read — reported plainly and declined,
+ * the way `doctor --rules-from` reports "not compared". Falling through to an
+ * unseeded wizard would be worse: the user asked for that repo's answers, and
+ * generic defaults would be written as though they had confirmed them.
  */
-async function seedFromReference(reference: string): Promise<ProjectConfig> {
+async function seedFromReference(reference: string): Promise<ProjectConfig | null> {
 	const result = await fetchReferenceLockfile(reference)
-	if (!result.ok) throw new Error(`Cannot seed from ${reference}: ${result.reason}`)
+	if (!result.ok) {
+		console.error(chalk.red(`\n❌ Cannot seed from ${reference} — ${result.reason}.`))
+		console.error(chalk.gray('   Re-run without --from to answer the wizard from scratch.\n'))
+		return null
+	}
 	console.log(
 		chalk.cyan(`\n🌱 Seeding defaults from ${reference} — every answer is still yours to change.\n`)
 	)
@@ -200,7 +209,12 @@ async function resolveConfig(options: SetupOptions): Promise<ProjectConfig | nul
 		if (options.dryRun || options.yes || !isInteractiveTerminal()) return config
 		return reviewPresetConfig(config)
 	}
-	const seed = options.from ? await seedFromReference(options.from) : undefined
+	let seed: ProjectConfig | undefined
+	if (options.from) {
+		const seeded = await seedFromReference(options.from)
+		if (seeded === null) return null
+		seed = seeded
+	}
 	return promptForConfig(path.resolve(options.directory), seed)
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,11 @@ program
 	)
 	.option('--dry-run', 'Print the resolved config and file list, write nothing')
 	.option('--config-schema', 'Print the JSON Schema for ProjectConfig and exit')
+	// Seeds the wizard, never skips it (#563) — every answer is still yours.
+	.option(
+		'--from <owner/repo>',
+		"Seed the wizard's defaults from that repo's .repo-tooling.json instead of the built-in ones (read via `gh`)"
+	)
 	.action(setupProject)
 
 program
@@ -348,6 +353,12 @@ program
 	.option(
 		'--skills-dir <path>',
 		'Where `fix claude-skills` installs user-global agent skills (default: ~/.claude/skills). Pass the same path `fix` was given, or the skill reports as not installed'
+	)
+	// Rules are per-repo (#563): this compares them against another repo's, and
+	// only reports. Never drift, never a fixer, never part of the exit code.
+	.option(
+		'--rules-from <owner/repo>',
+		"Report how this repo's config and rules differ from that repo's .repo-tooling.json (informational; read via `gh`)"
 	)
 	.action(doctorCommand)
 

--- a/src/cli/utils/json-schema.ts
+++ b/src/cli/utils/json-schema.ts
@@ -1,0 +1,71 @@
+/**
+ * A JSON Schema validator covering exactly the keyword subset `lockfileSchema()`
+ * and `CONFIG_SCHEMA` use: type (object/array/string/integer/boolean), enum,
+ * minLength, required, properties, additionalProperties (`false` or a schema)
+ * and items. Returns one message per problem; an empty array means valid.
+ *
+ * Hand-rolled because the repo has no JSON Schema validator and the schemas lean
+ * on seven keywords — not enough to justify an ajv dependency. It lives in src
+ * rather than in a test because a reference repo's lockfile is untrusted input
+ * that has to be schema-checked before it is read (#563).
+ */
+// ponytail: `format: date-time` is not checked, and neither are composition
+// keywords — none appear in either schema. Reach for ajv the day one does.
+
+export interface JsonSchema {
+	type?: string
+	enum?: readonly string[]
+	minLength?: number
+	required?: readonly string[]
+	properties?: Record<string, JsonSchema>
+	additionalProperties?: boolean | JsonSchema
+	items?: JsonSchema
+}
+
+export function validateAgainstSchema(value: unknown, schema: JsonSchema, path = '$'): string[] {
+	const errors: string[] = []
+	if (schema.enum && !schema.enum.includes(value as string)) {
+		errors.push(`${path}: ${JSON.stringify(value)} is not one of ${schema.enum.join(', ')}`)
+	}
+	if (schema.type === 'array') {
+		if (!Array.isArray(value)) return [`${path}: expected array`]
+		if (schema.items) {
+			for (const [i, item] of value.entries()) {
+				errors.push(...validateAgainstSchema(item, schema.items, `${path}[${i}]`))
+			}
+		}
+		return errors
+	}
+	if (schema.type === 'object') {
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+			return [`${path}: expected object`]
+		}
+		const obj = value as Record<string, unknown>
+		for (const key of schema.required ?? []) {
+			if (!(key in obj)) errors.push(`${path}: missing required property "${key}"`)
+		}
+		for (const [key, child] of Object.entries(obj)) {
+			const property = schema.properties?.[key]
+			if (property) errors.push(...validateAgainstSchema(child, property, `${path}.${key}`))
+			else if (schema.additionalProperties === false) {
+				errors.push(`${path}: unknown property "${key}"`)
+			} else if (typeof schema.additionalProperties === 'object') {
+				errors.push(...validateAgainstSchema(child, schema.additionalProperties, `${path}.${key}`))
+			}
+		}
+		return errors
+	}
+	if (schema.type === 'integer') {
+		if (!Number.isInteger(value)) errors.push(`${path}: expected integer`)
+	} else if (schema.type && typeof value !== schema.type) {
+		errors.push(`${path}: expected ${schema.type}, got ${typeof value}`)
+	}
+	if (
+		schema.minLength !== undefined &&
+		typeof value === 'string' &&
+		value.length < schema.minLength
+	) {
+		errors.push(`${path}: shorter than minLength ${schema.minLength}`)
+	}
+	return errors
+}

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -304,6 +304,25 @@ function migrate(raw: Record<string, unknown>): Lockfile {
 	}
 }
 
+/**
+ * Normalize already-parsed JSON into a Lockfile, or null when it isn't one.
+ * Split out of readLockfile so a lockfile fetched from somewhere other than the
+ * filesystem — a reference repo, over `gh` — goes through the same migration
+ * before anything reads it (#563).
+ */
+export function parseLockfile(raw: unknown): Lockfile | null {
+	if (typeof raw !== 'object' || raw === null) return null
+	const obj = raw as Record<string, unknown>
+	if (typeof obj.version !== 'number') return null
+	// v4+ keeps config under `record`; v1–v3 keep it at the top level (#559).
+	const config =
+		obj.version >= LOCKFILE_VERSION
+			? (obj.record as Record<string, unknown> | undefined)?.config
+			: obj.config
+	if (typeof config !== 'object' || config === null) return null
+	return migrate(obj)
+}
+
 export async function readLockfile(dir: string): Promise<Lockfile | null> {
 	let filepath = path.join(dir, LOCKFILE_NAME)
 	if (!(await fs.pathExists(filepath))) {
@@ -313,17 +332,7 @@ export async function readLockfile(dir: string): Promise<Lockfile | null> {
 		filepath = legacy
 	}
 	try {
-		const raw = (await fs.readJson(filepath)) as unknown
-		if (typeof raw !== 'object' || raw === null) return null
-		const obj = raw as Record<string, unknown>
-		if (typeof obj.version !== 'number') return null
-		// v4+ keeps config under `record`; v1–v3 keep it at the top level (#559).
-		const config =
-			obj.version >= LOCKFILE_VERSION
-				? (obj.record as Record<string, unknown> | undefined)?.config
-				: obj.config
-		if (typeof config !== 'object' || config === null) return null
-		return migrate(obj)
+		return parseLockfile((await fs.readJson(filepath)) as unknown)
 	} catch {
 		return null
 	}

--- a/src/cli/utils/reference-rules.ts
+++ b/src/cli/utils/reference-rules.ts
@@ -1,0 +1,169 @@
+import { type GhExec, realGhExec } from '../../base/github-settings.js'
+import { type JsonSchema, validateAgainstSchema } from './json-schema.js'
+import {
+	type Lockfile,
+	LOCKFILE_NAME,
+	lockfileSchema,
+	parseLockfile,
+	readLockfile,
+} from './lockfile.js'
+
+/**
+ * Rules are per-repo (#563): there is no guideline package, so sharing a
+ * guideline means pointing at another repo. This module is the one fetcher both
+ * halves of that share — `doctor --rules-from` reads a reference repo's rules to
+ * report differences, and `setup --from` reads the same file to seed the wizard.
+ *
+ * The reference is untrusted input from end to end: the `owner/repo` string is
+ * shape-checked before it reaches an API path, the response is size-capped, and
+ * the JSON is validated against the published schema before a single field is
+ * read. Nothing here ever writes, and nothing is ever applied.
+ */
+
+/**
+ * `owner/repo`. The injection boundary — the reference is interpolated into the
+ * gh API path below, so anything with a slash, `..` or a shell metacharacter in
+ * it has to be rejected here rather than defended against later.
+ */
+const REFERENCE = /^[A-Za-z0-9][A-Za-z0-9._-]*\/[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/**
+ * Generous by four orders of magnitude — a real lockfile is ~1 KB. This is not a
+ * tuning knob, it is the "huge file" guard: the response is fully buffered by the
+ * time we see it, so the cap stops us parsing and diffing a repo's 40 MB joke.
+ */
+const MAX_BYTES = 128 * 1024
+
+export type ReferenceResult = { ok: true; lockfile: Lockfile } | { ok: false; reason: string }
+
+/**
+ * The GitHub arm of the fetch. Another forge is a second function of this shape
+ * dispatched from fetchReferenceLockfile — everything downstream (size cap,
+ * parse, schema validation, diff) is forge-agnostic and already shared.
+ */
+async function fetchFromGitHub(
+	reference: string,
+	exec?: GhExec
+): Promise<{ ok: true; text: string } | { ok: false; reason: string }> {
+	const gh: GhExec = exec ?? ((args, stdin) => realGhExec(args, stdin))
+	// `Accept: raw` returns the file itself rather than the base64-in-JSON envelope.
+	const r = await gh([
+		'api',
+		`repos/${reference}/contents/${LOCKFILE_NAME}`,
+		'-H',
+		'Accept: application/vnd.github.raw',
+	])
+	if (r.ok) return { ok: true, text: r.stdout }
+	if (/HTTP 404/.test(r.stderr)) {
+		return { ok: false, reason: `${reference} has no ${LOCKFILE_NAME} (or is not visible to you)` }
+	}
+	const detail = r.stderr.trim().split('\n').pop() ?? 'gh failed'
+	return { ok: false, reason: `could not read ${reference}: ${detail}` }
+}
+
+function parseReference(reference: string, text: string): ReferenceResult {
+	if (Buffer.byteLength(text) > MAX_BYTES) {
+		return {
+			ok: false,
+			reason: `${reference}'s ${LOCKFILE_NAME} is larger than ${MAX_BYTES} bytes`,
+		}
+	}
+	let raw: unknown
+	try {
+		raw = JSON.parse(text)
+	} catch {
+		return { ok: false, reason: `${reference}'s ${LOCKFILE_NAME} is not valid JSON` }
+	}
+	// Migrate first, then validate: an older reference is flat on disk and would
+	// fail the current schema for a reason that says nothing about its rules.
+	const lockfile = parseLockfile(raw)
+	if (!lockfile) {
+		return { ok: false, reason: `${reference}'s ${LOCKFILE_NAME} is not a recognisable lockfile` }
+	}
+	const errors = validateAgainstSchema(lockfile, lockfileSchema() as unknown as JsonSchema)
+	if (errors.length > 0) {
+		return {
+			ok: false,
+			reason: `${reference}'s ${LOCKFILE_NAME} fails the published schema: ${errors.slice(0, 3).join('; ')}`,
+		}
+	}
+	return { ok: true, lockfile }
+}
+
+export async function fetchReferenceLockfile(
+	reference: string,
+	exec?: GhExec
+): Promise<ReferenceResult> {
+	if (!REFERENCE.test(reference)) {
+		return { ok: false, reason: `"${reference}" is not an owner/repo reference` }
+	}
+	const fetched = await fetchFromGitHub(reference, exec)
+	if (!fetched.ok) return fetched
+	return parseReference(reference, fetched.text)
+}
+
+export interface RuleDifference {
+	/** Dotted path within the rules view, e.g. `config.bundler`. */
+	path: string
+	/** `undefined` means the path is absent on that side. */
+	local: unknown
+	reference: unknown
+}
+
+/**
+ * The comparable half of a lockfile: the resolved config plus the human-written
+ * rules. `assets` hashes and the `writtenBy`/`writtenAt` stamps are excluded on
+ * purpose — they differ between any two repos by construction, so diffing them
+ * would bury every difference that means something.
+ */
+function rulesView(lock: Lockfile): Record<string, unknown> {
+	return { config: lock.record.config, ...(lock.rules ?? {}) }
+}
+
+function flatten(
+	value: unknown,
+	prefix = '',
+	out = new Map<string, unknown>()
+): Map<string, unknown> {
+	// Arrays are leaves: `requiredSkills` differing by one entry is one difference
+	// about the list, not a per-index report that shifts when the order does.
+	if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+		for (const [key, child] of Object.entries(value)) {
+			flatten(child, prefix ? `${prefix}.${key}` : key, out)
+		}
+		return out
+	}
+	out.set(prefix, value)
+	return out
+}
+
+export function diffRules(local: Lockfile | null, reference: Lockfile): RuleDifference[] {
+	const mine = local ? flatten(rulesView(local)) : new Map<string, unknown>()
+	const theirs = flatten(rulesView(reference))
+	return [...new Set([...mine.keys(), ...theirs.keys()])]
+		.sort()
+		.filter((p) => JSON.stringify(mine.get(p)) !== JSON.stringify(theirs.get(p)))
+		.map((p) => ({ path: p, local: mine.get(p), reference: theirs.get(p) }))
+}
+
+export interface RulesComparison {
+	reference: string
+	/** False when the reference could not be read — never a finding about this repo. */
+	compared: boolean
+	reason?: string
+	differences?: RuleDifference[]
+}
+
+export async function compareRulesWithReference(
+	dir: string,
+	reference: string,
+	exec?: GhExec
+): Promise<RulesComparison> {
+	const result = await fetchReferenceLockfile(reference, exec)
+	if (!result.ok) return { reference, compared: false, reason: result.reason }
+	return {
+		reference,
+		compared: true,
+		differences: diffRules(await readLockfile(dir), result.lockfile),
+	}
+}

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -806,6 +806,37 @@ describe('setup language prompt', () => {
 		expect(lock.rules).toBeUndefined()
 	})
 
+	// The reference is untrusted and remote, so "could not read it" is an ordinary
+	// outcome, not a crash. Declining leaves the directory untouched rather than
+	// scaffolding generic defaults the user never asked for.
+	it('declines plainly when the reference cannot be read', async () => {
+		const dir = newTmpDir()
+		vi.mocked(fetchReferenceLockfile).mockResolvedValue({
+			ok: false,
+			reason: 'someone/theirs has no .repo-tooling.json (or is not visible to you)',
+		})
+		const spy = mockPrompt({ language: 'js' }, JS_ANSWERS)
+		const errors: string[] = []
+		const errSpy = vi.spyOn(console, 'error').mockImplementation((m) => errors.push(String(m)))
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never)
+		try {
+			await setupProject({ directory: dir, skipInstall: true, from: 'someone/theirs' })
+		} finally {
+			logSpy.mockRestore()
+			errSpy.mockRestore()
+			exitSpy.mockRestore()
+		}
+		expect(errors.join('\n')).toContain('Cannot seed from someone/theirs')
+		expect(errors.join('\n')).toContain('is not visible to you')
+		// Reported, not thrown: no `Setup failed:` dump and no non-zero exit.
+		expect(errors.join('\n')).not.toContain('Setup failed')
+		expect(exitSpy).not.toHaveBeenCalled()
+		// Declined before the wizard ran, so nothing was asked and nothing written.
+		expect(spy).not.toHaveBeenCalled()
+		expect(await fs.pathExists(join(dir, '.repo-tooling.json'))).toBe(false)
+	})
+
 	it('ignores --from when --preset already skips the wizard', async () => {
 		const dir = newTmpDir()
 		// vi.restoreAllMocks() leaves a module-factory vi.fn's call log intact.

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -11,7 +11,15 @@ import {
 	validateProjectConfig,
 } from '../../../src/cli/commands/setup-presets.js'
 import { generateConfigs } from '../../../src/cli/generators/index.js'
+import { fetchReferenceLockfile } from '../../../src/cli/utils/reference-rules.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+// `setup --from` is the only thing in this file that would reach the network.
+// The fetch itself is covered in tests/cli/utils/reference-rules.test.ts; what
+// matters here is that a reference config lands on the wizard's defaults.
+vi.mock('../../../src/cli/utils/reference-rules.js', () => ({
+	fetchReferenceLockfile: vi.fn(),
+}))
 
 const newTmpDir = useTmpDir()
 
@@ -737,6 +745,87 @@ describe('setup language prompt', () => {
 		}
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
 		expect(lock.record.config.language).toBe('js')
+	})
+
+	// #563: rules are per-repo, so sharing a guideline means pointing at another
+	// repo. `--from` seeds the wizard from one — seeded, never skipped, so nothing
+	// is written that the user did not see and confirm.
+	it('seeds the wizard defaults from a reference repo without copying its record', async () => {
+		const dir = newTmpDir()
+		vi.mocked(fetchReferenceLockfile).mockResolvedValue({
+			ok: true,
+			lockfile: {
+				version: 4,
+				record: {
+					config: {
+						...buildPresetConfig('node-api', 'reference-repo'),
+						linting: { tool: 'eslint', eslintConfig: 'base' },
+						testing: { framework: 'jest', environment: 'both' },
+						bundler: 'esbuild',
+						gitHooks: false,
+						semanticRelease: false,
+						changesets: true,
+					},
+					assets: { biome: 'a'.repeat(64) },
+					writtenBy: '@rtorcato/repo-tooling@1.2.3',
+					writtenAt: '2026-01-01T00:00:00.000Z',
+				},
+				rules: { aiLoop: { agentUser: 'some-bot' } },
+			},
+		})
+		const spy = mockPrompt({ language: 'js' }, JS_ANSWERS)
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({ directory: dir, skipInstall: true, from: 'someone/theirs' })
+		} finally {
+			logSpy.mockRestore()
+		}
+		expect(fetchReferenceLockfile).toHaveBeenCalledWith('someone/theirs')
+
+		const [questions] = spy.mock.calls[1] as [Array<{ name: string; default?: unknown }>]
+		const defaults = Object.fromEntries(questions.map((q) => [q.name, q.default]))
+		expect(defaults).toMatchObject({
+			projectType: 'node-api',
+			useTypeScript: true,
+			lintingTool: 'eslint',
+			eslintConfig: 'base',
+			testingFramework: 'jest',
+			testEnvironment: 'both',
+			bundler: 'esbuild',
+			gitHooks: false,
+			// The config stores this as three booleans; the wizard asks it as one pick.
+			releaseTool: 'changesets',
+		})
+		// A new repo is not the reference repo: its name is never seeded.
+		expect(defaults.projectName).not.toBe('reference-repo')
+		// Record-side fields never cross over — this repo stamps its own, and the
+		// reference's rules stay with the repo that argued for them.
+		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
+		expect(lock.record.writtenBy).not.toBe('@rtorcato/repo-tooling@1.2.3')
+		expect(lock.record.assets).toBeUndefined()
+		expect(lock.rules).toBeUndefined()
+	})
+
+	it('ignores --from when --preset already skips the wizard', async () => {
+		const dir = newTmpDir()
+		// vi.restoreAllMocks() leaves a module-factory vi.fn's call log intact.
+		vi.mocked(fetchReferenceLockfile).mockClear()
+		const warnings: string[] = []
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation((m) => warnings.push(String(m)))
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+		try {
+			await setupProject({
+				directory: dir,
+				preset: 'library',
+				skipInstall: true,
+				from: 'someone/theirs',
+			})
+		} finally {
+			logSpy.mockRestore()
+			warnSpy.mockRestore()
+		}
+		expect(fetchReferenceLockfile).not.toHaveBeenCalled()
+		expect(warnings.join('\n')).toContain('ignoring --from')
 	})
 
 	// #463: every test above spies on `inquirer.prompt`, which replaces the

--- a/tests/cli/utils/lockfile-schema.test.ts
+++ b/tests/cli/utils/lockfile-schema.test.ts
@@ -3,6 +3,10 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { CONFIG_SCHEMA } from '../../../src/cli/commands/setup-presets.js'
+import {
+	type JsonSchema,
+	validateAgainstSchema as validate,
+} from '../../../src/cli/utils/json-schema.js'
 import { lockfileSchema } from '../../../src/cli/utils/lockfile.js'
 
 const repoRoot = join(fileURLToPath(new URL('.', import.meta.url)), '../../..')
@@ -38,76 +42,6 @@ describe('published JSON Schemas', () => {
 		)
 	})
 })
-
-interface JsonSchema {
-	type?: string
-	enum?: readonly string[]
-	minLength?: number
-	required?: readonly string[]
-	properties?: Record<string, JsonSchema>
-	additionalProperties?: boolean | JsonSchema
-	items?: JsonSchema
-}
-
-/**
- * Validate against the keyword subset lockfileSchema() actually uses: type
- * (object/array/string/integer/boolean), enum, minLength, required, properties,
- * additionalProperties (`false` or a schema) and items. Returns one message per
- * problem.
- *
- * Hand-rolled because the repo has no JSON Schema validator, and the schema
- * leans on seven keywords — not enough to justify an ajv devDependency.
- */
-// ponytail: `format: date-time` on writtenAt is not checked, and neither are
-// composition keywords — none appear in the schema. Reach for ajv the day one
-// does.
-function validate(value: unknown, schema: JsonSchema, path = '$'): string[] {
-	const errors: string[] = []
-	if (schema.enum && !schema.enum.includes(value as string)) {
-		errors.push(`${path}: ${JSON.stringify(value)} is not one of ${schema.enum.join(', ')}`)
-	}
-	if (schema.type === 'array') {
-		if (!Array.isArray(value)) return [`${path}: expected array`]
-		if (schema.items) {
-			for (const [i, item] of value.entries()) {
-				errors.push(...validate(item, schema.items, `${path}[${i}]`))
-			}
-		}
-		return errors
-	}
-	if (schema.type === 'object') {
-		if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-			return [`${path}: expected object`]
-		}
-		const obj = value as Record<string, unknown>
-		for (const key of schema.required ?? []) {
-			if (!(key in obj)) errors.push(`${path}: missing required property "${key}"`)
-		}
-		for (const [key, child] of Object.entries(obj)) {
-			const property = schema.properties?.[key]
-			if (property) errors.push(...validate(child, property, `${path}.${key}`))
-			else if (schema.additionalProperties === false) {
-				errors.push(`${path}: unknown property "${key}"`)
-			} else if (typeof schema.additionalProperties === 'object') {
-				errors.push(...validate(child, schema.additionalProperties, `${path}.${key}`))
-			}
-		}
-		return errors
-	}
-	if (schema.type === 'integer') {
-		if (!Number.isInteger(value)) errors.push(`${path}: expected integer`)
-	} else if (schema.type && typeof value !== schema.type) {
-		errors.push(`${path}: expected ${schema.type}, got ${typeof value}`)
-	}
-	if (
-		schema.minLength !== undefined &&
-		typeof value === 'string' &&
-		value.length < schema.minLength
-	) {
-		errors.push(`${path}: shorter than minLength ${schema.minLength}`)
-	}
-	return errors
-}
 
 describe("this repo's own lockfile", () => {
 	const schema = lockfileSchema() as unknown as JsonSchema

--- a/tests/cli/utils/reference-rules.test.ts
+++ b/tests/cli/utils/reference-rules.test.ts
@@ -1,0 +1,193 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it, vi } from 'vitest'
+import { buildPresetConfig } from '../../../src/cli/commands/setup-presets.js'
+import type { GhExec, GhResult } from '../../../src/base/github-settings.js'
+import {
+	compareRulesWithReference,
+	fetchReferenceLockfile,
+} from '../../../src/cli/utils/reference-rules.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+const gh = (r: Partial<GhResult>): GhExec =>
+	vi.fn(async () => ({ ok: true, stdout: '', stderr: '', code: 0, ...r }))
+
+/** gh returning a file body verbatim, the way `Accept: raw` does. */
+const serving = (body: unknown) =>
+	gh({ stdout: typeof body === 'string' ? body : JSON.stringify(body) })
+
+const REFERENCE_LOCKFILE = {
+	$schema: 'https://rtorcato.github.io/repo-tooling/schemas/lockfile.json',
+	version: 4,
+	record: {
+		config: buildPresetConfig('library', 'reference-repo'),
+		assets: { biome: 'a'.repeat(64) },
+		writtenBy: '@rtorcato/repo-tooling@1.2.3',
+		writtenAt: '2026-01-01T00:00:00.000Z',
+	},
+	rules: {
+		aiLoop: { agentUser: 'some-bot' },
+		requiredSkills: ['ai-issue-loop'],
+	},
+}
+
+async function repoWith(lockfile: unknown): Promise<string> {
+	const dir = newTmpDir()
+	await fs.writeJson(join(dir, '.repo-tooling.json'), lockfile)
+	return dir
+}
+
+describe('fetchReferenceLockfile', () => {
+	it('rejects a reference that is not owner/repo before it reaches an API path', async () => {
+		const exec = gh({})
+		for (const bad of ['evil/../../repos', 'owner/repo/extra', 'owner', '../../etc', 'a b/c']) {
+			const r = await fetchReferenceLockfile(bad, exec)
+			expect(r.ok, bad).toBe(false)
+			expect(r.ok === false && r.reason).toContain('not an owner/repo reference')
+		}
+		expect(exec).not.toHaveBeenCalled()
+	})
+
+	it('reports a missing reference file plainly', async () => {
+		const r = await fetchReferenceLockfile(
+			'someone/theirs',
+			gh({ ok: false, stderr: 'gh: Not Found (HTTP 404)', code: 1 })
+		)
+		expect(r.ok).toBe(false)
+		expect(r.ok === false && r.reason).toContain('has no .repo-tooling.json')
+	})
+
+	it('reports a gh failure without claiming the file is missing', async () => {
+		const r = await fetchReferenceLockfile(
+			'someone/theirs',
+			gh({ ok: false, stderr: 'gh: could not resolve host', code: 1 })
+		)
+		expect(r.ok).toBe(false)
+		expect(r.ok === false && r.reason).toContain('could not read someone/theirs')
+	})
+
+	it('reports malformed JSON instead of crashing', async () => {
+		const r = await fetchReferenceLockfile('someone/theirs', serving('{ not json'))
+		expect(r.ok).toBe(false)
+		expect(r.ok === false && r.reason).toContain('not valid JSON')
+	})
+
+	it('rejects well-formed JSON that is not a lockfile', async () => {
+		const r = await fetchReferenceLockfile('someone/theirs', serving({ hello: 'world' }))
+		expect(r.ok).toBe(false)
+		expect(r.ok === false && r.reason).toContain('not a recognisable lockfile')
+	})
+
+	it('rejects a lockfile that fails the published schema', async () => {
+		const r = await fetchReferenceLockfile(
+			'someone/theirs',
+			serving({ ...REFERENCE_LOCKFILE, strayKey: 'surprise' })
+		)
+		expect(r.ok).toBe(false)
+		expect(r.ok === false && r.reason).toContain('fails the published schema')
+	})
+
+	it('rejects a reference file too large to be a lockfile', async () => {
+		const r = await fetchReferenceLockfile('someone/theirs', serving('x'.repeat(128 * 1024 + 1)))
+		expect(r.ok).toBe(false)
+		expect(r.ok === false && r.reason).toContain('larger than')
+	})
+
+	it('accepts a valid reference and asks gh for the raw file', async () => {
+		const exec = serving(REFERENCE_LOCKFILE)
+		const r = await fetchReferenceLockfile('someone/theirs', exec)
+		expect(r.ok).toBe(true)
+		expect(r.ok === true && r.lockfile.record.config.projectName).toBe('reference-repo')
+		expect(exec).toHaveBeenCalledWith([
+			'api',
+			'repos/someone/theirs/contents/.repo-tooling.json',
+			'-H',
+			'Accept: application/vnd.github.raw',
+		])
+	})
+
+	// An older reference is flat on disk; validating before migrating would reject
+	// it for a reason that says nothing about its rules.
+	it('migrates an older flat reference before validating it', async () => {
+		const r = await fetchReferenceLockfile(
+			'someone/theirs',
+			serving({
+				version: 3,
+				config: buildPresetConfig('library', 'old-repo'),
+				aiLoop: { agentUser: 'some-bot' },
+				writtenBy: '@rtorcato/repo-tooling@1.0.0',
+				writtenAt: '2025-01-01T00:00:00.000Z',
+			})
+		)
+		expect(r.ok).toBe(true)
+		expect(r.ok === true && r.lockfile.rules?.aiLoop?.agentUser).toBe('some-bot')
+	})
+})
+
+describe('compareRulesWithReference', () => {
+	it('reports identical rules even when the record halves differ', async () => {
+		// Same config and rules; different asset hashes and stamps — which is the
+		// normal state of any two repos, and must not read as a difference.
+		const dir = await repoWith({
+			...REFERENCE_LOCKFILE,
+			record: {
+				...REFERENCE_LOCKFILE.record,
+				assets: { biome: 'b'.repeat(64) },
+				writtenBy: '@rtorcato/repo-tooling@9.9.9',
+				writtenAt: '2026-06-06T00:00:00.000Z',
+			},
+		})
+		const comparison = await compareRulesWithReference(
+			dir,
+			'someone/theirs',
+			serving(REFERENCE_LOCKFILE)
+		)
+		expect(comparison.compared).toBe(true)
+		expect(comparison.differences).toEqual([])
+	})
+
+	it('names every rules-side field that differs, and only those', async () => {
+		const dir = await repoWith({
+			...REFERENCE_LOCKFILE,
+			record: {
+				...REFERENCE_LOCKFILE.record,
+				config: { ...REFERENCE_LOCKFILE.record.config, bundler: 'esbuild' },
+			},
+			rules: { aiLoop: { agentUser: 'some-bot' }, requiredSkills: ['ai-workflow'] },
+		})
+		const comparison = await compareRulesWithReference(
+			dir,
+			'someone/theirs',
+			serving(REFERENCE_LOCKFILE)
+		)
+		expect(comparison.differences).toEqual([
+			{ path: 'config.bundler', local: 'esbuild', reference: 'tsup' },
+			{ path: 'requiredSkills', local: ['ai-workflow'], reference: ['ai-issue-loop'] },
+		])
+	})
+
+	it('treats a repo with no lockfile as absent on every path, not as an error', async () => {
+		const comparison = await compareRulesWithReference(
+			newTmpDir(),
+			'someone/theirs',
+			serving(REFERENCE_LOCKFILE)
+		)
+		expect(comparison.compared).toBe(true)
+		expect(comparison.differences?.length).toBeGreaterThan(0)
+		expect(comparison.differences?.every((d) => d.local === undefined)).toBe(true)
+		expect(comparison.differences?.map((d) => d.path)).toContain('aiLoop.agentUser')
+	})
+
+	it('carries the reason forward when the reference cannot be read', async () => {
+		const comparison = await compareRulesWithReference(
+			newTmpDir(),
+			'someone/theirs',
+			gh({ ok: false, stderr: 'gh: Not Found (HTTP 404)', code: 1 })
+		)
+		expect(comparison.compared).toBe(false)
+		expect(comparison.reason).toContain('has no .repo-tooling.json')
+		expect(comparison.differences).toBeUndefined()
+	})
+})


### PR DESCRIPTION
🤖 *Opened by an agent via ai-issue-loop.*

Rules are per-repo and **there is no guideline package** — so sharing a guideline means pointing at a *reference repo*. This adds both directions of that, over one shared fetcher, on top of the `record`/`rules` split from #559.

Closes #563

## The two capabilities

**`doctor --rules-from owner/repo`** — reports where this repo's rules differ from that repo's.

```
📐 Rules vs rtorcato/repo-tooling (informational — differences are not drift and do not affect the exit code)

  config.bundler
     here: "esbuild"
     rtorcato/repo-tooling: "none"
  requiredSkills
     here: ["ai-issue"]
     rtorcato/repo-tooling: ["ai-issue-loop","ai-workflow","ai-issue","ai-loop-status"]

  2 difference(s).
```

**`setup --from owner/repo`** — seeds the wizard's defaults from that repo's recorded config. Seeded, **not skipped**: every question is still asked, so nothing is written the user did not see.

## Design decisions worth reviewing

- **A flag, not a committed field.** A committed `rulesFrom` would make one repo's rules a standing input to another's audit, which is the guideline-package shape wearing a different hat. A flag keeps the comparison something a human asks for, on the run they ask for it.
- **Not a `CheckResult`.** The comparison is printed in its own section and, under `--json`, as a sibling `rulesReference` key. Keeping it out of `results` is what makes "never drift, never affects the exit code" *structural* rather than a promise the next check has to remember — it cannot reach `summarize()` at all.
- **What is compared:** `record.config` plus everything under `rules`. `assets` hashes and the `writtenBy`/`writtenAt` stamps are excluded — they differ between any two repos by construction, so including them would bury every difference that means something. There is a test that asserts exactly this (identical rules, deliberately different record halves → zero differences).
- **`setup --from` copies `record.config` only.** Not `projectName` (a new repo is not the reference repo), not the record-side stamps, and **not `rules`** — an `exceptions` entry excuses a deviation in the repo that argued for it, so copying one would mute a check somewhere it is still a real finding. If you want `aiLoop`/`requiredSkills`/`mcp` to travel too, say so and I will follow up; I left it out deliberately rather than by omission.

## Untrusted input, end to end

The reference repo is never trusted:

- `owner/repo` is shape-checked against a regex **before** it reaches the gh API path (it is interpolated there). `evil/../../repos` is rejected without spawning `gh`.
- The response is size-capped at 128 KB before it is parsed.
- The JSON is migrated (so an older flat reference is judged on its rules, not its layout) and then **validated against the published schema** before a single field is read.
- Missing, malformed, oversized, schema-invalid, or gh-unavailable are each reported plainly and the comparison is skipped — never as a finding about *your* repo, never a crash.
- Nothing from the reference is ever written. No fixer.

## Shape of the code

- `src/cli/utils/reference-rules.ts` — the one fetcher both paths share. `fetchFromGitHub` is the only forge-specific function; the size cap, parse, schema validation and diff downstream of it are forge-agnostic, so another forge is a second function dispatched from `fetchReferenceLockfile`, not a rewrite.
- `src/cli/utils/json-schema.ts` — the hand-rolled schema validator **moved out of `tests/cli/utils/lockfile-schema.test.ts`**, unchanged. It had to live in `src` for the untrusted-input check; the test now imports it, so the self-validation suite and the reference check are provably the same validator. Still no ajv.
- `parseLockfile()` split out of `readLockfile()` so a lockfile fetched over `gh` goes through the exact same v1–v4 migration as one read off disk.

## Tests

`tests/cli/utils/reference-rules.test.ts` (13 cases) covers the four the issue names — missing, malformed, valid-with-differences, valid-identical — plus: reference-string rejection before any API call, non-lockfile JSON, schema-invalid, oversized, gh failure distinguished from 404, an older flat reference migrated before validation, and a repo with no lockfile of its own. `tests/cli/commands/setup.test.ts` adds the config→wizard-defaults mapping (including the two derived answers, `releaseTool` and `orchestrator`) and asserts the record side does not cross over.

- `pnpm run verify`: **1142 passed, 1 expected fail** (pre-existing), lint/typecheck/build clean.
- Smoke-tested the built CLI against a scratch repo with a real `gh`: identical, with-differences, 404 reference, and malformed reference string all render correctly, and the exit code stays driven by the checks alone.
- No new doctor check, so the pinned check lists in `tests/languages/{python,swift,perl}/fixers.test.ts` are untouched.
- **Not verified:** the interactive `setup --from` terminal session. The defaults are asserted by inspecting the question list handed to inquirer (the #463 pattern), and `--from`'s CLI wiring was confirmed against the built binary, but I did not drive a live TTY wizard.

Per the repo's install guidance I did not run `pnpm install`; no dependencies changed.
