### PR TITLE
feat(doctor): flag Swift sources under Sources/ that no declared target claims

### DIFF
--- a/apps/docs/docs/reference/swift.md
+++ b/apps/docs/docs/reference/swift.md
@@ -20,6 +20,7 @@ The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-
 | Periphery | `optional-missing` | `periphery` |
 | swift-format | `optional-missing` | `swift-format` |
 | Swift `.gitignore` | `missing` | `swift-gitignore` |
+| Swift targets | `drift` | — (manifest edit, or delete the directory) |
 | Swift tests | `missing` | — (manifest edit, or `swift-ci`) |
 | DocC | `optional-missing` | `docc` |
 | Release automation | `optional-missing` | `swift-release` |
@@ -27,6 +28,20 @@ The standard here is the one [`swift-common`](https://github.com/rtorcato/swift-
 | Pre-push hook | `optional-missing` | `swift-git-hooks` |
 
 `Package.swift` is checked for two things SwiftPM will not infer: a `// swift-tools-version:` comment (without it the manifest doesn't parse) and an explicit `platforms:` clause (without it SwiftPM assumes its oldest supported deployment target, which rejects modern APIs at build time). There's no fixer — rewriting someone's manifest isn't safe, so `doctor` reports and you edit.
+
+`Swift targets` compares the directories under `Sources/` and `Tests/` against
+the target names the manifest declares. A directory no target names is invisible
+to SwiftPM: it is never compiled, its tests never run, and `swift build` /
+`swift test` both still exit 0 — a real defect with no red X anywhere. A renamed
+target, a dropped `.target(...)` line, or a generator that rewrote the manifest
+all produce it.
+
+The manifest is read with a regex, not a Swift toolchain, so the check only sees
+targets declared with a **literal** name — `.target(name: "Widget")`. Targets
+built in a loop, behind `#if`, or from a variable are invisible to it and their
+directories would be reported as orphans. It also skips the whole check on any
+manifest containing a `path:` argument, since a custom path decouples directory
+names from target names entirely.
 
 `Swift tests` has two halves: the manifest must declare a `.testTarget(`, and
 some pipeline (`.github/workflows/*` or `.gitlab-ci.yml`) must actually run

--- a/src/cli/commands/fix-targets.ts
+++ b/src/cli/commands/fix-targets.ts
@@ -80,6 +80,8 @@ const SWIFT_FIX_TARGETS: Record<string, string> = {
 	// `Swift tests` is deliberately absent: when it fails for the manifest half
 	// (no `.testTarget(`) there's nothing to run, and rewriting Package.swift
 	// isn't safe. The check's own hint covers both halves.
+	// `Swift targets` too (#575): the repair is either adding a target or
+	// deleting the directory, and only the project knows which.
 }
 
 /** The same shadowing for the Python module (#290). */

--- a/src/languages/swift/checks.ts
+++ b/src/languages/swift/checks.ts
@@ -17,6 +17,7 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import { type FileCheck, type GitHooksProfile, checkFile } from '../../base/checks.js'
 import type { CheckResult } from '../../base/types.js'
+import { parsePackageSwift } from './ci.js'
 import { SWIFT_HOOKS_DIR } from './git-hooks.js'
 
 const SWIFT_FILE_CHECKS: FileCheck[] = [
@@ -129,17 +130,86 @@ export async function checkPackageSwift(dir: string): Promise<CheckResult> {
 	}
 }
 
+/** Subdirectory names of `<dir>/<root>`, or none when that root doesn't exist. */
+async function subdirectories(dir: string, root: string): Promise<string[]> {
+	try {
+		const entries = await fs.readdir(path.join(dir, root), { withFileTypes: true })
+		return entries.filter((e) => e.isDirectory()).map((e) => e.name)
+	} catch {
+		return []
+	}
+}
+
 /**
  * Directory names under `Sources/`. For a SwiftPM package these are the target
  * names — a target's sources and its DocC catalogue live in the same folder,
  * so this is where both the check and the `docc` fixer have to look.
  */
 export async function swiftSourceTargets(dir: string): Promise<string[]> {
-	try {
-		const entries = await fs.readdir(path.join(dir, 'Sources'), { withFileTypes: true })
-		return entries.filter((e) => e.isDirectory()).map((e) => e.name)
-	} catch {
-		return []
+	return subdirectories(dir, 'Sources')
+}
+
+/** Where SwiftPM looks for a target's sources when the manifest gives no `path:`. */
+const TARGET_ROOTS = ['Sources', 'Tests']
+
+/**
+ * Sources that belong to no declared target (#575). SwiftPM silently ignores a
+ * directory under `Sources/` that no `.target(` names — so `swift build` and
+ * `swift test` both exit 0 while the code in it is never compiled and the tests
+ * in it are never run. There is no red X anywhere, which is the whole reason
+ * this check exists: a renamed target, a dropped `.target(...)` line, or a
+ * generator that rewrote the manifest all leave the same invisible hole.
+ *
+ * No fixer: repairing it means either adding a target or deleting the
+ * directory, and nothing outside the project can tell which.
+ */
+export async function checkSwiftTargets(dir: string): Promise<CheckResult> {
+	const check = 'Swift targets'
+	const filepath = path.join(dir, 'Package.swift')
+	if (!(await fs.pathExists(filepath))) {
+		return { check, status: 'missing', detail: 'no Package.swift' }
+	}
+
+	const contents = await fs.readFile(filepath, 'utf-8')
+	// A custom `path:` puts a target's sources anywhere, so directory names stop
+	// meaning target names and every comparison below becomes a guess. Bail out
+	// rather than report something we can't stand behind. Deliberately crude:
+	// `.package(path:)` for a local dependency trips this too, which costs a
+	// skipped check on repos that use one — cheaper than a false accusation.
+	if (/\bpath:\s*"/.test(contents)) {
+		return {
+			check,
+			status: 'ok',
+			detail:
+				'not checked — Package.swift uses a custom `path:`, so directories need not match targets',
+		}
+	}
+
+	const declared = new Set(parsePackageSwift(contents).targets)
+	const orphans: string[] = []
+	let scanned = 0
+	for (const root of TARGET_ROOTS) {
+		for (const name of await subdirectories(dir, root)) {
+			scanned++
+			if (!declared.has(name)) orphans.push(`${root}/${name}`)
+		}
+	}
+
+	if (scanned === 0) {
+		return { check, status: 'ok', detail: 'no directories under Sources/ or Tests/' }
+	}
+	if (orphans.length > 0) {
+		return {
+			check,
+			status: 'drift',
+			detail: `no target declares ${orphans.join(', ')} — SwiftPM ignores them, so \`swift build\` passes without building them`,
+			hint: `Add a target named after each directory to Package.swift, or delete the directory: ${orphans.join(', ')}`,
+		}
+	}
+	return {
+		check,
+		status: 'ok',
+		detail: `all ${scanned} source directories are declared as targets`,
 	}
 }
 
@@ -293,6 +363,7 @@ export async function runSwiftChecks(dir: string): Promise<CheckResult[]> {
 		await checkPackageSwift(dir),
 		...(await Promise.all(SWIFT_FILE_CHECKS.map((spec) => checkFile(dir, spec)))),
 		await checkSwiftGitignore(dir),
+		await checkSwiftTargets(dir),
 		await checkSwiftTests(dir),
 		await checkDocC(dir),
 		await checkSwiftRelease(dir),

--- a/src/languages/swift/ci.ts
+++ b/src/languages/swift/ci.ts
@@ -19,17 +19,36 @@ export interface SwiftPackage {
 	products: string[]
 	/** Deployment platforms declared in `platforms:`, as xcodebuild destination names. */
 	platforms: string[]
+	/** Declared target names, of every kind — the `Swift targets` check (#575) reads these. */
+	targets: string[]
 }
 
 /**
- * Pull the two facts CI needs out of a Package.swift. A regex rather than a
- * SwiftPM invocation: `swift package dump-package` would need a Swift toolchain
- * on the machine running `repo-tooling`, which is usually a Node environment.
+ * Every SwiftPM target factory. `name:` is their first parameter and Swift
+ * enforces argument order, so a literal name always follows the open paren.
+ * `binaryTarget` owns no source directory but is matched anyway: the only
+ * consumer uses this set to *suppress* a report, so over-matching costs a
+ * missed finding while under-matching costs a false one.
+ */
+const TARGET_DECL =
+	/\.(?:target|executableTarget|testTarget|macro|plugin|systemLibrary|binaryTarget)\(\s*name:\s*"([^"]+)"/g
+
+/**
+ * Pull the facts doctor and CI need out of a Package.swift. A regex rather than
+ * a SwiftPM invocation: `swift package dump-package` would need a Swift
+ * toolchain on the machine running `repo-tooling`, which is usually a Node
+ * environment.
+ *
+ * ponytail: literal string arguments only. A manifest that builds its target
+ * list in a loop, behind `#if`, or from a variable parses as fewer targets than
+ * it declares — callers that act on the result must fail open. Upgrade path is
+ * `swift package dump-package` on a machine that has Swift.
  */
 export function parsePackageSwift(contents: string): SwiftPackage {
 	const products = [...contents.matchAll(/\.library\(\s*name:\s*"([^"]+)"/g)].map(
 		(m) => m[1] as string
 	)
+	const targets = [...contents.matchAll(TARGET_DECL)].map((m) => m[1] as string)
 
 	// Only the `platforms:` array declares deployment targets — matching
 	// `.iOS(` across the whole manifest would also catch `.iOS` in target
@@ -39,12 +58,12 @@ export function parsePackageSwift(contents: string): SwiftPackage {
 		(m) => m[1] as string
 	)
 
-	return { products, platforms: [...new Set(platforms)] }
+	return { products, platforms: [...new Set(platforms)], targets }
 }
 
 export async function readSwiftPackage(dir: string): Promise<SwiftPackage> {
 	const filepath = path.join(dir, 'Package.swift')
-	if (!(await fs.pathExists(filepath))) return { products: [], platforms: [] }
+	if (!(await fs.pathExists(filepath))) return { products: [], platforms: [], targets: [] }
 	return parsePackageSwift(await fs.readFile(filepath, 'utf-8'))
 }
 

--- a/tests/languages/swift/checks.test.ts
+++ b/tests/languages/swift/checks.test.ts
@@ -6,6 +6,7 @@ import {
 	checkPackageSwift,
 	checkSwiftGitignore,
 	checkSwiftRelease,
+	checkSwiftTargets,
 	checkSwiftTests,
 	runSwiftChecks,
 } from '../../../src/languages/swift/checks.js'
@@ -131,6 +132,67 @@ describe('checkSwiftTests', () => {
 	})
 })
 
+describe('checkSwiftTargets', () => {
+	const manifest = (targets: string) =>
+		`// swift-tools-version: 5.9\nlet package = Package(\n    name: "Demo",\n    targets: [${targets}]\n)\n`
+
+	const pkg = async (dir: string, targets: string, dirs: string[]) => {
+		await fs.writeFile(join(dir, 'Package.swift'), manifest(targets))
+		for (const d of dirs) await fs.outputFile(join(dir, d, 'File.swift'), '')
+	}
+
+	it('is missing without a manifest', async () => {
+		expect((await checkSwiftTargets(newTmpDir())).status).toBe('missing')
+	})
+
+	// The failure this check exists for: SwiftPM ignores Sources/Widget, so
+	// `swift build` exits 0 while nothing in it is ever compiled.
+	it('flags a source directory that no target declares', async () => {
+		const dir = newTmpDir()
+		await pkg(dir, '.target(name: "Demo")', ['Sources/Demo', 'Sources/Widget'])
+		const result = await checkSwiftTargets(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('Sources/Widget')
+		expect(result.detail).not.toContain('Sources/Demo')
+		expect(result.hint).toContain('Sources/Widget')
+	})
+
+	it('flags an orphaned test directory too', async () => {
+		const dir = newTmpDir()
+		await pkg(dir, '.target(name: "Demo")', ['Sources/Demo', 'Tests/DemoTests'])
+		const result = await checkSwiftTargets(dir)
+		expect(result.status).toBe('drift')
+		expect(result.detail).toContain('Tests/DemoTests')
+	})
+
+	it('passes when every directory is declared', async () => {
+		const dir = newTmpDir()
+		await pkg(dir, '.target(name: "Demo"), .testTarget(name: "DemoTests")', [
+			'Sources/Demo',
+			'Tests/DemoTests',
+		])
+		const result = await checkSwiftTargets(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('2')
+	})
+
+	it('passes on a package with no source directories at all', async () => {
+		const dir = newTmpDir()
+		await fs.writeFile(join(dir, 'Package.swift'), manifest('.target(name: "Demo")'))
+		expect((await checkSwiftTargets(dir)).status).toBe('ok')
+	})
+
+	// A custom `path:` decouples directory names from target names, so the
+	// comparison would be a guess. Skipping beats a false accusation.
+	it('skips a manifest that uses a custom path:', async () => {
+		const dir = newTmpDir()
+		await pkg(dir, '.target(name: "Demo", path: "Sources/Other")', ['Sources/Other'])
+		const result = await checkSwiftTargets(dir)
+		expect(result.status).toBe('ok')
+		expect(result.detail).toContain('path:')
+	})
+})
+
 describe('checkDocC', () => {
 	const PLUGIN = '.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")'
 
@@ -220,6 +282,7 @@ describe('runSwiftChecks', () => {
 			'Periphery',
 			'swift-format',
 			'Swift .gitignore',
+			'Swift targets',
 			'Swift tests',
 			'DocC',
 			'Release automation',

--- a/tests/languages/swift/ci.test.ts
+++ b/tests/languages/swift/ci.test.ts
@@ -39,7 +39,24 @@ describe('parsePackageSwift', () => {
 		expect(parsePackageSwift('// swift-tools-version: 5.9\n')).toEqual({
 			products: [],
 			platforms: [],
+			targets: [],
 		})
+	})
+
+	it('reads target names of every kind, not product names', () => {
+		const pkg = parsePackageSwift(
+			`products: [.library(name: "Lib", targets: ["Core"])],
+			 targets: [
+			     .target(name: "Core"),
+			     .executableTarget(
+			         name: "Tool",
+			         dependencies: ["Core"]
+			     ),
+			     .testTarget(name: "CoreTests", dependencies: ["Core"])
+			 ]`
+		)
+		expect(pkg.targets).toEqual(['Core', 'Tool', 'CoreTests'])
+		expect(pkg.targets).not.toContain('Lib')
 	})
 
 	// `.iOS` also appears in target conditionals — only the platforms: clause

--- a/tests/languages/swift/fixers.test.ts
+++ b/tests/languages/swift/fixers.test.ts
@@ -71,7 +71,9 @@ describe('swift fixers', () => {
 		// there is no drift for a fixer to close. `Release gate` and `Release
 		// environment` (#429) are covered by the base `release-environment` fixer.
 		// `AI loop agent` (#530) is unfixable by design — inviting a collaborator
-		// is the operator's call.
+		// is the operator's call. `Swift targets` (#575) has two opposite repairs —
+		// declare the target, or delete the directory — and only the project knows
+		// which, so there is nothing safe for a fixer to do.
 		expect(uncovered).toEqual([
 			'language',
 			'Monorepo',
@@ -81,6 +83,7 @@ describe('swift fixers', () => {
 			'README badges',
 			'Coverage upload',
 			'Package.swift',
+			'Swift targets',
 			'Swift tests',
 		])
 	})

--- a/tests/languages/swift/scaffold.test.ts
+++ b/tests/languages/swift/scaffold.test.ts
@@ -89,6 +89,7 @@ describe('generateSwiftProject', () => {
 			'Periphery: ok',
 			'swift-format: optional-missing',
 			'Swift .gitignore: ok',
+			'Swift targets: ok',
 			'Swift tests: ok',
 			'DocC: optional-missing',
 			'Release automation: ok',


### PR DESCRIPTION
🤖 *Opened by an agent via ai-issue-loop.*

SwiftPM silently ignores a directory under `Sources/` that no target declares:
it is never compiled, its tests never run, and `swift build` / `swift test`
both still exit 0. That is the whole point of this check — it catches a real
defect that is otherwise green, with no red X anywhere. #574 fixed the write
side (the preset no longer rewrites an existing `Package.swift`); this is the
detection side, and it also covers the hand-edit cases — a renamed target, a
dropped `.target(...)` line, a merge that loses one.

## What changed

- `parsePackageSwift` (`src/languages/swift/ci.ts`) now also returns `targets`,
  the declared target names, alongside the products and platforms it already
  extracted. One parser for the manifest rather than a second one.
- New `checkSwiftTargets` in `src/languages/swift/checks.ts` compares those
  names against the subdirectories of `Sources/` and `Tests/`. Anything
  undeclared reports as **`drift`**, naming each orphan.
- `swiftSourceTargets` now delegates to a small `subdirectories(dir, root)`
  helper, which is what lets the check read `Tests/` with the same code.
- Docs: a `Swift targets` row and a prose paragraph in
  `apps/docs/docs/reference/swift.md`, including the limits below.

`Tests/` is included deliberately: an orphaned test directory is the same
failure with a worse consequence — the tests silently never run.

## No fixer, on purpose

The repair is either *add a target* or *delete the directory*, and nothing
outside the project can tell which. So the check carries a hint naming both and
stays out of `fix-targets.ts`, next to `Swift tests` and `Package.swift`, which
are absent for the same reason. `tests/languages/swift/fixers.test.ts` asserts
the uncovered list, so this is enforced rather than just documented.

## What the parser does *not* handle

This is a regex over Swift source, not `swift package dump-package` — running
that would need a Swift toolchain on a machine that is usually just Node. So:

- **Literal names only.** `.target(name: "Widget")` is seen. A target built in
  a loop, behind `#if`, or from a variable is **not**, and its directory would
  be reported as an orphan. This is the one false-positive shape that remains.
- **Any `path:` skips the check entirely.** A custom `path:` decouples
  directory names from target names, so the comparison would be a guess. The
  test is crude — `.package(path: "../Local")` for a local dependency trips it
  too — which costs a skipped check on those repos. A missed finding beats a
  false accusation, and the skip says so in its `detail`.
- `binaryTarget` names are collected even though a binary target owns no source
  directory, for the same reason: the set only ever *suppresses* a report.

Both limits are stated in the source comments, the docs page, and the commit
body rather than implied away.

## Fit with the in-flight Swift work

This layers onto the existing module (`runSwiftChecks`, `SWIFT_FIX_TARGETS`,
the docs check table) and introduces no new structure, so it should not
prejudge how the rest of Swift support lands. The one thing a future
`swift package dump-package`-based parser would replace is `TARGET_DECL` in
`ci.ts`; `checkSwiftTargets` would keep working against a better-populated
`SwiftPackage.targets`.

## Verification

- `tsc --noEmit --project src/cli/tsconfig.json` — clean
- `vitest run` — 1162 passed, 0 failed (69 files)
- `biome check .` — 0 errors (62 pre-existing `noImportantStyles` warnings in
  `apps/docs` CSS, untouched)

Six new tests cover the orphan case, the orphaned-`Tests/` case, the all-clean
case, an empty package, the `path:` skip, and target-name extraction across
`.target` / `.executableTarget` / `.testTarget` (asserting a `.library` product
name is *not* mistaken for a target). Notably `tests/languages/swift/scaffold.test.ts`
now shows `Swift targets: ok` for the `swift-library` preset — the scaffold it
produces is self-consistent.

Per repo convention I did not run `pnpm install`; `node_modules` was symlinked
from the main checkout to run the commands above.

Closes #575
