### PR TITLE
fix(setup): make the library preset own the build script it writes exports for

### DIFF
--- a/src/cli/generators/package-json.ts
+++ b/src/cli/generators/package-json.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import fs from 'fs-extra'
 import path from 'node:path'
 import type { ProjectConfig } from '../commands/setup.js'
@@ -13,6 +14,9 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 
 	const includeTreeshake = Boolean(config.treeshakeCheck && config.projectType === 'library')
 
+	const generatedScripts = getScripts(config, { includeTreeshake })
+	const existingScripts: Record<string, string> = (existingPackageJson as any)?.scripts ?? {}
+
 	const packageJson: any = {
 		name: config.projectName,
 		version: '0.1.0',
@@ -22,10 +26,7 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 		// generated workflows carry no `version:` input (#364).
 		packageManager: `pnpm@${detectPnpmVersion() ?? PNPM_FALLBACK_VERSION}`,
 		...existingPackageJson,
-		scripts: {
-			...getScripts(config, { includeTreeshake }),
-			...(existingPackageJson as any)?.scripts,
-		},
+		scripts: resolveScripts(config, generatedScripts, existingScripts),
 		dependencies: {
 			...(existingPackageJson as any)?.dependencies,
 		},
@@ -74,6 +75,40 @@ export async function generatePackageJson(config: ProjectConfig, targetDir: stri
 	// (see ensureBuildApprovals in build.ts).
 
 	await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 })
+}
+
+/**
+ * Merge the generated scripts with what the package.json already had. Existing
+ * values win — that merge-don't-clobber policy is what makes re-running `setup`
+ * on a live repo safe.
+ *
+ * `build` on a library is the one exception. The library branch of
+ * generatePackageJson overwrites the whole publish contract
+ * (main/module/types/exports) unconditionally, and that contract names files
+ * only the preset's bundler emits: a preserved `build: tsc` produces
+ * dist/index.js + dist/index.d.ts and never the ./dist/index.cjs that `main`
+ * and every `require` condition point at, so `pnpm build && npm publish` ships
+ * a package whose CJS entry points 404 (#570). Owning the contract means owning
+ * its producer; the replacement is announced rather than silent.
+ */
+function resolveScripts(
+	config: ProjectConfig,
+	generated: Record<string, string>,
+	existing: Record<string, string>
+): Record<string, string> {
+	const scripts = { ...generated, ...existing }
+
+	if (config.projectType !== 'library' || !generated.build) return scripts
+
+	if (existing.build && existing.build !== generated.build) {
+		console.warn(
+			chalk.yellow(
+				`⚠️  Replaced "build": "${existing.build}" with "${generated.build}" — the library exports map names files only ${config.bundler} emits.`
+			)
+		)
+	}
+	scripts.build = generated.build
+	return scripts
 }
 
 interface GetScriptsOptions {

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { buildPresetConfig } from '../../../src/cli/commands/setup-presets.js'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import {
 	SIZE_LIMIT_VERSION,
@@ -344,5 +345,72 @@ describe('composeVerifyScriptFromPkg test fallback', () => {
 			devDependencies: { typescript: '^5.9.3', vitest: '^4.0.0' },
 		})
 		expect(verify).toBe('pnpm typecheck && pnpm exec vitest run')
+	})
+})
+
+// #570: the preset wrote a dual-format publish contract but preserved the repo's
+// existing `build: tsc`, which emits neither ./dist/index.cjs nor
+// ./dist/index.d.cts — so every CJS entry point in the published package 404'd.
+// Nothing asserted setup's own output was internally coherent, which is why it
+// shipped.
+describe('library publish contract (#570)', () => {
+	// What each build command actually drops in dist/ for a `src/index.ts` in a
+	// "type": "module" package. tsup (format: ['cjs','esm'], dts: true) is the only
+	// one producing the .cjs / .d.cts half of the dual contract.
+	const EMITS: Record<string, string[]> = {
+		tsup: ['./dist/index.js', './dist/index.cjs', './dist/index.d.ts', './dist/index.d.cts'],
+		tsc: ['./dist/index.js', './dist/index.d.ts'],
+	}
+
+	function declaredEntryPoints(pkg: Record<string, any>): string[] {
+		const found: string[] = []
+		const walk = (node: unknown) => {
+			if (typeof node === 'string') found.push(node)
+			else if (node && typeof node === 'object') Object.values(node).forEach(walk)
+		}
+		walk(pkg.exports)
+		for (const field of ['main', 'module', 'types']) {
+			if (pkg[field]) found.push(pkg[field])
+		}
+		return [...new Set(found)]
+	}
+
+	async function readCoherentPkg(dir: string) {
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		const emitted = EMITS[pkg.scripts.build]
+		expect(emitted, `no emitted-file list for build script: ${pkg.scripts.build}`).toBeDefined()
+		expect(declaredEntryPoints(pkg).filter((p) => !emitted.includes(p))).toEqual([])
+		return pkg
+	}
+
+	it('names only entry points the resolved build script emits (greenfield)', async () => {
+		const dir = newTmpDir()
+		await generatePackageJson(buildPresetConfig('library', 'my-lib'), dir)
+		await readCoherentPkg(dir)
+	})
+
+	it('claims a stale `build` rather than shipping exports nothing emits', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), {
+			name: 'my-lib',
+			main: 'dist/index.js',
+			scripts: { build: 'tsc', 'my:script': 'echo hi', test: 'node --test' },
+		})
+		await generatePackageJson(buildPresetConfig('library', 'my-lib'), dir)
+
+		const pkg = await readCoherentPkg(dir)
+		expect(pkg.scripts.build).toBe('tsup')
+		// `build` is the only script the contract claims — the rest still merge.
+		expect(pkg.scripts['my:script']).toBe('echo hi')
+		expect(pkg.scripts.test).toBe('node --test')
+	})
+
+	it('leaves a non-library `build` alone', async () => {
+		const dir = newTmpDir()
+		await fs.writeJson(join(dir, 'package.json'), { scripts: { build: 'tsc' } })
+		await generatePackageJson(baseConfig({ projectType: 'node-api', bundler: 'tsup' }), dir)
+
+		const pkg = await fs.readJson(join(dir, 'package.json'))
+		expect(pkg.scripts.build).toBe('tsc')
 	})
 })


### PR DESCRIPTION
🤖 *Opened by an agent via ai-issue-loop.*

Closes #570

## The defect

`setup --preset library` writes the publish contract unconditionally — `main`, `module`, `types`, `exports`, `files`, `publishConfig` are all assigned after the merge, clobbering whatever was there. But `scripts` merged with **existing values winning**, so a repo's pre-existing `"build": "tsc"` survived.

`tsc` with `outDir: ./dist` emits `dist/index.js` and `dist/index.d.ts` and nothing else. The contract named `./dist/index.cjs` as `main` and `./dist/index.d.cts` as the `require` types condition. `pnpm build && npm publish` therefore shipped a package whose every CJS entry point 404s.

## Which resolution, and why

The issue sketched two: repoint `build` at tsup, or emit single-format `exports` matching `tsc`. **This takes the first**, scoped to `projectType === 'library'` when the preset generates a `build` at all.

The merge-don't-clobber policy is real and worth keeping — it is what makes re-running `setup` on a live repo safe, and what separates the JS presets from `swift-library`. But the policy was already not being applied to the publish contract: the library branch overwrites `main`/`module`/`types`/`exports`/`files`/`publishConfig` without asking. Preserving `build` alone, while overwriting every field that describes what `build` must produce, is the inconsistency. If the preset owns the contract, it has to own the producer.

The alternative — deriving single-format `exports` from the preserved `build` — is a bigger and leakier change. `attw` would need the `esm-only` profile (there is already an `isEsmOnly` branch in the `attw` fixer), the shipped `tsup.config.ts` would still say `format: ['cjs', 'esm']`, and `build:watch: tsup --watch` would still point at a bundler the `build` script does not use. It trades one incoherence for three smaller ones.

Scope is deliberately one script. Everything else — `test`, `lint`, custom targets — still merges under existing-wins, and the replacement is announced on stdout rather than done silently:

> ⚠️  Replaced "build": "tsc" with "tsup" — the library exports map names files only tsup emits.

## The regression test

The reason this shipped is that nothing asserted setup's own output was internally coherent. `tests/cli/generators/package-json.test.ts` now runs the real `library` preset (via `buildPresetConfig`) and asserts the invariant: **every path named in `main`/`module`/`types`/`exports` must be producible by the resolved `build` script**, checked both greenfield and against a package.json that arrived with `build: tsc`.

Verified it fails on the old behaviour before the fix:

```
AssertionError: expected [ './dist/index.d.cts', …(1) ] to deeply equal []
+ [ "./dist/index.d.cts", "./dist/index.cjs" ]
```

Two further assertions guard the blast radius: a sibling `my:script` and `test` still survive the merge, and a non-library project keeps its own `build` untouched.

## Checks

`pnpm typecheck`, `biome check` on the changed files, and the full suite (1146 passed) are green. Snapshot output for the greenfield library is unchanged — the fix only bites when an existing `build` differs.

Out of scope, as queued: #573 (`pnpm.minimumReleaseAgeExclude` on the same preset).
