### PR TITLE
feat(skills): ship the dogfood skill so fix claude-skills installs it

### DIFF
--- a/apps/docs/static/schemas/lockfile.json
+++ b/apps/docs/static/schemas/lockfile.json
@@ -262,7 +262,8 @@
 							"ai-issue-loop",
 							"ai-workflow",
 							"ai-issue",
-							"ai-loop-status"
+							"ai-loop-status",
+							"dogfood"
 						]
 					},
 					"description": "Agent skills this repo's workflows depend on. doctor compares each installed copy's stamped hash against the shipped one and reports a missing or stale skill — always as \"not configured\", never drift, because it probes the machine rather than the repo. It never runs the fixer for you."

--- a/src/cli/generators/claude-skills.ts
+++ b/src/cli/generators/claude-skills.ts
@@ -16,9 +16,17 @@ import { type GitExec, isNewerVersion, resolveShippedVersion } from '../utils/ve
 
 /**
  * Skills this package owns the content of and keeps up to date. The loop first —
- * it is the pipeline; the other three are its drivers (burst, on-ramp, status).
+ * it is the pipeline; the next three are its drivers (burst, on-ramp, status).
+ * `dogfood` stands apart: it tests the consuming repo's own tooling rather than
+ * driving the loop, and it is the only one that writes nothing outside a temp dir.
  */
-export const SHIPPED_SKILLS = ['ai-issue-loop', 'ai-workflow', 'ai-issue', 'ai-loop-status']
+export const SHIPPED_SKILLS = [
+	'ai-issue-loop',
+	'ai-workflow',
+	'ai-issue',
+	'ai-loop-status',
+	'dogfood',
+]
 
 /** The primary skill — the default everywhere a single name is accepted. */
 export const SHIPPED_SKILL = 'ai-issue-loop'


### PR DESCRIPTION
🤖 *Opened by an agent via Claude Code.*

`skills/dogfood/SKILL.md` landed in 6d45bc9 but was **inert** — nothing installs a skill that isn't in `SHIPPED_SKILLS`. This wires it up so `fix claude-skills` installs it alongside the other four.

### Not just one array entry

`SHIPPED_SKILLS` also feeds the published lockfile JSON Schema's `requiredSkills` enum, so `apps/docs/static/schemas/lockfile.json` is regenerated here (`pnpm schema:generate`). The change is **additive** — the enum only widens, so every existing `.repo-tooling.json` still validates.

I only found this because `tests/cli/utils/lockfile-schema.test.ts` failed; nothing about the one-line edit suggests it touches a published schema.

### What the skill is

Codifies the dogfood procedure that found five real defects this session (#576, #577, #579, #580, #581 all trace back to it). Asks what to exercise, builds throwaway fixtures in a temp dir, and runs three checks — what `setup` overwrote, whether `doctor` exits 0 on the repo the tool just made, and whether the emitted contract holds.

It writes only under a temp directory and **never deletes** — it reports the path and hands the `rm -rf` back to the user.

### Verification

- `pnpm verify` — 71 files, 1193 passed, 1 expected fail.
- The `SHIPPED_SKILLS` tests iterate the array, so the new skill is covered automatically: frontmatter `name` matches its directory, and it installs without collision.

### Before merging

`feat(skills):` cuts a **minor**. That's deliberate — a new skill reaching every consumer's `~/.claude/skills` is a feature — but say if you'd rather it were `chore` and not release.
