### PR TITLE
fix(swift): preserve an existing Package.swift instead of overwriting it

### DIFF
--- a/src/languages/swift/scaffold.ts
+++ b/src/languages/swift/scaffold.ts
@@ -19,7 +19,12 @@ import { generateEditorConfig } from '../../cli/generators/misc.js'
 import { generateCodeQLWorkflow, generateDependabotConfig } from '../../cli/generators/security.js'
 import { copyPreset } from '../../cli/utils/copy-preset.js'
 import { LANGUAGES } from '../registry.js'
-import { readSwiftPackage, renderSwiftReleaseWorkflow, renderSwiftWorkflow } from './ci.js'
+import {
+	parsePackageSwift,
+	readSwiftPackage,
+	renderSwiftReleaseWorkflow,
+	renderSwiftWorkflow,
+} from './ci.js'
 import { SWIFT_HOOKS_DIR, installSwiftGitHooks } from './git-hooks.js'
 import { ensureSwiftGitignore } from './gitignore.js'
 
@@ -205,6 +210,10 @@ git tag 1.0.0 && git push origin 1.0.0
 /**
  * Relative paths `setup --dry-run` reports for a Swift config, in write order.
  * Kept beside the writer so the two can't drift.
+ *
+ * This is the greenfield list. Against a directory that already has a
+ * Package.swift the writer preserves it and skips the target scaffolding, so the
+ * preview over-reports there — the safe direction for a dry run.
  */
 export function swiftFileList(config: ProjectConfig): string[] {
 	const module = swiftModuleName(config.projectName)
@@ -246,19 +255,36 @@ export function swiftFileList(config: ProjectConfig): string[] {
 	return files
 }
 
-/** Scaffold a SwiftPM library. The Swift arm of `generateConfigs`. */
+/**
+ * Scaffold a SwiftPM library. The Swift arm of `generateConfigs`.
+ *
+ * Package.swift is source, not config (#574): rewriting one that already exists
+ * renames the package after the *directory* and leaves the real `Sources/<Target>/`
+ * declared by no target — and `swift build` still exits 0, because SwiftPM just
+ * ignores the orphaned directory. So an existing manifest is left byte-identical
+ * and the module name is read back off it rather than derived from the directory,
+ * the same way the JS presets merge into a package.json instead of replacing it.
+ */
 export async function generateSwiftProject(config: ProjectConfig, targetDir: string) {
-	const module = swiftModuleName(config.projectName)
+	const manifestPath = path.join(targetDir, 'Package.swift')
+	const existingManifest = (await fs.pathExists(manifestPath))
+		? parsePackageSwift(await fs.readFile(manifestPath, 'utf-8'))
+		: null
+	const module = existingManifest?.products[0] ?? swiftModuleName(config.projectName)
 
-	await fs.writeFile(path.join(targetDir, 'Package.swift'), packageSwift(module))
-	await fs.outputFile(
-		path.join(targetDir, 'Sources', module, `${module}.swift`),
-		sourceFile(module)
-	)
-	await fs.outputFile(
-		path.join(targetDir, 'Tests', `${module}Tests`, `${module}Tests.swift`),
-		testFile(module)
-	)
+	// Nothing is scaffolded under Sources/ or Tests/ either: those would be
+	// directories for a target the existing manifest doesn't declare.
+	if (!existingManifest) {
+		await fs.writeFile(manifestPath, packageSwift(module))
+		await fs.outputFile(
+			path.join(targetDir, 'Sources', module, `${module}.swift`),
+			sourceFile(module)
+		)
+		await fs.outputFile(
+			path.join(targetDir, 'Tests', `${module}Tests`, `${module}Tests.swift`),
+			testFile(module)
+		)
+	}
 
 	await copyPreset('swiftlint', targetDir)
 	await copyPreset('periphery', targetDir)

--- a/tests/languages/swift/scaffold.test.ts
+++ b/tests/languages/swift/scaffold.test.ts
@@ -160,6 +160,61 @@ describe('generateSwiftProject', () => {
 		expect(editorconfig).toMatch(/\[\*\.swift\][\s\S]*indent_style = space/)
 	})
 
+	// #574: Package.swift is source. Rewriting one that exists renames the package
+	// after the directory and orphans Sources/<Target>/ — and `swift build` still
+	// exits 0, so the loss is silent.
+	describe('with a Package.swift already on disk', () => {
+		const EXISTING = `// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "Widget",
+    products: [
+        .library(name: "Widget", targets: ["Widget"])
+    ],
+    targets: [
+        .target(name: "Widget")
+    ]
+)
+`
+
+		async function scaffoldOver() {
+			const dir = newTmpDir()
+			await fs.writeFile(join(dir, 'Package.swift'), EXISTING)
+			await fs.outputFile(join(dir, 'Sources/Widget/Widget.swift'), 'public enum Widget {}\n')
+			await generateSwiftProject(buildPresetConfig('swift-library', 'swiftlib'), dir)
+			return dir
+		}
+
+		it('leaves the manifest byte-identical', async () => {
+			const dir = await scaffoldOver()
+			expect(await fs.readFile(join(dir, 'Package.swift'), 'utf-8')).toBe(EXISTING)
+		})
+
+		it('scaffolds no target the manifest does not declare', async () => {
+			const dir = await scaffoldOver()
+			expect(await fs.pathExists(join(dir, 'Sources/Swiftlib'))).toBe(false)
+			expect(await fs.pathExists(join(dir, 'Tests/SwiftlibTests'))).toBe(false)
+			expect(await fs.pathExists(join(dir, 'Sources/Widget/Widget.swift'))).toBe(true)
+		})
+
+		it('names the README after the manifest, not the directory', async () => {
+			const dir = await scaffoldOver()
+			const readme = await fs.readFile(join(dir, 'README.md'), 'utf-8')
+			expect(readme).toContain('Sources/Widget/')
+			expect(readme).not.toContain('Swiftlib')
+		})
+
+		// The rest of the standard still lands — preserving the manifest is not a
+		// reason to skip the linter config or CI.
+		it('still writes the surrounding tooling', async () => {
+			const dir = await scaffoldOver()
+			expect(await fs.pathExists(join(dir, '.swiftlint.yml'))).toBe(true)
+			expect(await fs.pathExists(join(dir, '.github/workflows/ci.yml'))).toBe(true)
+		})
+	})
+
 	it('omits security workflows when securityAutomation is off', async () => {
 		const dir = newTmpDir()
 		await generateSwiftProject(


### PR DESCRIPTION
🤖 *Opened by an agent via ai-issue-loop.*

**Swift support is still being built out, so this is deliberately scoped to the preserve rule and nothing else.** No restructuring of the preset, no new doctor check — just the one guard that stops the data loss, so it should not collide with work in progress.

Closes #574

## The defect

`setup --preset swift-library` rewrote any `Package.swift` already on disk. Three losses in one write: the package was renamed after the *directory*, tools-version was bumped, and platform floors were invented — leaving the real `Sources/<Target>/` declared by no target.

The part that makes it worth a guard rather than a note: **SwiftPM ignores an undeclared directory, so `swift build` still exits 0** and `doctor` reports clean. A build error would be noticed; this is not.

## The fix

`Package.swift` is source, not config. `generateSwiftProject` now reads the manifest before writing anything, and when one exists:

- it is left **byte-identical** — not merged, not extended;
- the module name is read back off the manifest (`.library(name:)`) rather than derived from the directory;
- nothing is scaffolded under `Sources/` or `Tests/`, since those would be directories for a target the manifest does not declare.

Everything else in the standard still lands — SwiftLint config, Periphery, CI, hooks, security workflows — so running the preset over an existing package remains useful. This mirrors how the JS presets already treat `package.json`. Reuses the existing `parsePackageSwift`; no new parser.

## Tests

Four new cases in `tests/languages/swift/scaffold.test.ts`, against a directory holding a tools-version 5.9 manifest declaring target `Widget` plus `Sources/Widget/Widget.swift`. The first three fail on `main`:

- manifest is byte-identical after the run
- no `Sources/Swiftlib` or `Tests/SwiftlibTests` appears, and `Sources/Widget/Widget.swift` survives
- the README names `Widget`, not the directory
- `.swiftlint.yml` and CI are still written

Full suite green (1147 passed), biome and tsc clean.

## Not done here

The doctor check for sources under `Sources/` belonging to no declared target is a larger, separate piece of work — filed rather than built.

Follow-up: #575
