### PR TITLE
feat(doctor): flag exports naming files the repo's build cannot emit

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -53,6 +53,7 @@ import {
 	checkConfigSchemaVersions,
 	checkDocsSite,
 	checkEnginesNode,
+	checkExportsBuildable,
 	checkGitDependencies,
 	checkKnip,
 	checkLintStaged,
@@ -489,6 +490,8 @@ export async function runDoctor(dir: string, skillsDir?: string): Promise<CheckR
 	results.push(await checkTypedoc(targetDir, pkg))
 	results.push(await checkAreTheTypesWrong(targetDir, pkg))
 	results.push(await checkPublint(targetDir, pkg))
+	// The setup/doctor-time half of what publint catches at release time (#578).
+	results.push(await checkExportsBuildable(targetDir, pkg))
 	results.push(await checkTreeshakeSetup(targetDir, pkg))
 	results.push(await checkPnpmWorkspace(targetDir, pkg))
 	results.push(await checkBuildApprovals(targetDir, pkg))

--- a/src/languages/js/checks.ts
+++ b/src/languages/js/checks.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import type { BadgeAudience, FileCheck, GitHooksProfile } from '../../base/checks.js'
 import { checkFile, hookHasUncommented } from '../../base/checks.js'
+import { type GitExec, realGitExec } from '../../base/git-identity.js'
 import {
 	CLAUDE_SETTINGS_FILE,
 	readClaudeSettings,
@@ -1061,6 +1062,211 @@ export async function checkPublint(_dir: string, pkg: Pkg | null): Promise<Check
 		status: 'optional-missing',
 		detail: 'publint not configured',
 		hint: 'Run `npx @rtorcato/repo-tooling fix publint` to lint your package before publishing',
+	}
+}
+
+/**
+ * The file extensions each recognised build command drops in the output
+ * directory. Inferring this from an arbitrary shell command is inherently
+ * partial, so the table is deliberately small and anything missing from it
+ * makes the whole check stand down (see `emittedExtensions`) — a doctor check
+ * that cries wolf on a valid config is worse than one with a stated blind spot.
+ */
+const BUILD_EMITS: Record<string, readonly string[]> = {
+	// tsc mirrors its input extension: .ts → .js + .d.ts. It reaches .cjs/.d.cts
+	// only from .cts sources, which is why a repo that has any stands the check
+	// down below.
+	tsc: ['.js', '.d.ts'],
+	// tsup's real set is whatever `format`/`dts` say in a config file this does
+	// not parse, so it claims the broadest set tsup could emit. A tsup build is
+	// therefore passed rather than guessed at, while `rimraf dist && tsup` still
+	// resolves instead of standing the check down.
+	tsup: ['.js', '.cjs', '.mjs', '.d.ts', '.d.cts', '.d.mts'],
+	// Cleaners emit nothing. Recognised only so the very common
+	// `rimraf dist && tsc` is still judged on its tsc half.
+	rimraf: [],
+	rm: [],
+	del: [],
+}
+
+/** Package-manager noise to strip before the command name: `pnpm exec tsup`. */
+const RUNNER_TOKENS = new Set([
+	'npx',
+	'npm',
+	'pnpm',
+	'yarn',
+	'bun',
+	'exec',
+	'dlx',
+	'run',
+	'x',
+	'-s',
+	'--silent',
+])
+
+/**
+ * Extensions this check will judge, longest suffix first. Anything else — a
+ * package publishing `./src/index.ts` directly, a `./dist/style.css` from a
+ * non-JS step — is left alone rather than measured against a JS emit table.
+ */
+const ARTEFACT_EXTENSIONS = ['.d.cts', '.d.mts', '.d.ts', '.cjs', '.mjs', '.js'] as const
+
+function artefactExtension(p: string): string | null {
+	return ARTEFACT_EXTENSIONS.find((ext) => p.endsWith(ext)) ?? null
+}
+
+/**
+ * Every file path the publish contract names. Shared with the #570 regression
+ * test so doctor and that test agree on what the contract is.
+ */
+export function declaredEntryPoints(pkg: Pkg): string[] {
+	const found: string[] = []
+	const walk = (node: unknown) => {
+		if (typeof node === 'string') found.push(node)
+		else if (node && typeof node === 'object') Object.values(node).forEach(walk)
+	}
+	walk(pkg.exports)
+	for (const field of ['main', 'module', 'types']) {
+		const value = pkg[field]
+		if (typeof value === 'string') found.push(value)
+	}
+	return [...new Set(found)]
+}
+
+/**
+ * What `command` puts in the output directory, or null when any part of it is
+ * absent from BUILD_EMITS. Null means "don't know", and every caller stands
+ * down on it rather than guessing.
+ */
+function emittedExtensions(
+	scripts: Record<string, string>,
+	command: string,
+	seen: Set<string> = new Set()
+): string[] | null {
+	// Only a plain `a && b` chain is read. Pipes, `||`, subshells and redirects
+	// are not something to infer an output set from.
+	if (/[|;`<>]|\$\(/.test(command)) return null
+	const emitted = new Set<string>()
+	for (const segment of command.split('&&')) {
+		const tokens = segment.trim().split(/\s+/).filter(Boolean)
+		const before = tokens.length
+		while (tokens.length > 0 && RUNNER_TOKENS.has(tokens[0] as string)) tokens.shift()
+		const name = tokens[0]
+		if (!name) return null
+		// `"build": "pnpm build-cli"` — one script delegating to another. Followed
+		// only when a runner was actually stripped, because a bare `tsc` runs the
+		// binary even in a repo that also happens to have a script by that name.
+		const nested = tokens.length < before ? scripts[name] : undefined
+		if (nested !== undefined) {
+			if (seen.has(name)) return null
+			seen.add(name)
+			const inner = emittedExtensions(scripts, nested, seen)
+			if (!inner) return null
+			for (const ext of inner) emitted.add(ext)
+			continue
+		}
+		const known = BUILD_EMITS[name]
+		if (!known) return null
+		for (const ext of known) emitted.add(ext)
+	}
+	return [...emitted]
+}
+
+/**
+ * Catches a publish contract naming files the repo's own `build` cannot produce
+ * (#578) — the class of bug that shipped `main: ./dist/index.cjs` alongside
+ * `build: tsc`, which emits only .js and .d.ts, so every CJS consumer of the
+ * published package got a 404 (#570). #577 fixed the preset that wrote that
+ * pair; this catches it however else it arises, e.g. a repo editing `build` or
+ * the contract by hand afterwards.
+ *
+ * Judged from the build *script*, never from `dist/` on disk: a clean checkout
+ * has no dist/ and a stale one has whatever the last build left, so neither
+ * answers the question. Git is what separates the two kinds of path a contract
+ * may name — a tracked `./tooling/preset.mjs` ships as committed source and
+ * needs no build, while an untracked `./dist/index.cjs` has to come out of
+ * `build` or it will not exist at publish time.
+ *
+ * This overlaps publint, which the generated `verify` already runs — but not in
+ * time. publint fires at release, against a dist/ just built on a machine where
+ * it happens to work; this fires at setup/doctor time, on a checkout, before
+ * anything is built.
+ */
+export async function checkExportsBuildable(
+	dir: string,
+	pkg: Pkg | null,
+	exec?: GitExec
+): Promise<CheckResult> {
+	const check = 'Exports buildable'
+	if (!pkg || !isPublishableLibrary(pkg)) {
+		return { check, status: 'ok', detail: 'not applicable (private or no published exports)' }
+	}
+	const scripts = (pkg.scripts as Record<string, string> | undefined) ?? {}
+	const build = scripts.build
+	if (!build) {
+		return { check, status: 'ok', detail: 'no build script — nothing is expected to be generated' }
+	}
+	const emitted = emittedExtensions(scripts, build)
+	if (!emitted) {
+		return {
+			check,
+			status: 'ok',
+			detail: `not checked — cannot infer what \`${build}\` emits (recognised: ${Object.keys(BUILD_EMITS).join(', ')})`,
+		}
+	}
+	const declared = declaredEntryPoints(pkg).filter((p) => artefactExtension(p))
+	if (declared.length === 0) {
+		return { check, status: 'ok', detail: 'no JS entry points named in main/module/types/exports' }
+	}
+	if (!(await fs.pathExists(path.join(dir, '.git')))) {
+		return {
+			check,
+			status: 'ok',
+			detail:
+				'not checked — not a git repository, so committed assets and build output are indistinguishable',
+		}
+	}
+
+	// Declared paths are `./dist/index.js`; git speaks `dist/index.js`.
+	const declaredByPath = new Map(declared.map((p) => [p.replace(/^\.\//, ''), p]))
+	const git: GitExec = exec ?? ((args) => realGitExec(args, dir))
+	// One call answers both questions: which declared paths are committed, and
+	// whether the repo has .cts/.mts sources. Every argument is a pathspec behind
+	// `--`, so a package.json path beginning with `-` cannot become a flag.
+	const listed = await git(['ls-files', '-z', '--', ...declaredByPath.keys(), '*.cts', '*.mts'])
+	if (listed === null) {
+		return { check, status: 'ok', detail: 'not checked — `git ls-files` is unavailable here' }
+	}
+	const tracked = new Set(listed.split('\0').filter(Boolean))
+
+	const unbuildable = [...declaredByPath]
+		.filter(([bare]) => !tracked.has(bare))
+		.map(([, declaredPath]) => declaredPath)
+		.filter((p) => !emitted.includes(artefactExtension(p) as string))
+
+	if (unbuildable.length === 0) {
+		return {
+			check,
+			status: 'ok',
+			detail: `every declared entry point is committed or emitted by \`${build}\``,
+		}
+	}
+	// tsc emits .cjs/.d.cts from a .cts input, so its narrow BUILD_EMITS entry is
+	// wrong for a repo that has any. Checked last, and only when there is
+	// something to report, so the common repo pays nothing for it.
+	if ([...tracked].some((p) => !declaredByPath.has(p) && /\.[cm]ts$/.test(p))) {
+		return {
+			check,
+			status: 'ok',
+			detail:
+				'not checked — repo has .cts/.mts sources, whose emitted extensions this cannot infer',
+		}
+	}
+	return {
+		check,
+		status: 'drift',
+		detail: `\`${build}\` emits ${emitted.join(', ')}; package.json names ${unbuildable.length} entry point(s) nothing produces: ${unbuildable.join(', ')}`,
+		hint: 'The published package will 404 on those paths. Either point `build` at a bundler that emits those formats (tsup with `format: ["cjs", "esm"]`), or narrow main/module/exports to the formats the current build produces. No autofix — both directions are valid and only the package author knows which one it promises.',
 	}
 }
 

--- a/tests/cli/generators/package-json.test.ts
+++ b/tests/cli/generators/package-json.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { buildPresetConfig } from '../../../src/cli/commands/setup-presets.js'
+import { declaredEntryPoints } from '../../../src/languages/js/checks.js'
 import type { ProjectConfig } from '../../../src/cli/commands/setup.js'
 import {
 	SIZE_LIMIT_VERSION,
@@ -362,19 +363,8 @@ describe('library publish contract (#570)', () => {
 		tsc: ['./dist/index.js', './dist/index.d.ts'],
 	}
 
-	function declaredEntryPoints(pkg: Record<string, any>): string[] {
-		const found: string[] = []
-		const walk = (node: unknown) => {
-			if (typeof node === 'string') found.push(node)
-			else if (node && typeof node === 'object') Object.values(node).forEach(walk)
-		}
-		walk(pkg.exports)
-		for (const field of ['main', 'module', 'types']) {
-			if (pkg[field]) found.push(pkg[field])
-		}
-		return [...new Set(found)]
-	}
-
+	// `declaredEntryPoints` is doctor's own walker (#578), so this test and the
+	// `Exports buildable` check cannot drift on what the contract even is.
 	async function readCoherentPkg(dir: string) {
 		const pkg = await fs.readJson(join(dir, 'package.json'))
 		const emitted = EMITS[pkg.scripts.build]

--- a/tests/languages/js/exports-buildable.test.ts
+++ b/tests/languages/js/exports-buildable.test.ts
@@ -1,0 +1,180 @@
+import { join } from 'node:path'
+import fs from 'fs-extra'
+import { describe, expect, it } from 'vitest'
+import type { GitExec } from '../../../src/base/git-identity.js'
+import { checkExportsBuildable, declaredEntryPoints } from '../../../src/languages/js/checks.js'
+import { useTmpDir } from '../../helpers/tmp-dir.js'
+
+const newTmpDir = useTmpDir()
+
+/** The cheap .git gate must pass before git is consulted. */
+function gitRepo(): string {
+	const dir = newTmpDir()
+	fs.ensureDirSync(join(dir, '.git'))
+	return dir
+}
+
+/** Stands in for `git ls-files -z`: the repo's tracked paths, NUL-separated. */
+const tracks =
+	(...paths: string[]): GitExec =>
+	async () =>
+		paths.join('\0')
+
+/** The contract #570 shipped: dual-format, so half of it only tsup can produce. */
+const DUAL_CONTRACT = {
+	name: 'demo',
+	main: './dist/index.cjs',
+	module: './dist/index.js',
+	types: './dist/index.d.ts',
+	exports: {
+		'.': {
+			import: { types: './dist/index.d.ts', default: './dist/index.js' },
+			require: { types: './dist/index.d.cts', default: './dist/index.cjs' },
+		},
+	},
+}
+
+describe('declaredEntryPoints', () => {
+	it('collects main/module/types and every nested exports condition', () => {
+		expect(declaredEntryPoints(DUAL_CONTRACT).sort()).toEqual([
+			'./dist/index.cjs',
+			'./dist/index.d.cts',
+			'./dist/index.d.ts',
+			'./dist/index.js',
+		])
+	})
+
+	it('is empty for a package that declares no contract', () => {
+		expect(declaredEntryPoints({ name: 'demo' })).toEqual([])
+	})
+})
+
+describe('checkExportsBuildable', () => {
+	it('flags the #570 case: a dual contract with `build: tsc`', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{ ...DUAL_CONTRACT, scripts: { build: 'tsc' } },
+			tracks()
+		)
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('./dist/index.cjs')
+		expect(r.detail).toContain('./dist/index.d.cts')
+		// The halves tsc does emit are not reported.
+		expect(r.detail).not.toContain('./dist/index.js,')
+	})
+
+	it('passes the same contract when tsup builds it', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{ ...DUAL_CONTRACT, scripts: { build: 'tsup' } },
+			tracks()
+		)
+		expect(r.status).toBe('ok')
+	})
+
+	it('passes a single-format contract under tsc', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{
+				name: 'demo',
+				main: './dist/index.js',
+				types: './dist/index.d.ts',
+				scripts: { build: 'tsc' },
+			},
+			tracks()
+		)
+		expect(r.status).toBe('ok')
+	})
+
+	it('leaves committed assets alone — they need no build', async () => {
+		// repo-tooling's own shape: exports point at .mjs/.d.mts files that are
+		// checked in, which no build script emits and none needs to.
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{
+				name: 'demo',
+				exports: { './preset': { types: './tooling/x.d.mts', default: './tooling/x.mjs' } },
+				scripts: { build: 'tsc' },
+			},
+			tracks('tooling/x.mjs', 'tooling/x.d.mts')
+		)
+		expect(r.status).toBe('ok')
+	})
+
+	it('resolves a cleaner chain and a script indirection', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{
+				...DUAL_CONTRACT,
+				scripts: { build: 'pnpm build-cli', 'build-cli': 'rimraf ./dist && tsc -p tsconfig.json' },
+			},
+			tracks()
+		)
+		expect(r.status).toBe('drift')
+		expect(r.detail).toContain('./dist/index.cjs')
+	})
+
+	it('stands down on a build command it does not recognise', async () => {
+		for (const build of ['vite build', 'tsc | tee log', 'node ./scripts/build.mjs']) {
+			const r = await checkExportsBuildable(
+				gitRepo(),
+				{ ...DUAL_CONTRACT, scripts: { build } },
+				tracks()
+			)
+			expect(r.status, build).toBe('ok')
+			expect(r.detail, build).toContain('not checked')
+		}
+	})
+
+	it('stands down when .cts sources make tsc a dual-format emitter after all', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{ ...DUAL_CONTRACT, scripts: { build: 'tsc' } },
+			tracks('src/index.cts')
+		)
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('.cts/.mts sources')
+	})
+
+	it('does not judge a package that publishes its TypeScript source', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{ name: 'demo', main: './src/index.ts', scripts: { build: 'tsc' } },
+			tracks()
+		)
+		expect(r.status).toBe('ok')
+	})
+
+	it('stands down outside a git repository', async () => {
+		const r = await checkExportsBuildable(newTmpDir(), {
+			...DUAL_CONTRACT,
+			scripts: { build: 'tsc' },
+		})
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('not a git repository')
+	})
+
+	it('stands down when git is unavailable', async () => {
+		const r = await checkExportsBuildable(
+			gitRepo(),
+			{ ...DUAL_CONTRACT, scripts: { build: 'tsc' } },
+			async () => null
+		)
+		expect(r.status).toBe('ok')
+		expect(r.detail).toContain('git ls-files')
+	})
+
+	it('is not applicable to a private package or one with no build', async () => {
+		const priv = await checkExportsBuildable(
+			gitRepo(),
+			{ ...DUAL_CONTRACT, private: true, scripts: { build: 'tsc' } },
+			tracks()
+		)
+		expect(priv.status).toBe('ok')
+		expect(priv.detail).toContain('not applicable')
+
+		const noBuild = await checkExportsBuildable(gitRepo(), DUAL_CONTRACT, tracks())
+		expect(noBuild.status).toBe('ok')
+		expect(noBuild.detail).toContain('no build script')
+	})
+})


### PR DESCRIPTION
🤖 *Opened by an agent via ai-issue-loop.*

Closes #578

#577 fixed the *preset* that produced the pair. This is the general check for however else it arises — a repo editing `build` or the contract by hand, long after setup ran.

## The check

A new JS check, **Exports buildable**, reports `drift` when a path named in `main`/`module`/`types`/`exports` carries an extension the repo's own `build` script cannot produce. The motivating case: `main: ./dist/index.cjs` and a `require` condition on `./dist/index.d.cts`, while `build` was still plain `tsc`, which emits only `.js` and `.d.ts`. That publishes green and 404s for every CJS consumer.

```
⚠️  Exports buildable — drift
   `tsc` emits .js, .d.ts; package.json names 2 entry point(s) nothing
   produces: ./dist/index.cjs, ./dist/index.d.cts
```

**Judged from the build script, not from `dist/` on disk.** A clean checkout has no `dist/`, and a stale one has whatever the last build left, so neither answers the question.

**Git is what separates the two kinds of path a contract can name.** A tracked `./tooling/preset.mjs` ships as committed source and needs no build; an untracked `./dist/index.cjs` has to come out of `build` or it will not exist at publish time. This is load-bearing, not incidental — without it the check flags **46 valid paths on this repo alone**, whose `exports` point at committed `.mjs`/`.d.mts` presets. Verified against the real checkout: it resolves `build` → `pnpm build-cli` → `rimraf ./dist && tsc …` and reports `ok`.

## Stated limits — where it deliberately says nothing

Inferring emitted extensions from an arbitrary build command is inherently partial, so the check stands down with a reason in `detail` rather than guess. Each of these reports `ok`, never a finding:

| Situation | Why |
|---|---|
| Build command not in the table | Only `tsc`, `tsup`, and the cleaners `rimraf`/`rm`/`del` are recognised |
| `\|`, `\|\|`, `;`, backticks, `$(…)`, redirects | Only a plain `a && b` chain is read |
| Not a git repository | Committed assets and build output become indistinguishable |
| `git ls-files` unavailable | Same |
| Repo has `.cts`/`.mts` sources | `tsc` *does* emit `.cjs`/`.d.cts` from those, so its narrow entry would be wrong |
| Path extension outside `.js`/`.cjs`/`.mjs`/`.d.ts`/`.d.cts`/`.d.mts` | A package publishing `./src/index.ts` directly is not measured against a JS emit table |

**On `tsup` specifically:** only `tsc` narrows the emitted set. `tsup`'s real set is whatever `format`/`dts` say in a config file this does not parse, so it claims the broadest set it *could* emit — a tsup build is effectively passed rather than guessed at, while `rimraf dist && tsup` still resolves instead of standing down. Regex-parsing `tsup.config.ts` to do better is exactly the fragile step that would produce false positives, so it is not done. The table takes one line per new command if that changes.

The bias throughout is under-reporting: a doctor check that cries wolf on a valid config is worse than one with a stated blind spot.

## Not a duplicate of publint

The generated `verify` already runs publint — but at **release** time, against a `dist/` that was just built on a machine where it happens to work. This runs at **setup/doctor** time, on a checkout, before anything is built. Same class, different moment; that gap is the whole point of #578.

## No fixer

Deliberately absent from `FIX_TARGETS`. Both resolutions are valid — point `build` at a bundler that emits those formats, or narrow the contract to what the current build produces — and only the package author knows which one the package promises. The hint names both.

## Shared with the #570 regression test

`declaredEntryPoints` is now exported from `src/languages/js/checks.ts` and the #577 test imports it, deleting its local copy. That test and this check can no longer drift on what the publish contract even is.

## Checks

- `vitest run` — 1168 passed, 1 expected fail, 18 skipped (71 files). Also run as part of pre-push `verify`.
- `tsc --noEmit --project src/cli/tsconfig.json` — clean.
- `biome check .` — exit 0. The 62 warnings are pre-existing `noImportantStyles` hits in `apps/docs` CSS, untouched here.
- `rimraf ./dist && tsc --project src/cli/tsconfig.json` — clean, via pre-push.
- Dogfooded against this repo, as described above.

13 new tests in `tests/languages/js/exports-buildable.test.ts` cover the #570 case, the same contract under tsup, committed assets, the cleaner chain and `pnpm <script>` indirection, and every stand-down path.

Co-authored-by: Claude <noreply@anthropic.com>
