### PR TITLE
feat(lockfile): write an empty rules scaffold so a new repo has rules to edit

### DIFF
--- a/apps/docs/docs/reference/repo-tooling-json.mdx
+++ b/apps/docs/docs/reference/repo-tooling-json.mdx
@@ -89,8 +89,18 @@ enum-valued records — see the schema for their exact shapes.
 ## `rules` — what the humans wrote
 
 Everything under `rules` is edited by hand and reviewed in PRs. It is deliberately outside
-the `writtenBy`/`writtenAt` stamps: the tool never writes here, so it never claims authorship
-of a rule — a hand edit to `rules` leaves the record's provenance true.
+the `writtenBy`/`writtenAt` stamps: the tool never writes a rule here, so it never claims
+authorship of one — a hand edit to `rules` leaves the record's provenance true.
+
+`setup` does write the **empty containers**, so a new repo has the shape in front of it rather
+than a blank page — and `doctor --rules-from` has something local to compare:
+
+```json
+"rules": { "aiLoop": {}, "requiredSkills": [], "mcp": { "recommended": [] }, "exceptions": {} }
+```
+
+Every value is empty on purpose. A default here would be this tool asserting a rule on a repo
+whose humans have not stated one. An existing `rules` is carried forward untouched.
 
 ### `rules.aiLoop` — ai-issue-loop settings
 
@@ -120,7 +130,7 @@ Two rules make it safe to commit:
 - **Never `drift`, never `missing`.** The check probes your machine, not the repo, so a
   contributor with no Claude installed must not fail its `doctor`. It only ever reports
   "not configured", which leaves the exit code alone. It is also skipped entirely unless the
-  file has a `rules.aiLoop` key — that key is already the "this repo uses the pipeline" signal.
+  file sets `rules.aiLoop.agentUser` — that login is the "this repo uses the pipeline" signal.
 - **Check and hint only.** `doctor` names `fix claude-skills`; it never runs it. Committed
   repo config that directs writes into your home directory is the shape of a supply-chain
   attack even when the content is benign, so that step stays a human's.

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -326,9 +326,11 @@ async function runBaseChecks(
 	results.push(await checkAiSetup(dir))
 	// User-global, not repo state — see checkClaudeSkills on why it never returns drift.
 	results.push(await checkClaudeSkills(opts.skillsDir))
-	// #533: gated on `aiLoop`, which is already the "this repo uses the pipeline"
+	// #533: gated on `aiLoop.agentUser`, which is the "this repo uses the pipeline"
 	// signal, so a repo that doesn't gets no line at all rather than an empty one.
-	if (lock?.rules?.aiLoop && lock.rules.requiredSkills?.length) {
+	// The key itself no longer says that — since #571 every repo is scaffolded with
+	// an empty `aiLoop`, and the skills have always read the login, not the key.
+	if (lock?.rules?.aiLoop?.agentUser && lock.rules.requiredSkills?.length) {
 		results.push(await checkRequiredSkills(lock.rules.requiredSkills, opts.skillsDir))
 	}
 	// #534: advisory. Absent `mcp.recommended` means the repo has nothing to say

--- a/src/cli/utils/lockfile.ts
+++ b/src/cli/utils/lockfile.ts
@@ -122,6 +122,22 @@ export interface Lockfile {
 }
 
 /**
+ * The empty ruleset a repo with no stated rules gets (#571). `rules` used to
+ * appear only via v1–v3 migration, so the repos this tool creates were exactly
+ * the ones with nothing to edit and nothing to compare. Writing the containers
+ * — with `$schema` stamped alongside — makes the file teach its own shape.
+ *
+ * Values, never defaults: every entry is empty, because a populated one would
+ * be this tool asserting a rule on a repo whose humans have not stated any.
+ */
+export const DEFAULT_RULES: LockfileRules = {
+	aiLoop: {},
+	requiredSkills: [],
+	mcp: { recommended: [] },
+	exceptions: {},
+}
+
+/**
  * JSON Schema for the lockfile, published with the docs site at the exact URL
  * every written lockfile's `$schema` points to (#529). The `satisfies` clauses
  * bind the property lists to the Lockfile interface, so adding or removing a
@@ -368,7 +384,8 @@ export async function writeLockfile(
 			writtenBy: `@rtorcato/repo-tooling@${packageJson.version}`,
 			writtenAt: new Date().toISOString(),
 		},
-		...(existing?.rules ? { rules: existing.rules } : {}),
+		// A repo that has stated no rules gets the empty scaffold, not nothing (#571).
+		rules: existing?.rules ?? DEFAULT_RULES,
 	}
 	await fs.writeJson(filepath, lockfile, { spaces: 2 })
 	// Migrate a pre-rename repo to the new name: now that the canonical file is

--- a/tests/cli/commands/setup.test.ts
+++ b/tests/cli/commands/setup.test.ts
@@ -11,6 +11,7 @@ import {
 	validateProjectConfig,
 } from '../../../src/cli/commands/setup-presets.js'
 import { generateConfigs } from '../../../src/cli/generators/index.js'
+import { DEFAULT_RULES } from '../../../src/cli/utils/lockfile.js'
 import { fetchReferenceLockfile } from '../../../src/cli/utils/reference-rules.js'
 import { useTmpDir } from '../../helpers/tmp-dir.js'
 
@@ -799,11 +800,12 @@ describe('setup language prompt', () => {
 		// A new repo is not the reference repo: its name is never seeded.
 		expect(defaults.projectName).not.toBe('reference-repo')
 		// Record-side fields never cross over — this repo stamps its own, and the
-		// reference's rules stay with the repo that argued for them.
+		// reference's rules stay with the repo that argued for them: the new repo
+		// gets the empty scaffold to fill in, not someone else's agentUser (#571).
 		const lock = await fs.readJson(join(dir, '.repo-tooling.json'))
 		expect(lock.record.writtenBy).not.toBe('@rtorcato/repo-tooling@1.2.3')
 		expect(lock.record.assets).toBeUndefined()
-		expect(lock.rules).toBeUndefined()
+		expect(lock.rules).toEqual(DEFAULT_RULES)
 	})
 
 	// The reference is untrusted and remote, so "could not read it" is an ordinary

--- a/tests/cli/utils/lockfile.test.ts
+++ b/tests/cli/utils/lockfile.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra'
 import { describe, expect, it } from 'vitest'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import {
+	DEFAULT_RULES,
 	LEGACY_LOCKFILE_NAME,
 	LOCKFILE_NAME,
 	LOCKFILE_VERSION,
@@ -235,10 +236,12 @@ describe('rules survive a rewrite', () => {
 		expect(after.record.config.projectName).toBe('renamed')
 	})
 
-	it('omits the key entirely when nothing set it', async () => {
+	// #571: a greenfield repo used to get `record` only, so there was nothing to
+	// edit and nothing for `doctor --rules-from` to compare against.
+	it('writes the empty scaffold when nothing set it', async () => {
 		const dir = newTmpDir()
 		await writeLockfile(dir, baseConfig())
-		expect(await fs.readJson(join(dir, '.repo-tooling.json'))).not.toHaveProperty('rules')
+		expect((await fs.readJson(join(dir, '.repo-tooling.json'))).rules).toEqual(DEFAULT_RULES)
 	})
 
 	// #559: rewriting a flat v3 file migrates it on disk — the hand-edited fields


### PR DESCRIPTION
🤖 *Opened by an agent via ai-issue-loop.*

`rules` was only ever populated by v1–v3 migration, so a greenfield `setup` produced `record` only — nothing for a human to edit, and nothing local for `doctor --rules-from` to compare against. The repos this tool creates were exactly the ones with no stated rules.

## What changed

`writeLockfile` now emits `DEFAULT_RULES` when the file has no `rules` of its own; an existing `rules` is still carried forward verbatim, untouched and unstamped.

```json
"rules": { "aiLoop": {}, "requiredSkills": [], "mcp": { "recommended": [] }, "exceptions": {} }
```

Every value is empty on purpose. A populated one would be this tool asserting a rule on a repo whose humans have stated none. The containers plus the stamped `$schema` are what teach the shape — an editor autocompletes `agentUser` and the `mcp.recommended` item fields from there.

One consequence, followed through: every repo now carries an `aiLoop` key, so its *presence* no longer means "this repo uses the pipeline". `doctor`'s `requiredSkills` gate reads `rules.aiLoop.agentUser` instead — the login the loop skills have always read (`jq '.rules.aiLoop.agentUser'`). Behaviour only changes for an `aiLoop: {}`, where skipping is the right answer. Docs updated to match.

## Decisions

- **Not seeding `rules` from `setup --from`.** The issue floats it; it would copy another repo's `agentUser` and exceptions into a new repo, which is a stated rule the new repo's humans never stated. `--from` still seeds config defaults only.
- **No doctor `optional-missing` for an absent `rules`.** With the scaffold written on every save, absence now only happens when someone deletes the key by hand — a check for that would fire on nothing.

## Verification

- `pnpm typecheck` ✅
- `pnpm test` ✅ — 1161 passed, 1 expected fail (69 files)
- `pnpm build` ✅
- `pnpm check` — 62 pre-existing CSS `noImportantStyles` warnings under `apps/docs/`, untouched by this branch; `biome check` on the four changed source files is clean

Two existing assertions flipped, both deliberately: `writeLockfile` "omits the key entirely when nothing set it" now asserts the scaffold, and the `setup --from` test asserts the new repo gets the empty scaffold rather than the reference's `agentUser`.

The `runChecks` gate itself has no direct test (it needs `gh`); `checkRequiredSkills` remains unit-tested in `tests/base/required-skills.test.ts`.

Closes #571